### PR TITLE
Support @OnEvent for DeviceScoped objects

### DIFF
--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/StateManager.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/StateManager.java
@@ -1083,6 +1083,9 @@ public class StateManager implements IStateManager {
         List<Class> classes = initialFlowConfig.getEventHandlers();
         classes.forEach(clazz -> eventBroadcaster.postEventToObject(clazz, event));
 
+        applicationState.getScope().getDeviceScope().values().
+                forEach(obj->eventBroadcaster.postEventToObject(obj, event));
+
         Object state = getCurrentState();
         if (state != null) {
             eventBroadcaster.postEventToObject(state, event);


### PR DESCRIPTION
Adding all of you guys as reviewers is my way of letting you know this feature exists now.  If you try to listen for events directly using Spring's ApplicationListener or Spring's annotation then you get errors if the device scoped object doesn't exist yet because there is no StateManager context.