### PR TITLE
Don't send back negative index values for selected item

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-item-card-list/sale-item-card-list.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-item-card-list/sale-item-card-list.component.ts
@@ -87,7 +87,11 @@ export class SaleItemCardListComponent extends ScreenPartComponent<SaleItemCardL
 
     this.keyPressProvider.globalSubscribe(allActions).pipe(
         takeUntil(this.stop$)
-    ).subscribe(action => this.doAction(action, [this.expandedIndex]));
+    ).subscribe(action => {
+        if (this.expandedIndex >= 0) {
+            this.doAction(action, [this.expandedIndex]);
+        }
+    });
   }
 
   scrollToView(index: number): void {


### PR DESCRIPTION
I am not sure how the client managed to do this, but it allowed a negative selected index to be sent back to the server on a keypress action.  This hopefully will fix that.

- Don't send an action on a keypress if the selected item index is negative
- Addresses commerce issue 1469