### PR TITLE
Upgrading from H2 1.4.197 to 1.4.199 now requires ifNotExists flag

### DIFF
--- a/openpos-service/src/main/java/org/jumpmind/pos/service/AbstractRDBMSModule.java
+++ b/openpos-service/src/main/java/org/jumpmind/pos/service/AbstractRDBMSModule.java
@@ -17,7 +17,6 @@ import static org.jumpmind.db.util.BasicDataSourcePropertyConstants.DB_POOL_URL;
 import static org.jumpmind.db.util.BasicDataSourcePropertyConstants.DB_POOL_USER;
 import static org.jumpmind.db.util.BasicDataSourcePropertyConstants.DB_POOL_VALIDATION_QUERY;
 import static org.jumpmind.pos.service.util.ClassUtils.getClassesForPackageAndAnnotation;
-import static org.apache.commons.lang3.StringUtils.*;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -25,9 +24,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URL;
 import java.sql.SQLException;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import javax.sql.DataSource;
 
@@ -129,7 +126,7 @@ abstract public class AbstractRDBMSModule extends AbstractServiceFactory impleme
             String configDbUrl = getDbProperties(DB_POOL_URL, "jdbc:h2:mem:config");
             if (h2Server == null && configDbUrl.contains("h2:tcp")) {
                 try {
-                    h2Server = Server.createTcpServer("-tcpPort", env.getProperty("db.h2.port", "1973"));
+                    h2Server = Server.createTcpServer("-tcpPort", env.getProperty("db.h2.port", "1973"), "-ifNotExists");
                     ((Server) h2Server).start();
                 } catch (SQLException e) {
                     throw new SqlException(e);


### PR DESCRIPTION
- H2 disabled default auto-creation of a non-existent DB in version
1.4.199
- Add -ifNotExists flag at h2 server startup
- See https://github.com/h2database/h2database/commit/8b53f3999c6c5c3d5ca29020e2657968f4f59ec4