### PR TITLE
Bugfix/lock screen triggers keybind actions and inactivity monitor not checking scroll and mouse down

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/lock-screen/lock-screen.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/lock-screen/lock-screen.component.ts
@@ -1,4 +1,4 @@
-import {Component, Inject, OnDestroy, OnInit} from '@angular/core';
+import {Component, HostListener, Inject, OnDestroy, OnInit} from '@angular/core';
 import {Observable, Subject} from 'rxjs';
 import {takeUntil, tap} from 'rxjs/operators';
 import {ActionService} from '../actions/action.service';
@@ -35,6 +35,13 @@ export class LockScreenComponent implements OnDestroy{
     }else{
       this.submitPassword();
     }
+  }
+
+  @HostListener('keydown', ['$event'])
+  onKeyDown(event: KeyboardEvent) {
+    // Stop the key presses from bubbling up out of the lock screen, so it doesn't trigger any actions
+    // on the page behind the lock screen
+    event.stopPropagation();
   }
 
   submitPassword(){

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/lock-screen/lock-screen.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/lock-screen/lock-screen.component.ts
@@ -39,7 +39,7 @@ export class LockScreenComponent implements OnDestroy{
 
   @HostListener('keydown', ['$event'])
   onKeyDown(event: KeyboardEvent) {
-    // Stop the key press events from bubbling up out of the lock screen, so they don't trigger any actions
+    // Stop the key press events from bubbling up out of the lock screen so they don't trigger any actions
     // on the page behind the lock screen
     event.stopPropagation();
   }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/lock-screen/lock-screen.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/lock-screen/lock-screen.component.ts
@@ -39,7 +39,7 @@ export class LockScreenComponent implements OnDestroy{
 
   @HostListener('keydown', ['$event'])
   onKeyDown(event: KeyboardEvent) {
-    // Stop the key presses from bubbling up out of the lock screen, so it doesn't trigger any actions
+    // Stop the key press events from bubbling up out of the lock screen, so they don't trigger any actions
     // on the page behind the lock screen
     event.stopPropagation();
   }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/directives/inactivity-monitor.directive.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/directives/inactivity-monitor.directive.ts
@@ -22,7 +22,8 @@ export class InactivityMonitorDirective implements OnDestroy {
                 .pipe(takeUntil(this.destroyed$)).subscribe((event: TouchEvent) => this.touchEvent(event));
         }
 
-        const throttledEvents = merge(
+        // Throttle events that can fire very rapidly to prevent too much unnecessary processing
+        const throttledEvents = merge (
             // Scroll events don't bubble, so we need to get them top-down to handle them globally
             fromEvent(window, 'scroll', {capture: true}),
             // Get mouse move event on capture, instead of bubble, so we'll still be notified if nested components stop propagation of event bubbling
@@ -30,11 +31,11 @@ export class InactivityMonitorDirective implements OnDestroy {
         );
 
         throttledEvents.pipe(
-                // leading: get notified at start of throttle interval (as opposed to debounceTime, which waits xxx ms after first event)
-                // trailing: get notified at end of throttle interval too
-                throttleTime(this.eventThrottleTime, undefined, { leading: true, trailing: true }),
-                takeUntil(this.destroyed$)
-            ).subscribe(event => this.throttledEvent(event));
+            // leading: get notified at start of throttle interval (as opposed to debounceTime, which waits xxx ms after first event)
+            // trailing: get notified at end of throttle interval too
+            throttleTime(this.eventThrottleTime, undefined, { leading: true, trailing: true }),
+            takeUntil(this.destroyed$)
+        ).subscribe(event => this.throttledEvent(event));
     }
 
     ngOnDestroy(): void {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/directives/inactivity-monitor.directive.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/directives/inactivity-monitor.directive.ts
@@ -1,6 +1,8 @@
 import { Directive, HostListener, Input, Renderer2, ElementRef, OnDestroy } from '@angular/core';
 import { Configuration } from '../../configuration/configuration';
 import { SessionService } from '../../core/services/session.service';
+import {fromEvent, merge, Subject} from 'rxjs';
+import {takeUntil, throttleTime} from 'rxjs/operators';
 
 
 @Directive({
@@ -8,26 +10,35 @@ import { SessionService } from '../../core/services/session.service';
     selector: '[inactivityMonitor]'
 })
 export class InactivityMonitorDirective implements OnDestroy {
-
+    private destroyed$ = new Subject();
     static lastKeepAliveFlushTime: number = new Date().getTime();
+    private eventThrottleTime = 500;
 
     @Input() keepAliveMillis = Configuration.keepAliveMillis;
 
-    private timerHandle: any;
-    private _timeoutActive;
-
-    private unlisten = () => {};
-
     constructor(private elRef: ElementRef, public renderer: Renderer2, private session: SessionService) {
         if (Configuration.useTouchListener) {
-            this.unlisten = this.renderer.listen(elRef.nativeElement, 'touchstart', (event) => {
-                this.touchEvent(event);
-            });
+            fromEvent(elRef.nativeElement, 'touchstart')
+                .pipe(takeUntil(this.destroyed$)).subscribe((event: TouchEvent) => this.touchEvent(event));
         }
+
+        const throttledEvents = merge(
+            // Scroll events don't bubble, so we need to get them top-down to handle them globally
+            fromEvent(window, 'scroll', {capture: true}),
+            // Capture move move, instead of bubble, so we'll still be notified if nested components stop propagation of event bubbling
+            fromEvent(window,'mousemove', {capture: true})
+        );
+
+        throttledEvents.pipe(
+                // leading: get notified at start of throttle interval (as opposed to debounceTime, which waits xxx ms after first event)
+                // trailing: get notified at end of throttle interval too
+                throttleTime(this.eventThrottleTime, undefined, { leading: true, trailing: true }),
+                takeUntil(this.destroyed$)
+            ).subscribe(event => this.throttledEvent(event));
     }
 
     ngOnDestroy(): void {
-        this.unlisten();
+        this.destroyed$.next();
     }
 
 
@@ -37,11 +48,15 @@ export class InactivityMonitorDirective implements OnDestroy {
     }
 
     @HostListener('window:click', ['$event'])
-    mouseEvent(event: MouseEvent) {
+    mouseClickEvent(event: MouseEvent) {
         this.keepAlive();
     }
 
     touchEvent(event: TouchEvent) {
+        this.keepAlive();
+    }
+
+    throttledEvent(event: Event) {
         this.keepAlive();
     }
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/directives/inactivity-monitor.directive.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/directives/inactivity-monitor.directive.ts
@@ -25,7 +25,7 @@ export class InactivityMonitorDirective implements OnDestroy {
         const throttledEvents = merge(
             // Scroll events don't bubble, so we need to get them top-down to handle them globally
             fromEvent(window, 'scroll', {capture: true}),
-            // Capture move move, instead of bubble, so we'll still be notified if nested components stop propagation of event bubbling
+            // Get mouse move event on capture, instead of bubble, so we'll still be notified if nested components stop propagation of event bubbling
             fromEvent(window,'mousemove', {capture: true})
         );
 


### PR DESCRIPTION
# Fixes
1. `LockScreenComponent` to block key press events from bubbling up outside of the lock screen so they don't trigger actions on the page behind the lock screen
2. `InactivityMonitorDirective` to include `scroll` and `mousemove` events when signaling keep alive to the server. The handling of these events is throttled, to process at most every `500ms`, to prevent a bunch of unnecessary processing for these rapidly firing events.

These fix issue **#2014**:

**If you scroll through the customer loyalty lookup results for too long the system will lock you out due to inactivity even though you are scrolling. After getting locked out and logging back in the system has proceeded to select one of the customers and link them to the transaction even though they were not actually selected (could the last highlighted record?) (PDPOS-3695) #2014**

https://github.com/JumpMind/commerce/issues/2014
