### PR TITLE
Exclude effectively read-only fields from form validation

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/interfaces/form-field.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/interfaces/form-field.interface.ts
@@ -45,6 +45,7 @@ export interface IFormElement {
     startAtDate: any;
     hintText: string;
     hideButtons: boolean;
+    readOnly: boolean;
 }
 
 export interface IDynamicListField {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/services/form-builder.service.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/services/form-builder.service.ts
@@ -19,7 +19,9 @@ export class FormBuilder {
         const group: any = {};
         if (form.formElements) {
             form.formElements.forEach((element) => {
-                group[element.id] = new FormControl(element.value, this.createControlValidators(element));
+                group[element.id] = new FormControl(element.value,
+                    ! this.isReadOnlyElement(element) ? this.createControlValidators(element) : []
+                );
 
                 // For a DATE type element, there is also a hidden field to handle picking of dates using
                 // a date picker, need to add a FormControl for that hidden input also.
@@ -30,6 +32,10 @@ export class FormBuilder {
         }
 
         return new FormGroup(group, this.createFormLevelValidators(form, extraValidators));
+    }
+
+    isReadOnlyElement(element: IFormElement): boolean {
+        return element.elementType === 'Display' || element.disabled || element.readOnly;
     }
 
     buildFormPayload(formGroup: FormGroup, form: IForm): IForm {


### PR DESCRIPTION
- Discovered this problem when trying to edit an existing customer for Petco which had a loyalty number that was no longer valid per the current validation rules.  Even though the loyalty number fields was read only, the form would not validate and would not submit the "Update" action.  The form also did not show any errors.