### PR TITLE
Changes for #1926: Qty hotkey working when it shouldn't

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-item-card-list/sale-item-card-list.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-item-card-list/sale-item-card-list.component.ts
@@ -3,11 +3,12 @@ import { SaleItemCardListInterface } from './sale-item-card-list.interface';
 import { ScreenPart } from '../../decorators/screen-part.decorator';
 import { ScreenPartComponent } from '../screen-part';
 import { UIDataMessageService } from '../../../core/ui-data-message/ui-data-message.service';
-import {merge, Observable, Subject} from 'rxjs';
+import {merge, Observable} from 'rxjs';
 import { ISellItem } from '../../../core/interfaces/sell-item.interface';
 import { KeyPressProvider } from '../../providers/keypress.provider';
 import { Configuration } from '../../../configuration/configuration';
 import {filter, takeUntil} from 'rxjs/operators';
+import {IActionItem} from "../../../core/actions/action-item.interface";
 
 
 @ScreenPart({
@@ -90,8 +91,15 @@ export class SaleItemCardListComponent extends ScreenPartComponent<SaleItemCardL
 
     this.keyPressProvider.globalSubscribe(uniqueActions).pipe(
         filter(() => this.expandedIndex >= 0),
+        filter(action => this.doesExpandedItemHaveAction(sellItems,action)),
         takeUntil(this.stop$)
     ).subscribe(action => this.doAction(action, [this.expandedIndex]));
+  }
+
+  doesExpandedItemHaveAction(sellItems: ISellItem[], action: IActionItem): boolean {
+    return !!sellItems[this.expandedIndex]
+        .menuItems
+        .find(menuItem=>menuItem.action === action.action);
   }
 
   scrollToView(index: number): void {


### PR DESCRIPTION
The gif shows the steps from ticket #1926, but without the Qty hotkey triggering the Change Quantity modal. Here are those steps:

1. add a sku that is not qty enabled
2. QTY hotkey does not work (as designed)
3. Add a Qty enabled sku
4. add a sku that is not qty enabled (can use same as #1)
5. Select QTY hotkey
6. System prompts for Qty which is not correct.

The action seen after the addition of each item is the pressing of F5, which by default maps to both Change Quantity and Item Inquiry, based on scope. That being the case, F5 should trigger Change Quantity for quantity-modifiable items(RAID HOUSE/GARDEN 17) and then trigger Item Inquiry of the drawer menu at left for not-quantity-modifiable items (FLUID POWER STEERING) when an item is ineligible for Change Quantity. With distinct mappings, like Petco's Qty key, item inquiry would not be triggered.

![Adjust Quantity Hotkey](https://user-images.githubusercontent.com/24829305/91514068-d515ff00-e8b3-11ea-865c-66c5eec0ee49.gif)