### PR TITLE
Feature/item detail promotions

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/_item-detail-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/_item-detail-theme.scss
@@ -1,4 +1,10 @@
 @mixin item-detail-theme($theme) {
+    $app-primary: mat-color(map-get($theme, primary));
+
+    .promotion-icon {
+        color: $app-primary;
+    }
+
     .rounded-edge {
         border-radius: 4px;
     }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.html
@@ -16,11 +16,12 @@
 
     <section class="promotions">
         <h3>
-            {{screen.itemPromotionsTitle}}
+            {{screen.promotions.length > 0 ? screen.itemPromotionsTitle : screen.itemNoPromotionsTitle}}
         </h3>
-        <ul responsive-class>
+        <ul responsive-class class="promotion-list">
             <li *ngFor="let promo of screen.promotions">
-                {{promo}}
+                <app-icon [iconName]="promo.icon" color="primary" class="promotion-icon" iconClass="material-icons md"></app-icon>
+                {{promo.promotionName}}
             </li>
         </ul>
     </section>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.html
@@ -4,13 +4,26 @@
     <p responsive-class>{{screen.summary}}</p>
     <app-carousel class="carousel" carouselSize="xl" [carouselItemClass]="'rounded-edge'">
         <ng-template *ngFor="let image of screen.imageUrls" #carouselItem>
-            <img [src]="image | imageUrl">
+            <app-image [imageUrl]="image | imageUrl" [altImageUrl]="screen.alternateImageUrl" [altText]="'Image NotFound'"></app-image>
         </ng-template>
     </app-carousel>
+
     <ul responsive-class class="properties">
         <li *ngFor="let prop of screen.itemProperties">
             <app-display-property [property]="prop"></app-display-property>
         </li>
     </ul>
+
+    <section class="promotions">
+        <h3>
+            {{screen.itemPromotionsTitle}}
+        </h3>
+        <ul responsive-class>
+            <li *ngFor="let promo of screen.promotions">
+                {{promo}}
+            </li>
+        </ul>
+    </section>
+
     <app-options-list optionListSizeClass="md"></app-options-list>
 </section>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.scss
@@ -34,6 +34,7 @@ p{
     grid-template: "image title" auto
                     "image summary" auto
                     "image properties" 1fr
+                    "image promotions" 1fr
                     "actions actions" auto/ auto 1fr;
     &.mobile,
     &.tablet-portrait{
@@ -54,6 +55,17 @@ app-options-list {
 .carousel {
     grid-area: image;
     justify-self: center;
+}
+
+.promotions {
+    grid-area: promotions;
+    align-self: end;
+    ul{
+        list-style-type: none;
+        padding-inline-start: 0;
+    }
+
+    @extend %text-md;
 }
 
 .properties {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.scss
@@ -60,12 +60,22 @@ app-options-list {
 .promotions {
     grid-area: promotions;
     align-self: end;
-    ul{
-        list-style-type: none;
-        padding-inline-start: 0;
-    }
 
     @extend %text-md;
+}
+
+.promotion-list {
+    list-style-type: none;
+    padding-inline-start: 0;
+
+    > li {
+        display: flex;
+        align-items: center;
+    }
+}
+
+.promotion-icon {
+    margin-right: 1rem;
 }
 
 .properties {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.interface.ts
@@ -1,6 +1,7 @@
 import {IActionItem} from '../../core/actions/action-item.interface';
 import { IAbstractScreen } from '../../core/interfaces/abstract-screen.interface';
 import { DisplayProperty } from '../../shared/components/display-property/display-property.interface';
+import {IPromotionInterface} from './promotion.interface';
 
 export interface ItemDetailInterface extends IAbstractScreen {
     imageUrls: string[];
@@ -10,6 +11,6 @@ export interface ItemDetailInterface extends IAbstractScreen {
     itemProperties: DisplayProperty[];
     itemActions: IActionItem[];
     itemPromotionsTitle: string;
-    promotions: string[];
-
+    itemNoPromotionsTitle: string;
+    promotions: IPromotionInterface[];
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.interface.ts
@@ -4,8 +4,12 @@ import { DisplayProperty } from '../../shared/components/display-property/displa
 
 export interface ItemDetailInterface extends IAbstractScreen {
     imageUrls: string[];
+    alternateImageUrl: string;
     itemName: string;
     summary: string;
     itemProperties: DisplayProperty[];
     itemActions: IActionItem[];
+    itemPromotionsTitle: string;
+    promotions: string[];
+
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/promotion.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/promotion.interface.ts
@@ -1,0 +1,14 @@
+import {IAbstractScreen} from '../../core/interfaces/abstract-screen.interface';
+
+export interface IPromotionInterface extends IAbstractScreen {
+    icon: string;
+    promotionId: string;
+    promotionName: string;
+    priority: number;
+    singleUse: boolean;
+    autoApply: boolean;
+    maxUses: number;
+    vendorFunded: boolean;
+    rewardApplicationTypeCode: string;
+    forLoyaltyReward: boolean;
+}

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/data/Promotion.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/data/Promotion.java
@@ -1,0 +1,26 @@
+package org.jumpmind.pos.core.ui.data;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Promotion implements Serializable {
+    String icon;
+    String promotionId;
+    String promotionName;
+    BigDecimal priority;
+    boolean singleUse = false;
+    boolean autoApply = true;
+    BigDecimal maxUses;
+    boolean vendorFunded;
+    String rewardApplicationTypeCode;
+    boolean forLoyaltyReward;
+}

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/ItemDetailUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/ItemDetailUIMessage.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import org.jumpmind.pos.core.model.DisplayProperty;
 import org.jumpmind.pos.core.ui.AssignKeyBindings;
 import org.jumpmind.pos.core.ui.UIMessage;
+import org.jumpmind.pos.core.ui.data.Promotion;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,16 +25,19 @@ public class ItemDetailUIMessage extends UIMessage {
     private String alternateImageUrl;
     private List<DisplayProperty> itemProperties;
     private String itemPromotionsTitle;
-    private List<String> promotions;
+    private String itemNoPromotionsTitle;
+    private List<Promotion> promotions;
 
 
-    public void addItemProperty(DisplayProperty property){
-        if(itemProperties == null){
+    public void addItemProperty(DisplayProperty property) {
+        if (itemProperties == null) {
             itemProperties = new ArrayList<>();
         }
         itemProperties.add(property);
     }
 
     @Override
-    public String getScreenType(){ return UIMessageType.ITEM_DETAIL; }
+    public String getScreenType() {
+        return UIMessageType.ITEM_DETAIL;
+    }
 }

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/ItemDetailUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/ItemDetailUIMessage.java
@@ -21,7 +21,11 @@ public class ItemDetailUIMessage extends UIMessage {
     private String itemName;
     private String summary;
     private List<String> imageUrls;
+    private String alternateImageUrl;
     private List<DisplayProperty> itemProperties;
+    private String itemPromotionsTitle;
+    private List<String> promotions;
+
 
     public void addItemProperty(DisplayProperty property){
         if(itemProperties == null){


### PR DESCRIPTION
# Changes
This updates the item details page to include available promotions

# Example

**With and without available promotions**

![item-details-promos](https://user-images.githubusercontent.com/3991426/88592000-44859e00-d02b-11ea-9fbd-ab16d428ebf5.gif)
