### PR TITLE
Ensure server really dies when failStartupOnModuleLoadFailure is enabled

### DIFF
--- a/openpos-util/src/main/java/org/jumpmind/pos/util/startup/AbstractStartupTask.java
+++ b/openpos-util/src/main/java/org/jumpmind/pos/util/startup/AbstractStartupTask.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationListener;
+import org.springframework.core.env.Environment;
 
 abstract public class AbstractStartupTask implements ApplicationListener<ApplicationReadyEvent> {
 
@@ -18,10 +19,18 @@ abstract public class AbstractStartupTask implements ApplicationListener<Applica
             doTask();
         } catch (Exception e) {
             this.taskException = e;
-            logger.error("Failed to execute " + getClass().getName(), e);
+            String message = "Failed to execute " + getClass().getName();
+            if (isFailOnExceptionEnabled(event.getApplicationContext().getEnvironment())) {
+                throw new RuntimeException(message, e);
+            }
+            logger.error(message, e);
         } finally {
             logger.info("{} is complete", getClass().getSimpleName());
         }
+    }
+
+    protected boolean isFailOnExceptionEnabled(Environment env) {
+        return Boolean.parseBoolean(env.getProperty("openpos.general.failStartupOnModuleLoadFailure", "false"));
     }
 
     public boolean hasException() {


### PR DESCRIPTION
Follow up to PR #778

- AbstractStartupTask was swallowing exception which would still allow server to start
- This will also ensure no cucumber tests run.  Before this change, they would all run, but fail quickly.
- Found this when I enabled failStartupOnModuleLoadFailure in Petco for the dev profile