### PR TITLE
Make ScanData Serializable

### DIFF
--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/model/ScanData.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/model/ScanData.java
@@ -1,6 +1,8 @@
 package org.jumpmind.pos.core.model;
 
-public class ScanData {
+import java.io.Serializable;
+
+public class ScanData implements Serializable {
     
     private OpenposBarcodeType type;
     private String data;


### PR DESCRIPTION
- Fixes exception found in a Cucumber test

Saw this exception in a cucumber test

```
2020-07-01 07:42:25.783 INFO  [pos:05243-013] [main] [CucumberListener$2] 
+---------------------------------------------------------------------------------------------------------+
|  Test Step: user scans barcode "8110100178002153053200110150320070159333521845329402" on screen "Sale"  |
+---------------------------------------------------------------------------------------------------------+ 
2020-07-01 07:42:25.791 WARN  [pos:05243-013] [Thread-116] [ObjectUtils] Failed to serialize object Action(name=Scan, doNotBlockForResponse=false) 
java.io.NotSerializableException: org.jumpmind.pos.core.model.ScanData
	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1184)
	at java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1548)
	at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1509)
	at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1432)
	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1178)
	at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:348)
	at org.jumpmind.pos.util.ObjectUtils.serialize(ObjectUtils.java:38)
	at org.jumpmind.pos.util.ObjectUtils.deepClone(ObjectUtils.java:17)
	at org.jumpmind.pos.core.util.ActionSerializer.serialize(ActionSerializer.java:31)
	at org.jumpmind.pos.core.util.ActionSerializer.serialize(ActionSerializer.java:18)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider._serialize(DefaultSerializerProvider.java:480)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:319)
	at com.fasterxml.jackson.databind.ObjectWriter$Prefetch.serialize(ObjectWriter.java:1396)
	at com.fasterxml.jackson.databind.ObjectWriter._configAndWriteValue(ObjectWriter.java:1120)
	at com.fasterxml.jackson.databind.ObjectWriter.writeValueAsString(ObjectWriter.java:993)
	at org.jumpmind.pos.core.util.LogFormatter.toJsonString(LogFormatter.java:71)
	at org.jumpmind.pos.core.service.ScreenService.actionOccured(ScreenService.java:216)
	at org.jumpmind.pos.cucumber.CucumberMessageService.action(CucumberMessageService.java:106)
	at org.jumpmind.pos.cucumber.CucumberContainer$1.run(CucumberContainer.java:96)
	at java.lang.Thread.run(Thread.java:748)
2020-07-01 07:42:25.792 WARN  [pos:05243-013] [Thread-116] [ObjectUtils] Failed to deserialize byte array. 
java.lang.NullPointerException: null
	at java.io.ByteArrayInputStream.<init>(ByteArrayInputStream.java:106)
	at org.jumpmind.pos.util.ObjectUtils.deserialize(ObjectUtils.java:24)
	at org.jumpmind.pos.util.ObjectUtils.deepClone(ObjectUtils.java:18)
	at org.jumpmind.pos.core.util.ActionSerializer.serialize(ActionSerializer.java:31)
	at org.jumpmind.pos.core.util.ActionSerializer.serialize(ActionSerializer.java:18)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider._serialize(DefaultSerializerProvider.java:480)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:319)
	at com.fasterxml.jackson.databind.ObjectWriter$Prefetch.serialize(ObjectWriter.java:1396)
	at com.fasterxml.jackson.databind.ObjectWriter._configAndWriteValue(ObjectWriter.java:1120)
	at com.fasterxml.jackson.databind.ObjectWriter.writeValueAsString(ObjectWriter.java:993)
	at org.jumpmind.pos.core.util.LogFormatter.toJsonString(LogFormatter.java:71)
	at org.jumpmind.pos.core.service.ScreenService.actionOccured(ScreenService.java:216)
	at org.jumpmind.pos.cucumber.CucumberMessageService.action(CucumberMessageService.java:106)
	at org.jumpmind.pos.cucumber.CucumberContainer$1.run(CucumberContainer.java:96)
	at java.lang.Thread.run(Thread.java:748)
2020-07-01 07:42:25.793 WARN  [pos:05243-013] [Thread-116] [LogFormatter] Could not serialize object for logging: Action(name=Scan, doNotBlockForResponse=false) 
com.fasterxml.jackson.databind.JsonMappingException: [no message for java.lang.NullPointerException]
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider._wrapAsIOE(DefaultSerializerProvider.java:509)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider._serialize(DefaultSerializerProvider.java:482)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:319)
	at com.fasterxml.jackson.databind.ObjectWriter$Prefetch.serialize(ObjectWriter.java:1396)
	at com.fasterxml.jackson.databind.ObjectWriter._configAndWriteValue(ObjectWriter.java:1120)
	at com.fasterxml.jackson.databind.ObjectWriter.writeValueAsString(ObjectWriter.java:993)
	at org.jumpmind.pos.core.util.LogFormatter.toJsonString(LogFormatter.java:71)
	at org.jumpmind.pos.core.service.ScreenService.actionOccured(ScreenService.java:216)
	at org.jumpmind.pos.cucumber.CucumberMessageService.action(CucumberMessageService.java:106)
	at org.jumpmind.pos.cucumber.CucumberContainer$1.run(CucumberContainer.java:96)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.NullPointerException: null
	at org.jumpmind.pos.core.util.ActionSerializer.serialize(ActionSerializer.java:33)
	at org.jumpmind.pos.core.util.ActionSerializer.serialize(ActionSerializer.java:18)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider._serialize(DefaultSerializerProvider.java:480)
	... 9 common frames omitted
2020-07-01 07:42:25.793 INFO  [pos:05243-013] [Thread-116] [ScreenService] Received action from 05243-013
```