### PR TITLE
Blur the active element when scanning so we complete any pending input

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/focus/focus.service.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/focus/focus.service.ts
@@ -33,4 +33,11 @@ export class FocusService {
             element.focus();
         }
     }
+
+    blurCurrentElement() {
+        if( document.activeElement instanceof HTMLElement){
+            document.activeElement.blur();
+        }
+    }
+
 }


### PR DESCRIPTION
The issue is if the user while filling out a form doesn't tab off a field and then does a scan we loose the data in the field due to it not having been sent to the server yet. In fact Angular doesn't even know about the value yet.

This fix for this is to blur the activeElement so that we trigger any valueChangedActions. This possibly creates a race condition between the valueChangedAction and the scanAction so we'll use a setTimeout of 1 ms on the scanAction. This will queue up that method and make sure that the javascript microqueue is drained and anything queued with a setTimeout of 0 will be completed before sending the scanAction. Essentially we are making sure the valueChangedAction is sent first.

Adding everyone so you are aware of the issue and fix if we run into this scenario elsewhere. If you are working on a form that can have parts of it filled via a scan we'll need to set up valueChangedActions for the fields so they are persisted on the server.