### PR TITLE
Add personalization params to client context

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/device-model.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/device-model.interface.ts
@@ -1,5 +1,7 @@
+import {IDeviceParamModel} from './device-param-model.interface';
+
 export interface  IDeviceModel {
     deviceId: string;
     appId: string;
-
+    deviceParamModels: IDeviceParamModel[];
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/device-param-model.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/device-param-model.interface.ts
@@ -1,0 +1,4 @@
+export interface IDeviceParamModel {
+    paramName: string;
+    paramValue: string;
+}

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/personalization.service.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/personalization.service.ts
@@ -64,6 +64,11 @@ export class PersonalizationService {
                 this.setDeviceId(response.deviceModel.deviceId);
                 this.setDeviceToken(response.authToken);
                 this.setAppId(response.deviceModel.appId);
+                if( !personalizationParameters ){
+                    personalizationParameters = new Map<string, string>();
+                }
+                response.deviceModel.deviceParamModels.forEach(value => personalizationParameters.set(value.paramName, value.paramValue));
+
                 this.setPersonalizationProperties(personalizationParameters);
 
                 if (sslEnabled) {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/personalization.service.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/personalization.service.ts
@@ -67,7 +67,9 @@ export class PersonalizationService {
                 if( !personalizationParameters ){
                     personalizationParameters = new Map<string, string>();
                 }
-                response.deviceModel.deviceParamModels.forEach(value => personalizationParameters.set(value.paramName, value.paramValue));
+                if(response.deviceModel.deviceParamModels){
+                    response.deviceModel.deviceParamModels.forEach(value => personalizationParameters.set(value.paramName, value.paramValue));
+                }
 
                 this.setPersonalizationProperties(personalizationParameters);
 

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/StateManagerContainer.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/StateManagerContainer.java
@@ -110,6 +110,7 @@ public class StateManagerContainer implements IStateManagerContainer, Applicatio
             setCurrentStateManager(stateManager);
             clientContext.put("deviceId", deviceId);
             clientContext.put("appId", appId);
+            personalizationProperties.entrySet().forEach(entry -> clientContext.put(entry.getKey(), entry.getValue()) );
 
             stateManager.setTransitionSteps(createTransitionSteps(appId, deviceId));
             stateManager.registerQueryParams(queryParams);
@@ -187,6 +188,7 @@ public class StateManagerContainer implements IStateManagerContainer, Applicatio
             for (String property : stateManager.getClientContext().keySet()) {
                 clientContext.put(property, stateManager.getClientContext().get(property));
             }
+
             clientContext.put("deviceId", stateManager.getDeviceId());
             clientContext.put("appId", stateManager.getAppId());
         } else {

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/StateManagerContainer.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/StateManagerContainer.java
@@ -110,7 +110,9 @@ public class StateManagerContainer implements IStateManagerContainer, Applicatio
             setCurrentStateManager(stateManager);
             clientContext.put("deviceId", deviceId);
             clientContext.put("appId", appId);
-            personalizationProperties.entrySet().forEach(entry -> clientContext.put(entry.getKey(), entry.getValue()) );
+            if(personalizationProperties != null){
+                personalizationProperties.entrySet().forEach(entry -> clientContext.put(entry.getKey(), entry.getValue()) );
+            }
 
             stateManager.setTransitionSteps(createTransitionSteps(appId, deviceId));
             stateManager.registerQueryParams(queryParams);


### PR DESCRIPTION
It looks like somewhere along the way we broke attaching the personalization params in the client headers. This makes it easy for them to be sucked into the client context object.