### PR TITLE
Fix for commerce issue #1434 - selection-list-screen and selection-list-screen-dialog button fixes

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/selection-list/selection-list-screen-dialog.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/selection-list/selection-list-screen-dialog.component.html
@@ -37,22 +37,22 @@
         
         <mat-dialog-actions class="buttons">
             <app-secondary-button *ngFor="let m of screen.nonSelectionButtons"[actionItem]="m"
-                (actionClick)="doMenuItemAction(m)"
-                (click)="doMenuItemAction(m)" [disabled]="!isSelectionDisabled()">
+                (actionClick)="doNonSelectionButtonAction(m)"
+                (click)="doNonSelectionButtonAction(m)" [disabled]="!isSelectionDisabled()">
                 <span>{{m.title}}</span>&nbsp;
                 <span *ngIf="keybindsEnabled(m)" class="muted-color">{{m.keybindDisplayName}}</span>
             </app-secondary-button>
             <div *ngFor="let m of screen.selectionButtons;  let i = index">
                 <app-secondary-button *ngIf="screen.selectionButtons.length-1 !== i"
                     [disabled]="isSelectionDisabled()"
-                    [actionItem]="m" (actionClick)="doMenuItemAction(m)" (click)="doMenuItemAction(m)">
+                    [actionItem]="m" (actionClick)="doSelectionButtonAction(m)" (click)="doSelectionButtonAction(m)">
                     <span>{{m.title}}</span>&nbsp;
                     <span *ngIf="keybindsEnabled(m)" class="muted-color">{{m.keybindDisplayName}}</span>
                 </app-secondary-button>
                 <app-primary-button *ngIf="screen.selectionButtons.length-1 == i" 
                     [attr.cdkFocusInitial]="screen.selectionButtons.length-1 == i ? '' : null"
                     [disabled]="isSelectionDisabled()"
-                    [actionItem]="m" (actionClick)="doMenuItemAction(m)" (click)="doMenuItemAction(m)">
+                    [actionItem]="m" (actionClick)="doSelectionButtonAction(m)" (click)="doSelectionButtonAction(m)">
                     <span>{{m.title}}</span>&nbsp;
                     <span *ngIf="keybindsEnabled(m)" class="muted-color">{{m.keybindDisplayName}}</span>
                 </app-primary-button>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/selection-list/selection-list-screen.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/selection-list/selection-list-screen.component.html
@@ -43,22 +43,22 @@
         </app-content-card>
         <div class="buttons">
             <app-secondary-button *ngFor="let m of screen.nonSelectionButtons" [actionItem]="m"
-                (actionClick)="doMenuItemAction(m)"
-                (click)="doMenuItemAction(m)" [disabled]="!isSelectionDisabled()">
+                (actionClick)="doNonSelectionButtonAction(m)"
+                (click)="doNonSelectionButtonAction(m)" [disabled]="!isSelectionDisabled()">
                 <span>{{m.title}}</span>&nbsp;
                 <span *ngIf="keybindsEnabled(m)" class="muted-color">{{m.keybindDisplayName}}</span>
             </app-secondary-button>
             <div *ngFor="let m of screen.selectionButtons;  let i = index">
                 <app-secondary-button *ngIf="screen.selectionButtons.length-1 !== i"
                     [disabled]="isSelectionDisabled()"
-                    [actionItem]="m" (actionClick)="doMenuItemAction(m)" (click)="doMenuItemAction(m)">
+                    [actionItem]="m" (actionClick)="doSelectionButtonAction(m)" (click)="doSelectionButtonAction(m)">
                     <span>{{m.title}}</span>&nbsp;
                     <span *ngIf="keybindsEnabled(m)" class="muted-color">{{m.keybindDisplayName}}</span>
                 </app-secondary-button>
                 <app-primary-button *ngIf="screen.selectionButtons.length-1 == i" 
                     [attr.cdkFocusInitial]="screen.selectionButtons.length-1 == i ? '' : null"
                     [disabled]="isSelectionDisabled()"
-                    [actionItem]="m" (actionClick)="doMenuItemAction(m)" (click)="doMenuItemAction(m)">
+                    [actionItem]="m" (actionClick)="doSelectionButtonAction(m)" (click)="doSelectionButtonAction(m)">
                     <span>{{m.title}}</span>&nbsp;
                     <span *ngIf="keybindsEnabled(m)" class="muted-color">{{m.keybindDisplayName}}</span>
                 </app-primary-button>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/selection-list/selection-list-screen.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/selection-list/selection-list-screen.component.ts
@@ -124,7 +124,19 @@ export class SelectionListScreenComponent extends PosScreen<SelectionListInterfa
         }
     }
 
-    public doMenuItemAction(menuItem: IActionItem) {
+    public doSelectionButtonAction(menuItem: IActionItem) {
+        if (! this.isSelectionDisabled()) {
+            this.doMenuItemAction(menuItem);
+        }
+    }
+
+    public doNonSelectionButtonAction(menuItem: IActionItem) {
+        if (this.isSelectionDisabled()) {
+            this.doMenuItemAction(menuItem);
+        }
+    }
+
+    protected doMenuItemAction(menuItem: IActionItem) {
         if (this.screen.multiSelect) {
             this.doAction(menuItem, this.indexes);
         } else {


### PR DESCRIPTION
- For selection buttons, don't allow button actions to be sent if selected item is disabled
- For non-selection buttons, don't allow button actions to be sent if selected item is enabled