### PR TITLE
Add support for optional failing during startup on SQL script error

### DIFF
--- a/openpos-persist/src/test/java/org/jumpmind/pos/persist/cars/TestPersistCarsConfig.java
+++ b/openpos-persist/src/test/java/org/jumpmind/pos/persist/cars/TestPersistCarsConfig.java
@@ -73,11 +73,11 @@ public class TestPersistCarsConfig {
 
         DatabaseScriptContainer scripts = new DatabaseScriptContainer("persist-test/sql", PersistTestUtil.testDbPlatform());
 
-        scripts.executePreInstallScripts(fromVersion, "0.0.1");
+        scripts.executePreInstallScripts(fromVersion, "0.0.1", true);
 
         sessionFactory.createAndUpgrade();
 
-        scripts.executePostInstallScripts(fromVersion, "0.0.1");
+        scripts.executePostInstallScripts(fromVersion, "0.0.1", true);
     }
 
 

--- a/openpos-service/src/main/java/org/jumpmind/pos/service/AbstractRDBMSModule.java
+++ b/openpos-service/src/main/java/org/jumpmind/pos/service/AbstractRDBMSModule.java
@@ -91,6 +91,9 @@ abstract public class AbstractRDBMSModule extends AbstractServiceFactory impleme
     @Value("${openpos.general.dataModelExtensionPackages:#{null}}")
     protected String additionalPackages;
 
+    @Value("${openpos.general.failStartupOnModuleLoadFailure:false}")
+    boolean failStartupOnModuleLoadFailure;
+
     protected DataSource dataSource;
 
     protected ISecurityService securityService;
@@ -306,15 +309,14 @@ abstract public class AbstractRDBMSModule extends AbstractServiceFactory impleme
                 fromVersion, currentVersion, sqlScriptProfile);
         DatabaseScriptContainer scripts = new DatabaseScriptContainer(String.format("%s/sql/%s", getName(), sqlScriptProfile),
                 getDatabasePlatform());
-
         IDBSchemaListener schemaListener = getDbSchemaListener();
 
-        scripts.executePreInstallScripts(fromVersion, currentVersion);
+        scripts.executePreInstallScripts(fromVersion, currentVersion, failStartupOnModuleLoadFailure);
         schemaListener.beforeSchemaCreate(sessionFactory);
         sessionFactory.createAndUpgrade();
         upgradeDbFromXml();
         schemaListener.afterSchemaCreate(sessionFactory);
-        scripts.executePostInstallScripts(fromVersion, currentVersion);
+        scripts.executePostInstallScripts(fromVersion, currentVersion, failStartupOnModuleLoadFailure);
 
         ModuleModel moduleModel = session.findByNaturalId(ModuleModel.class, installationId);
         if (moduleModel == null) {

--- a/openpos-service/src/main/java/org/jumpmind/pos/service/startup/ModuleStartupTask.java
+++ b/openpos-service/src/main/java/org/jumpmind/pos/service/startup/ModuleStartupTask.java
@@ -9,6 +9,7 @@ import org.jumpmind.pos.service.IModule;
 import org.jumpmind.pos.util.BoxLogging;
 import org.jumpmind.pos.util.startup.AbstractStartupTask;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
@@ -18,6 +19,9 @@ public class ModuleStartupTask extends AbstractStartupTask {
 
     @Autowired
     ModuleRegistry moduleRegistry;
+
+    @Value("${openpos.general.failStartupOnModuleLoadFailure:false}")
+    boolean failStartupOnModuleLoadFailure;
 
     @Override
     protected void doTask() throws Exception {
@@ -31,6 +35,9 @@ public class ModuleStartupTask extends AbstractStartupTask {
                     module.initialize();
                 } catch (Exception ex) {
                     logger.error(logMessage("Failed to initialize module: ", module), ex);
+                    if (failStartupOnModuleLoadFailure) {
+                        throw ex;
+                    }
                     i.remove();
                 }
             }
@@ -40,6 +47,9 @@ public class ModuleStartupTask extends AbstractStartupTask {
                     module.start();
                 } catch (Exception ex) {
                     logger.error(logMessage("Failed to start module: ", module), ex);
+                    if (failStartupOnModuleLoadFailure) {
+                        throw ex;
+                    }
                 }
             }
 


### PR DESCRIPTION
@mmichalek 's idea. Both of us were recently snagged on this issue of cucumber tests not running because of a SQL script error.

- Adds `openpos.general.failStartupOnModuleLoadFailure` configuration parameter which will cause startup of the server to fail if there is any error loading the SQL scripts.  Defaults to `false` in order to preserve existing behavior.
- Will allow for us to catch failures in cucumber if a SQL script doesn't completely load. This has cost several of us troubleshooting time when tests fail because of a problem in the SQL and not in the actual tests.