### PR TITLE
Fixed tendering cash back message from overlapping keybind display text

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/option-button/_option-button-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/option-button/_option-button-theme.scss
@@ -3,6 +3,7 @@
     $disabled-border: map-get(map-get($theme, foreground), disabled-button);
     $focused-color: map-get(map-get($theme, background), focused-button);
     $success-color: mat-color(map-get($theme, success));
+    $success-color-lighter: mat-color(map-get($theme, success), 50);
 
     app-option-button {
         button {
@@ -13,18 +14,27 @@
                 border-color: $disabled-border;
             }
 
+            .option-content,
+            .option-right {
+                padding-left: 8px;
+                padding-right: 8px;
+            }
+
             .option-content {
                 .additional-text {
-                    text-align: left;
+                    background: $success-color-lighter;
+                    text-align: center;
                     white-space: pre-line;
                     font-size: $text-sm !important;
-                    border: 1px solid $success-color;
+                    font-weight: bold;
+                    border: 2px solid $success-color;
                     color: $success-color;
-                    border-radius: 5px;
+                    border-radius: 4px;
                     line-height: 1.5rem;
                     padding: .25rem;
                     display: inline-block;
                     width: 100%;
+                    box-sizing: border-box;
                     &:empty {
                         border: none;
                     }


### PR DESCRIPTION
# Fixes
1. The cash back message, on receipted returns, from overlapping keybinding display name. Also a few minor style tweaks (bold text, light green background and border thicker) to make the message pop out a little more.

# Example

<img width="1788" alt="Screen Shot 2020-09-03 at 1 28 10 PM" src="https://user-images.githubusercontent.com/3991426/92148149-23625b00-edea-11ea-9940-1738c8dff3ab.png">
