### PR TITLE
Ensure model extensions map is serializable with Jackson

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-item-card-list/sale-item-card-list.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-item-card-list/sale-item-card-list.component.ts
@@ -87,7 +87,11 @@ export class SaleItemCardListComponent extends ScreenPartComponent<SaleItemCardL
 
     this.keyPressProvider.globalSubscribe(allActions).pipe(
         takeUntil(this.stop$)
-    ).subscribe(action => this.doAction(action, [this.expandedIndex]));
+    ).subscribe(action => {
+        if (this.expandedIndex >= 0) {
+            this.doAction(action, [this.expandedIndex]);
+        }
+    });
   }
 
   scrollToView(index: number): void {

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/AbstractModel.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/AbstractModel.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 import java.util.*;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.jumpmind.pos.persist.model.IAuditableModel;
 import org.jumpmind.pos.util.ClassUtils;
@@ -33,7 +34,8 @@ public abstract class AbstractModel implements IAuditableModel, Serializable {
 
     @JsonIgnore
     private Map<String, Object> additionalFields = new CaseInsensitiveMap<String, Object>();
-    
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "__extensionClass")
     private Map<Class, Object> extensions = new HashMap<>();
 
     @Override

--- a/openpos-persist/src/test/java/org/jumpmind/pos/persist/DBSessionExtensionModelTest.java
+++ b/openpos-persist/src/test/java/org/jumpmind/pos/persist/DBSessionExtensionModelTest.java
@@ -2,8 +2,8 @@ package org.jumpmind.pos.persist;
 
 import org.jumpmind.pos.persist.cars.CarModel;
 import org.jumpmind.pos.persist.cars.CarModelExtension;
-import org.jumpmind.pos.persist.cars.ServiceInvoice;
 import org.jumpmind.pos.persist.cars.TestPersistCarsConfig;
+import org.jumpmind.pos.util.DefaultObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -11,10 +11,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import java.math.BigDecimal;
-import java.util.Date;
-
-import static org.jumpmind.pos.persist.DBSessionNaturalIdTest.clearTime;
 import static org.junit.Assert.*;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -82,4 +78,21 @@ public class DBSessionExtensionModelTest {
 
         }
     }
+
+    @Test
+    public void testExtensionSerialization() throws Exception {
+        final String VIN = "KMHCN46C58U242743";
+        DBSession db = sessionFactory.createDbSession();
+        CarModel hyundaiLookupedUp = db.findByNaturalId(CarModel.class, VIN);
+        CarModelExtension carModelExtension = ((CarModelExtension)hyundaiLookupedUp.getExtension(CarModelExtension.class));
+
+        assertNotNull(carModelExtension);
+        assertTrue(carModelExtension.isTrailerHitch());
+
+        String serializedCarModel = DefaultObjectMapper.defaultObjectMapper().writeValueAsString(hyundaiLookupedUp);
+        CarModel carModel = DefaultObjectMapper.defaultObjectMapper().readValue(serializedCarModel, CarModel.class);
+        CarModelExtension deserialized = carModel.getExtension(CarModelExtension.class);
+        assertTrue(deserialized.isTrailerHitch());
+    }
+
 }

--- a/openpos-server-core/src/main/java/org/jumpmind/pos/server/service/MessageService.java
+++ b/openpos-server-core/src/main/java/org/jumpmind/pos/server/service/MessageService.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import javax.annotation.PostConstruct;
 
-import org.jumpmind.pos.devices.service.model.PersonalizationParameters;
 import org.jumpmind.pos.server.model.Action;
 import org.jumpmind.pos.util.web.ServerException;
 import org.slf4j.Logger;
@@ -95,10 +94,6 @@ public class MessageService implements IMessageService {
             String jsonString = messageToJson(message);
 
             byte[] json = jsonString.getBytes("UTF-8");
-
-            if (jsonString.contains("\"type\" : \"UIData\"")) {
-                logger.info("Sending message to client: \n" + jsonString);
-            }
 
             if( json.length <= websocketSendBufferLimit ){
                 this.template.send(topic.toString(), MessageBuilder.withPayload(json).build());


### PR DESCRIPTION
- Fixes commerce issue 1544
- Add unit test to check round trip serialize/deserialize
- Also remove duplicate logging of UIData messages
-- Already logging in WebSocketConfig class