### PR TITLE
Execute OnDepart before outjections

### DIFF
--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/StateManager.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/StateManager.java
@@ -382,12 +382,12 @@ public class StateManager implements IStateManager {
                             + "exiting a subState. These two should not be happening at the same time.");
         }
 
+        boolean enterSubState = enterSubStateConfig != null;
+        stateLifecycle.executeDepart(applicationState.getCurrentContext().getState(), newState, enterSubState, action);
+
         if (applicationState.getCurrentContext().getState() != null) {
             performOutjections(applicationState.getCurrentContext().getState());
         }
-
-        boolean enterSubState = enterSubStateConfig != null;
-        stateLifecycle.executeDepart(applicationState.getCurrentContext().getState(), newState, enterSubState, action);
 
         Transition transition = new Transition(transitionStepConfigs,
                 applicationState.getCurrentContext(), newState, enterSubStateConfig, resumeSuspendedState, autoTransition);

--- a/openpos-flow/src/test/java/org/jumpmind/pos/core/flow/TestStates.java
+++ b/openpos-flow/src/test/java/org/jumpmind/pos/core/flow/TestStates.java
@@ -362,7 +362,50 @@ public class TestStates {
             
         }
     }
-    
+    public static class SetVariablesState {
+        @InOut(scope = ScopeType.Flow, required = false)
+        String variableToClear;
+
+        @InOut(scope = ScopeType.Flow, required = false)
+        String variableToKeep;
+
+
+        @OnArrive
+        void init() {
+            variableToClear = "value-1";
+            variableToKeep = "keep-me";
+        }
+    }
+
+    public static class UnsetVariablesState {
+        @InOut(scope = ScopeType.Flow)
+        String variableToClear;
+
+        @InOut(scope = ScopeType.Flow)
+        String variableToKeep;
+
+        @OnArrive
+        void init() {
+        }
+
+        @OnDepart
+        void doOnDepart() {
+            variableToClear = null;
+        }
+    }
+
+    public static class CheckVariablesState {
+        @InOut(scope = ScopeType.Flow, required = false)
+        String variableToClear;
+        @InOut(scope = ScopeType.Flow)
+        String variableToKeep;
+
+        @OnArrive
+        void init() {
+        }
+
+    }
+
     public static class StateWithBeforeActionMethod {
         
         boolean onAction1Invoked = false;

--- a/openpos-hazelcast/src/main/java/org/jumpmind/pos/hazelcast/HazelcastPublisher.java
+++ b/openpos-hazelcast/src/main/java/org/jumpmind/pos/hazelcast/HazelcastPublisher.java
@@ -33,7 +33,7 @@ public class HazelcastPublisher implements IEventDistributor, ApplicationListene
                 if (!event.isRemote()) {
                     log.info("{} received an event {},{} from {}. PUBLISHING IT ", this.getClass().getSimpleName(), event.toString(), System.identityHashCode(event), event.getSource());
                     // then share it with the world
-                    ITopic<AppEvent> topic = hz.getTopic("nucommerce/events");
+                    ITopic<AppEvent> topic = hz.getTopic("commerce/events");
                     topic.publish(event);
                 } else {
                     log.info("{} received an event {},{} from {}.  It was from a remote node already.  NOT PUBLISHING ", this.getClass().getSimpleName(), event.toString(), System.identityHashCode(event), event.getSource());

--- a/openpos-hazelcast/src/main/java/org/jumpmind/pos/hazelcast/HazelcastSubscriber.java
+++ b/openpos-hazelcast/src/main/java/org/jumpmind/pos/hazelcast/HazelcastSubscriber.java
@@ -26,7 +26,7 @@ public class HazelcastSubscriber {
 
     @PostConstruct
     protected void subscribe() {
-        ITopic<AppEvent> topic = hz.getTopic("nucommerce/events");
+        ITopic<AppEvent> topic = hz.getTopic("commerce/events");
         topic.addMessageListener(new LocalListener());
     }
 


### PR DESCRIPTION
Move outjections to occur AFTER @OnDepart methods

- Ran into a case where I was wanting to reset a variable to null in the @OnDepart method of state, but it was not sticking and the variable was set back to its old value when the state was active again.
- Related to commerce issue 1951
- Threw in a unit test as well