### PR TITLE
Feature/returns style change new theme

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/return/_return-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/return/_return-theme.scss
@@ -1,9 +1,9 @@
 @mixin return-theme($theme){
-    $app-primary: mat-color(map-get($theme, primary));
+    $app-primary: mat-color(map-get($theme, returns));
     $app-accent: mat-color(map-get($theme, accent));
     $app-warn: mat-color(map-get($theme, warn));
     
-    $contrast: mat-color(map-get($theme,primary), default-contrast);
+    $contrast: mat-color(map-get($theme, returns), default-contrast);
     $dark: map-get($mat-grey, 600);
 
     $foreground: map-get($theme, foreground );
@@ -15,5 +15,29 @@
 
     .contrast-color {
         color: $contrast;
+    }
+
+    app-return {
+            .scan-or-search {
+                .mat-button.mat-primary-inverse {
+                    background-color:$app-primary;
+                    color:$contrast;
+                }
+            }
+
+            .item-count {
+                background-color:$app-primary;
+                color:$contrast;
+            }
+
+            .sale-total-button {
+                    .mat-flat-button.mat-primary {
+                        background-color:$app-primary;
+                        color:$contrast;
+                    }
+                    button {
+                        border-color:$app-primary;
+                    }
+            }
     }
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/item-card/item-card.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/item-card/item-card.component.html
@@ -8,7 +8,7 @@
             <div *ngIf="item.description" responsive-class class="item-card-title">
                 {{item.description}}
             </div>
-            <section class="return-info warn" *ngIf="item.returnItemLabels && expanded">
+            <section class="return-info return-color" *ngIf="item.returnItemLabels && expanded">
                 <app-icon [iconName]="item.isOrderItem ? 'assignment': 'receipt'"></app-icon>
                 <ul responsive-class class="return-info-text">
                     <li *ngFor="let returnItemLabel of item.returnItemLabels">
@@ -34,7 +34,7 @@
             <section class="price" [ngClass]="{'collapsed': !expanded}">
                 <div class="item-price-and-indicators">
                     <app-icon *ngIf="item.isGiftReceipt" class="giftReceipt" [iconName]="'Gift'" [iconClass]="'material-icons sm muted-color'"></app-icon>
-                    <app-currency-text responsive-class class="item-card-price" [ngClass]="{'order-color': item.isOrderItem, 'warn': item.returnItemLabels, 'success': item.isTender}"
+                    <app-currency-text responsive-class class="item-card-price" [ngClass]="{'order-color': item.isOrderItem, 'return-color': item.returnItemLabels, 'success': item.isTender}"
                     [amountText]="item.amount">
                     </app-currency-text>
                 </div>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/mobile-item/mobile-item.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/mobile-item/mobile-item.component.html
@@ -6,7 +6,7 @@
             <div *ngIf="item.description" responsive-class class="item-card-title">
                 {{item.description}}
             </div>
-            <section class="return-info warn" *ngIf="item.returnItemLabels && expanded">
+            <section class="return-info return-color" *ngIf="item.returnItemLabels && expanded">
                 <app-icon [iconName]="item.isOrderItem ? 'assignment': 'receipt'"></app-icon>
                 <ul responsive-class class="return-info-text">
                     <li *ngFor="let returnItemLabel of item.returnItemLabels">

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/_app-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/_app-theme.scss
@@ -56,7 +56,8 @@
         background: map-merge($mat-light-theme-background, $openpos-background),
         selected: $selected,
         success: mat-palette($mat-green),
-        orders: mat-palette($mat-orange, 800)
+        orders: mat-palette($mat-orange, 800),
+        returns: mat-palette($mat-red, 900)
     );
     @return map-merge(map-merge($openpos-mat-theme, $openpos-addons), $addons);
 }
@@ -84,6 +85,7 @@
     $background: map-get($theme, background);
     $success-color: mat-color(map-get($theme, success));
     $order-color: mat-color(map-get($theme, orders));
+    $return-color: mat-color(map-get($theme, returns));
 
 
     // this is a hack to get around a default value in angular material that they removed in future versions
@@ -115,6 +117,10 @@
 
     .order-color {
         color: $order-color;
+    }
+
+    .return-color {
+        color: $return-color;
     }
 
     .order-background {


### PR DESCRIPTION
Added a new theme to Returns to make it distinct from the sales screen. The item cards for return items have been updated to reference this theme as well. For reference:
![image](https://user-images.githubusercontent.com/39058176/92249415-0be1ab80-ee98-11ea-86b9-3f11f78afb6e.png)

The theme is modeled after Mark's moqup here: https://github.com/JumpMind/commerce/issues/1910

Corresponding label changes: https://github.com/JumpMind/commerce/pull/2009