### PR TITLE
fix hotkeys/field validation for loyalty lookup

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/core.module.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/core.module.ts
@@ -63,6 +63,7 @@ import { CLIENTCONTEXT } from './client-context/client-context-provider.interfac
 import { TimeZoneContext } from './client-context/time-zone-context';
 import {UIDataMessageService} from './ui-data-message/ui-data-message.service';
 import { HelpTextService } from './help-text/help-text.service';
+import {ErrorStateMatcher, ShowOnDirtyErrorStateMatcher} from "@angular/material/core";
 
 registerLocaleData(locale_enCA, 'en-CA');
 registerLocaleData(locale_frCA, 'fr-CA');
@@ -137,7 +138,8 @@ registerLocaleData(locale_frCA, 'fr-CA');
         KeyPressProvider,
         { provide: LOGGERS, useExisting: ServerLogger, multi: true, deps: [HttpClient, PersonalizationService, ConsoleIntercepter] },
         HelpTextService,
-        { provide: CLIENTCONTEXT, useClass: TimeZoneContext, multi: true }
+        { provide: CLIENTCONTEXT, useClass: TimeZoneContext, multi: true },
+        { provide: ErrorStateMatcher, useClass: ShowOnDirtyErrorStateMatcher }
     ]
 })
 export class CoreModule {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/primary-button/_primary-button-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/primary-button/_primary-button-theme.scss
@@ -4,6 +4,7 @@
 
     app-primary-button {
         button {
+            padding: 8px 16px;
             border-color: $primary;
             border-style: solid;
             border-width: 2px;

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/secondary-button/_secondary-button-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/secondary-button/_secondary-button-theme.scss
@@ -4,6 +4,7 @@
 
     app-secondary-button {
         button {
+            padding: 8px 16px;
             border-color: $border;
             border-style: solid;
             border-width: 2px;

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/secondary-button/secondary-button.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/secondary-button/secondary-button.component.ts
@@ -8,7 +8,7 @@ import { Component, Input, EventEmitter, Output } from '@angular/core';
 export class SecondaryButtonComponent {
 
   @Input() disabled: boolean;
-  @Input() inputType: string;
+  @Input() inputType = 'button';
   @Output() buttonClick = new EventEmitter();
   constructor() {
     this.disabled = false;

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.component.html
@@ -9,12 +9,12 @@
             <app-content-card>
                 <div class="content">
                     <app-prompt-input #promptInput [placeholderText]="screenData.placeholderText"
-                        [responseType]="screenData.responseType" [promptIcon]="screenData.promptIcon"
-                        [responseText]="screenData.responseText" [hintText]="screenData.hintText" [minLength]="screenData.minLength"
-                        [maxLength]="screenData.maxLength" [promptFormGroup]="promptFormGroup"
-                        [keyboardPreference]="screenData.keyboardPreference" [scanEnabled]="screenData.scanEnabled"
-                        [validationMessages]="screenData.validationMessages"
-                        [readOnly]="!screenData.editable">
+                                      [responseType]="screenData.responseType" [promptIcon]="screenData.promptIcon"
+                                      [responseText]="screenData.responseText" [hintText]="screenData.hintText" [minLength]="screenData.minLength"
+                                      [maxLength]="screenData.maxLength" [promptFormGroup]="promptFormGroup"
+                                      [keyboardPreference]="screenData.keyboardPreference" [scanEnabled]="screenData.scanEnabled"
+                                      [validationMessages]="screenData.validationMessages"
+                                      [readOnly]="!screenData.editable">
                     </app-prompt-input>
                     <app-instructions *ngIf="instructions" [instructions]="instructions" [instructionsSize]="'text-sm'"></app-instructions>
                     <div #optionsRef>
@@ -29,14 +29,14 @@
             </app-content-card>
 
             <div *ngIf="screenData.otherActions || screenData.actionButton" class="prompt-buttons">
-                <app-secondary-button *ngFor="let menuItem of screenData.otherActions" (click)="onAction(menuItem)">
-                        <span responsive-class>{{menuItem.title}}</span>
-                        <app-icon *ngIf="menuItem.icon" [iconClass]="'md'" [iconName]="menuItem.icon"></app-icon>
+                <app-secondary-button inputType="button" *ngFor="let menuItem of screenData.otherActions" (click)="onAction(menuItem)">
+                    <span responsive-class>{{menuItem.title}}</span>
+                    <app-icon *ngIf="menuItem.icon" [iconClass]="'md'" [iconName]="menuItem.icon"></app-icon>
                 </app-secondary-button>
                 <app-primary-button (click)="onFormSubmit()">
                     <span responsive-class>{{screenData.actionButton.title}}</span>
                     <app-icon *ngIf="screenData.actionButton.icon" [iconClass]="'md'"
-                        [iconName]="screenData.actionButton.icon"></app-icon>
+                              [iconName]="screenData.actionButton.icon"></app-icon>
                 </app-primary-button>
             </div>
         </div>
@@ -44,7 +44,7 @@
 </ng-template>
 
 <ng-template #dialogForm>
-    <form [formGroup]="promptFormGroup" (ngSubmit)="onFormSubmit()" novalidate [markDirtyOnSubmit]="promptFormGroup" class="form">
+    <form appKeypressSource [formGroup]="promptFormGroup" (ngSubmit)="onFormSubmit()" novalidate [markDirtyOnSubmit]="promptFormGroup" class="form">
         <div responsive-class class="form-part-body">
             <app-content-card *ngIf="screenData.info && screenData.promptPosition === 'Bottom'">
                 <div class="content">
@@ -54,10 +54,10 @@
             <app-content-card>
                 <mat-dialog-content class="content">
                     <app-prompt-input #promptInput [placeholderText]="screenData.placeholderText" [responseType]="screenData.responseType ? screenData.responseType.toString() : null"
-                        [promptIcon]="screenData.promptIcon" [responseText]="screenData.responseText" [hintText]="screenData.hintText"
-                        [minLength]="screenData.minLength" [maxLength]="screenData.maxLength" [promptFormGroup]="promptFormGroup"
-                        [validationMessages]="screenData.validationMessages"
-                        [keyboardPreference]="screenData.keyboardPreference" [scanEnabled]="screenData.scanEnabled" [readOnly]="!screenData.editable">
+                                      [promptIcon]="screenData.promptIcon" [responseText]="screenData.responseText" [hintText]="screenData.hintText"
+                                      [minLength]="screenData.minLength" [maxLength]="screenData.maxLength" [promptFormGroup]="promptFormGroup"
+                                      [validationMessages]="screenData.validationMessages"
+                                      [keyboardPreference]="screenData.keyboardPreference" [scanEnabled]="screenData.scanEnabled" [readOnly]="!screenData.editable">
                     </app-prompt-input>
                     <app-instructions *ngIf="instructions" [instructions]="instructions" [instructionsSize]="'text-sm'"></app-instructions>
                     <div #optionsRef>
@@ -72,19 +72,22 @@
             </app-content-card>
 
             <mat-dialog-actions *ngIf="screenData.otherActions && screenData.otherActions.length > 0" class="prompt-buttons">
-                <app-secondary-button *ngFor="let menuItem of screenData.otherActions" (click)="onAction(menuItem)">
+                <app-secondary-button inputType="button" *ngFor="let menuItem of screenData.otherActions" (click)="onAction(menuItem)">
                     <span>{{menuItem.title}}</span>
                     <app-icon *ngIf="menuItem.icon" [iconClass]="'md'" [iconName]="menuItem.icon"></app-icon>
+                    <div class="muted-color keybind-display-name-secondary" *ngIf="menuItem.keybind && keybindsEnabled()">{{menuItem.keybindDisplayName}}</div>
                 </app-secondary-button>
                 <app-primary-button>
                     <span>{{screenData.actionButton.title}}</span>
                     <app-icon *ngIf="screenData.actionButton.icon" [iconClass]="'md'" [iconName]="screenData.actionButton.icon"></app-icon>
+                    <div class="muted-color keybind-display-name-primary" *ngIf="screenData.actionButton.keybind && keybindsEnabled()">{{screenData.actionButton.keybindDisplayName}}</div>
                 </app-primary-button>
             </mat-dialog-actions>
             <mat-dialog-actions *ngIf="(!screenData.otherActions || screenData.otherActions && screenData.otherActions.length == 0) && screenData.actionButton" align="end">
                 <app-primary-button>
                     <span>{{screenData.actionButton.title}}</span>
                     <app-icon *ngIf="screenData.actionButton.icon" [iconClass]="'md'" [iconName]="screenData.actionButton.icon"></app-icon>
+                    <div class="muted-color keybind-display-name-primary" *ngIf="screenData.actionButton.keybind && keybindsEnabled()">{{screenData.actionButton.keybindDisplayName}}</div>
                 </app-primary-button>
             </mat-dialog-actions>
         </div>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.component.scss
@@ -38,3 +38,7 @@
     padding: 0;
     margin: 0;
 }
+
+.keybind-display-name-secondary {
+    padding-left: 8px;
+}

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.component.ts
@@ -4,6 +4,8 @@ import { Validators, FormControl, FormGroup, ValidatorFn } from '@angular/forms'
 import { ValidatorsService } from '../../../core/services/validators.service';
 import { IActionItem } from '../../../core/actions/action-item.interface';
 import { PromptFormPartInterface } from './prompt-form-part.interface';
+import {Configuration} from "../../../configuration/configuration";
+import {merge} from "rxjs";
 
 @Component({
     selector: 'app-prompt-form-part',
@@ -14,6 +16,7 @@ export class PromptFormPartComponent extends ScreenPartComponent<PromptFormPartI
 
     @ViewChild('optionsRef') options;
 
+    stop$ = merge(this.beforeScreenDataUpdated$, this.destroyed$);
     promptFormGroup: FormGroup;
     initialized = false;
     instructions: string;
@@ -68,6 +71,13 @@ export class PromptFormPartComponent extends ScreenPartComponent<PromptFormPartI
             group[this.hiddenInputControlName] = new FormControl();
         }
         this.promptFormGroup = new FormGroup(group);
+
+        this.keyPressProvider.subscribe(this.screenData.actionButton, 100,() => this.onFormSubmit(), this.stop$);
+        this.keyPressProvider.subscribe(this.screenData.otherActions, 100,(event, action) => this.doAction(action), this.stop$);
+    }
+
+    public keybindsEnabled() {
+        return Configuration.enableKeybinds;
     }
 
     ngAfterViewInit(): void {


### PR DESCRIPTION
Changes:
- When on the loyalty screen and then clicking Add New Customer, the input field validation had been getting triggered.  Same for the First Name field on the Add New Customer screen when the x was clicked to close it.  No longer happens.
- added some minor padding to primary and secondary buttons
- Hotkeys were added to the Loyalty Lookup, and Enter now triggers Search.

validation and hotkeys functioning can be seen here:
![Validation and hotkeys](https://user-images.githubusercontent.com/24829305/92276347-cf757600-eebe-11ea-94f0-6c7e9803c724.gif)
