### PR TITLE
Add null check to screenData

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/tender-part/tender-part.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/tender-part/tender-part.component.ts
@@ -20,7 +20,7 @@ export class TenderPartComponent extends ScreenPartComponent<TenderPartInterface
     amountCss: string = '';
 
     screenDataUpdated() {
-        if (parseFloat(this.screenData.amountDue.amount) < 0) {
+        if (this.screenData.amountDue && parseFloat(this.screenData.amountDue.amount) < 0) {
             this.amountCss = 'negative';
         }
         else {


### PR DESCRIPTION
Looks like theres a possibility of an old screen getting into the screenDataUpdated method, that only seems to be happening on cordova. Preventing this is pretty tricky so we just need to protect against it for now.