### PR TITLE
Bugfix/value change action

### DIFF
--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/model/ComboField.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/model/ComboField.java
@@ -13,7 +13,6 @@ public class ComboField extends FormField implements IDynamicListField {
 
     private List<String> values;
     
-    private String valueChangedAction;
     private boolean dynamicListEnabled = true;
 
     public ComboField() {
@@ -76,19 +75,6 @@ public class ComboField extends FormField implements IDynamicListField {
     @JsonSetter("values")
     public void setValues(List<String> values) {
         this.values = values;
-    }
-
-    public String getValueChangedAction() {
-        return valueChangedAction;
-    }
-
-    /**
-     * When this value is set, the client will call back upon the selected value changing with an action whose name is the same 
-     * as the one given
-     * @param valueChangedAction The name of an action to generate when the Combo box selected value changes.
-     */
-    public void setValueChangedAction(String valueChangedAction) {
-        this.valueChangedAction = valueChangedAction;
     }
     
     @Override

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/model/FormField.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/model/FormField.java
@@ -7,7 +7,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.jumpmind.pos.core.ui.ActionItem;
 import org.jumpmind.pos.core.ui.validator.IValidatorSpec;
@@ -228,15 +228,13 @@ public class FormField implements IFormElement, IField, Serializable {
     /**
      * When this value is set, the client will call back upon the selected value changing with an action whose name is the same 
      * as the one given
-     * @param valueChangedAction The name of an action to generate when the Combo box selected value changes.
+     * @param action The name of an action to generate when the selected value changes.
      */
-
-
     public void setValueChangedAction(ActionItem action){
         if (action == null) {
             this.optionalProperties.remove("valueChangedAction");
         }
-        else if (action.getAction() != null) {
+        else if (StringUtils.isNotEmpty(action.getAction())) {
             this.put("valueChangedAction", action);
         }
     }

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/model/FormField.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/model/FormField.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.jumpmind.pos.core.ui.ActionItem;
 import org.jumpmind.pos.core.ui.validator.IValidatorSpec;
@@ -232,14 +233,21 @@ public class FormField implements IFormElement, IField, Serializable {
 
 
     public void setValueChangedAction(ActionItem action){
-        this.put("valueChangedAction", action);
+        if (action == null) {
+            this.optionalProperties.remove("valueChangedAction");
+        }
+        else if (action.getAction() != null) {
+            this.put("valueChangedAction", action);
+        }
     }
 
     @JsonIgnore
     public void setValueChangedAction(String valueChangedAction) {
-        ActionItem action = new ActionItem(valueChangedAction);
-        action.setDoNotBlockForResponse(true);
-        setValueChangedAction(action);
+        if (StringUtils.isNotEmpty(valueChangedAction)) {
+            ActionItem action = new ActionItem(valueChangedAction);
+            action.setDoNotBlockForResponse(true);
+            setValueChangedAction(action);
+        }
     }
     
     public void setIconName(String iconName) {

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/model/RadioField.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/model/RadioField.java
@@ -10,8 +10,6 @@ public class RadioField extends FormField {
 
     private List<List<String>> values;
 
-    private String valueChangedAction;
-
     private int selectedIndex;
 
     public RadioField() {
@@ -57,22 +55,6 @@ public class RadioField extends FormField {
     @JsonSetter("values")
     public void setValues(List<List<String>> values) {
         this.values = values;
-    }
-
-    public String getValueChangedAction() {
-        return valueChangedAction;
-    }
-
-    /**
-     * When this value is set, the client will call back upon the selected value
-     * changing with an action whose name is the same as the one given
-     * 
-     * @param valueChangedAction
-     *            The name of an action to generate when the Combo box selected
-     *            value changes.
-     */
-    public void setValueChangedAction(String valueChangedAction) {
-        this.valueChangedAction = valueChangedAction;
     }
 
     public int getSelectedIndex() {

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/model/ToggleField.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/model/ToggleField.java
@@ -11,8 +11,7 @@ public class ToggleField extends FormField implements IDynamicListField {
     private static final long serialVersionUID = 1L;
 
     private List<String> values;
-    
-    private String valueChangedAction;
+
     private boolean dynamicListEnabled = true;
 
     public ToggleField() {
@@ -63,19 +62,6 @@ public class ToggleField extends FormField implements IDynamicListField {
     @JsonSetter("values")
     public void setValues(List<String> values) {
         this.values = values;
-    }
-
-    public String getValueChangedAction() {
-        return valueChangedAction;
-    }
-
-    /**
-     * When this value is set, the client will call back upon the selected value changing with an action whose name is the same 
-     * as the one given
-     * @param valueChangedAction The name of an action to generate when the Combo box selected value changes.
-     */
-    public void setValueChangedAction(String valueChangedAction) {
-        this.valueChangedAction = valueChangedAction;
     }
     
     @Override


### PR DESCRIPTION
The valueChangedAction is being handed as an optionalProperty in the formField class now. Was causing the action not be serialized correctly due to the value in the superclass being used causing the valueChangedActions from firing. Also prevent actions without action names from being set as valueChangedActions.