### PR TITLE
Proposed fix for commerce issue 1767: Backwards compatibility issue when searching for customer transactions

### DIFF
--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/ColumnDef.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/ColumnDef.java
@@ -38,4 +38,10 @@ public @interface ColumnDef {
     String description() default "";
     CrossReference[] crossReferences() default {};
     String crossReference() default "";
+    /**
+     * An optional list of alternate property names for this column that can be used when querying by criteria.
+     * Useful for providing backward compatibility for properties and columns whose names have changed.
+     * @return The list of alternate property names for the column.
+     */
+    String[] propertyAliases() default {};
 }

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/DatabaseSchema.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/DatabaseSchema.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 
 import lombok.SneakyThrows;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.money.Money;
 import org.jumpmind.db.model.Column;
@@ -319,7 +320,15 @@ public class DatabaseSchema {
                 } else {
                     columns.add(column);
                 }
-                metaData.addEntityFieldMetaData(field.getName(), new FieldMetaData(clazz, field, column));
+                FieldMetaData fieldMetaData = new FieldMetaData(clazz, field, column);
+                metaData.addEntityFieldMetaData(field.getName(), fieldMetaData);
+                ColumnDef colAnnotation = field.getAnnotation(ColumnDef.class);
+                if (colAnnotation != null && ArrayUtils.isNotEmpty(colAnnotation.propertyAliases())) {
+                    for (String alias: colAnnotation.propertyAliases()) {
+                        // Add a mapping entry for each optional propertyAlias for the column
+                        metaData.addEntityFieldMetaData(alias, fieldMetaData);
+                    }
+                }
             }
             CompositeDef compositeDefAnnotation = field.getAnnotation(CompositeDef.class);
             if (compositeDefAnnotation != null) {

--- a/openpos-persist/src/test/java/org/jumpmind/pos/persist/DBSessionTest.java
+++ b/openpos-persist/src/test/java/org/jumpmind/pos/persist/DBSessionTest.java
@@ -12,6 +12,7 @@ import org.joda.money.Money;
 import org.jumpmind.pos.persist.cars.CarModel;
 import org.jumpmind.pos.persist.cars.CarTrimTypeCode;
 import org.jumpmind.pos.persist.cars.RaceCarModel;
+import org.jumpmind.pos.persist.cars.SubModelCode;
 import org.jumpmind.pos.persist.cars.TestPersistCarsConfig;
 import org.junit.After;
 import org.junit.Before;
@@ -385,12 +386,60 @@ public class DBSessionTest {
             db.close();
         }
     }
-    
+
+    @Test
+    public void testFindByFieldsWithAliasedColumnDef() {
+        final String VIN1 = "TACO12335R980975874872";
+        {
+            DBSession db = sessionFactory.createDbSession();
+            CarModel someToyota = new CarModel();
+            someToyota.setVin(VIN1);
+            someToyota.setMake("Toyota");
+            someToyota.setModel("Tacoma");
+            someToyota.setModelYear("2007");
+            someToyota.setSubModelCode(SubModelCode.HD);
+            db.save(someToyota);
+            db.close();
+        }
+
+        {
+            Map<String, Object> fieldValues = new HashMap<>();
+            // subModel does not have a Column def and is deprecated, but the @ColumnDef annotation for subModelCode,
+            // has a property alias of "subModel"
+            fieldValues.put("subModel", "HD");
+            fieldValues.put("vin", VIN1);
+
+            DBSession db = sessionFactory.createDbSession();
+            List<CarModel> cars = db.findByFields(CarModel.class, fieldValues, 100);
+            assertNotNull(cars);
+            assertEquals(1, cars.size());
+            assertEquals(VIN1, cars.get(0).getVin());
+
+            db.close();
+        }
+
+        {
+            Map<String, Object> fieldValues = new HashMap<>();
+            // subModel does not have a Column def and is deprecated, but the @ColumnDef annotation for subModelCode,
+            // has a property alias of "sub_model"
+            fieldValues.put("sub_model", "HD");
+            fieldValues.put("vin", VIN1);
+
+            DBSession db = sessionFactory.createDbSession();
+            List<CarModel> cars = db.findByFields(CarModel.class, fieldValues, 100);
+            assertNotNull(cars);
+            assertEquals(1, cars.size());
+            assertEquals(VIN1, cars.get(0).getVin());
+
+            db.close();
+        }
+
+    }
     @Test
     public void testFindByFields() {
         final String VIN1 = "KMHCN46C58U242743";
         final String VIN2 = "KMHCN46C58U2427432342";
-        
+
         {
             DBSession db = sessionFactory.createDbSession();
             CarModel someHyundai = new CarModel();
@@ -410,8 +459,8 @@ public class DBSessionTest {
             someHyundai.setModelYear("2005");
             db.save(someHyundai);
             db.close();
-        }        
-        
+        }
+
         Map<String, Object> fieldValues = new HashMap<>();
         fieldValues.put("vin", VIN1);
         

--- a/openpos-persist/src/test/java/org/jumpmind/pos/persist/cars/CarModel.java
+++ b/openpos-persist/src/test/java/org/jumpmind/pos/persist/cars/CarModel.java
@@ -42,11 +42,12 @@ public class CarModel extends AbstractTaggedModel implements ITaggedModel {
     /*
      This tests deprecating a field and mapping to a new field, while keeping the column name the same.  The subModel
      attribute used to be mapped to the sub_model column (by default), but I changed the mapping to the subModelCode
-     property in order to test use of the 'name' attribute on a ColumnDef.
+     property in order to test use of the 'name' attribute on a ColumnDef.  Also tests use of propertyAliases
+     which allows for alternate names that can be used when querying with criteria using the property name.
      */
     @Deprecated
     private String subModel;
-    @ColumnDef(name="sub_model")
+    @ColumnDef(name="sub_model", propertyAliases = {"subModel", "sub_model"})
     private SubModelCode subModelCode;
     
     public String getModelYear() {
@@ -128,5 +129,4 @@ public class CarModel extends AbstractTaggedModel implements ITaggedModel {
         }
         return subModelCode;
     }
-
 }


### PR DESCRIPTION
- Support property name "aliases" for a given column def for case when a property name has changed
- Provides backward compatibility for older code client code to be able to query by criteria for columns/properties whose name has changed

Problem in commerce was as follows:

1. The older client sent over a `TransSearchRequest` to the `SearchReturnsTransEndpoint`.
2. The `TransSearchRequest` had `SearchCriteria` embedded within it that is referencing a column whose name has changed from trans_status to trans_status_code (See commerce issue 763).
3. In OpenPOS #658, I added a check to make sure that the parameters specified on a query can all be mapped to a specific attribute with an `@ColumnDef` annotation, otherwise an exception is thrown.  That change was designed to protect against mistakes in SearchCriteria map keys.
4. Since the `TransModel` class on the CO server no longer has an `@ColumnDef` annotation on the deprecated transStatus attribute, we get an exception on the CO server.