### PR TITLE
Bugfix/keypress provider non regex change

### DIFF
--- a/openpos-client-libs/package-lock.json
+++ b/openpos-client-libs/package-lock.json
@@ -6969,8 +6969,7 @@
     "lodash": {
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
-      "dev": true
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash.assign": {
       "version": "4.2.0",


### PR DESCRIPTION
# Fixes
This changes the `KeyPressProvider` to use manual parsing, instead of a regex, to get parse action key bindings. Previously, I had used a "negative lookbehind" in a regex but this isn't supported by some environments we need to support.

# Examples
The key press is show in the scan input, and wait for 3 seconds before navigating, so you can see what key press is triggering what action in the examples.

**Multiple Keybinds for an Action**
```
- action: ItemInquiry
  key: Shift+F4,Ctrl+\\,,Ctrl+Shift+\\+,Shift+F5
```

![action-with-multiple-key-binds](https://user-images.githubusercontent.com/3991426/90299016-6f148b00-de62-11ea-8882-1eb5ce870825.gif)

**Single Keybind for an Action**
```
- action: GiftCardOptions
  key: Alt+F10
```

![action-with-single-key-bind](https://user-images.githubusercontent.com/3991426/90299022-7176e500-de62-11ea-9294-c7cd429f1c0e.gif)