### PR TITLE
Feature/personalization enhancements

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/personalization-config-response.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/personalization-config-response.interface.ts
@@ -4,6 +4,7 @@ export interface PersonalizationConfigResponse {
     devicePattern?: string;
     parameters?: PersonalizationParameter[];
     availableDevices?: Map<string, string>;
+    loadedAppIds?: string[];
 
     //If this is from the ManagementServer we will also get these properties
     openposManagementServer?: boolean;

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/personalization-config-response.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/personalization-config-response.interface.ts
@@ -3,6 +3,7 @@ import { PersonalizationParameter } from './personalization-parameter.interface'
 export interface PersonalizationConfigResponse {
     devicePattern?: string;
     parameters?: PersonalizationParameter[];
+    availableDevices?: Map<string, string>;
 
     //If this is from the ManagementServer we will also get these properties
     openposManagementServer?: boolean;

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/personalization.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/personalization.component.html
@@ -59,7 +59,8 @@
             </form>
         </mat-step>
         <mat-step [stepControl]="thirdFormGroup">
-            <form *ngIf="thirdFormGroup" [formGroup]="thirdFormGroup">
+            <mat-slide-toggle [(ngModel)]="manualPersonalization" (change)="updateThirdFormGroup()">Manual Personalization</mat-slide-toggle>
+            <form *ngIf="thirdFormGroup && manualPersonalization" [formGroup]="thirdFormGroup">
                 <ng-template matStepLabel>Enter device information</ng-template>
                 <mat-form-field>
                     <input matInput placeholder="Device ID" formControlName="deviceId" required novalidate
@@ -72,11 +73,20 @@
                 <mat-form-field>
                     <input matInput placeholder="App ID" formControlName="appId" required novalidate>
                 </mat-form-field>
-                <div>
-                    <button mat-button matStepperPrevious>Back</button>
-                    <button mat-button matStepperNext color='primary'>Next</button>
-                </div>
-            </form>                        
+            </form>
+            <form *ngIf="thirdFormGroup && !manualPersonalization" [formGroup]="thirdFormGroup">
+                <ng-template matStepLabel>Select Device</ng-template>
+                <mat-form-field>
+                    <mat-select formControlName="device" required >
+                        <mat-option *ngFor="let value of availableDevices" [value]="value.key">{{value.value}}</mat-option>
+                    </mat-select>
+                </mat-form-field>
+
+            </form>
+            <div>
+                <button mat-button matStepperPrevious>Back</button>
+                <button mat-button matStepperNext color='primary'>Next</button>
+            </div>
         </mat-step>
 
         <mat-step *ngIf="openposMgmtServerPresent" [completed]="isDiscoveryCompleted()">
@@ -101,7 +111,7 @@
             </div>
         </mat-step>
 
-        <mat-step [stepControl]="lastFormGroup">
+        <mat-step *ngIf="manualPersonalization" [stepControl]="lastFormGroup">
             <ng-template matStepLabel>Additional configuration</ng-template>
             <form *ngIf="lastFormGroup" [formGroup]="lastFormGroup">
                 <ng-container *ngIf="serverResponse && serverResponse.parameters">

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/personalization.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/personalization.component.html
@@ -71,7 +71,10 @@
                     The Device ID must match openpos.ui.personalization.devicePattern
                 </div>
                 <mat-form-field>
-                    <input matInput placeholder="App ID" formControlName="appId" required novalidate>
+                    <mat-select *ngIf="appIds" formControlName="appId" placeholder="App ID" required>
+                        <mat-option *ngFor="let appId of appIds" [value]="appId">{{appId}}</mat-option>
+                    </mat-select>
+                    <input *ngIf="!appIds" matInput placeholder="App ID" formControlName="appId" required novalidate>
                 </mat-form-field>
             </form>
             <form *ngIf="thirdFormGroup && !manualPersonalization" [formGroup]="thirdFormGroup">

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/personalization.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/personalization.component.html
@@ -66,10 +66,6 @@
                     <input matInput placeholder="Device ID" formControlName="deviceId" required novalidate
                         pattern="[a-zA-Z0-9\-]+">
                 </mat-form-field>
-                <div class="warn"
-                    *ngIf="thirdFormGroup.get('deviceId').errors && thirdFormGroup.get('deviceId').errors.pattern">
-                    The Device ID must match openpos.ui.personalization.devicePattern
-                </div>
                 <mat-form-field>
                     <mat-select *ngIf="appIds" formControlName="appId" placeholder="App ID" required>
                         <mat-option *ngFor="let appId of appIds" [value]="appId">{{appId}}</mat-option>
@@ -86,6 +82,10 @@
                 </mat-form-field>
 
             </form>
+            <div class="warn"
+                 *ngIf="thirdFormGroup.get('deviceId') && thirdFormGroup.get('deviceId').errors && thirdFormGroup.get('deviceId').errors.pattern">
+                The Device ID must match openpos.ui.personalization.devicePattern
+            </div>
             <div>
                 <button mat-button matStepperPrevious>Back</button>
                 <button mat-button matStepperNext color='primary'>Next</button>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/personalization.service.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/personalization.service.ts
@@ -45,7 +45,16 @@ export class PersonalizationService {
 
         let request = new PersonalizationRequest(this.deviceToken$.getValue(), deviceId, appId, null);
         return this.sendPersonalizationRequest( sslEnabled, serverName, serverPort, request, personalizationProperties);
+    }
 
+    public personalizeWithToken(
+        serverName: string,
+        serverPort: string,
+        deviceToken: string,
+        sslEnabled?: boolean
+    ){
+        let request = new PersonalizationRequest(deviceToken, null, null, null);
+        return this.sendPersonalizationRequest( sslEnabled, serverName, serverPort, request, null);
     }
 
     private sendPersonalizationRequest( sslEnabled: boolean, serverName: string, serverPort: string, request: PersonalizationRequest, personalizationParameters: Map<string, string> ) : Observable<string> {

--- a/openpos-devices/src/main/java/org/jumpmind/pos/devices/model/DeviceAuthModel.java
+++ b/openpos-devices/src/main/java/org/jumpmind/pos/devices/model/DeviceAuthModel.java
@@ -1,9 +1,13 @@
 package org.jumpmind.pos.devices.model;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.jumpmind.pos.persist.*;
 
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 @TableDef(name = "device_auth",
         primaryKey = {"deviceId", "appId"})
 @IndexDefs({

--- a/openpos-devices/src/main/java/org/jumpmind/pos/devices/model/DeviceStatusConstants.java
+++ b/openpos-devices/src/main/java/org/jumpmind/pos/devices/model/DeviceStatusConstants.java
@@ -1,0 +1,6 @@
+package org.jumpmind.pos.devices.model;
+
+final public class DeviceStatusConstants {
+    public final static String CONNECTED = "CONNECTED";
+    public final static String DISCONNECTED = "DISCONNECTED";
+}

--- a/openpos-devices/src/main/java/org/jumpmind/pos/devices/model/DeviceStatusModel.java
+++ b/openpos-devices/src/main/java/org/jumpmind/pos/devices/model/DeviceStatusModel.java
@@ -1,0 +1,25 @@
+package org.jumpmind.pos.devices.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.jumpmind.pos.persist.AbstractModel;
+import org.jumpmind.pos.persist.ColumnDef;
+import org.jumpmind.pos.persist.TableDef;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@TableDef(name="device_status",
+        primaryKey = {"deviceId", "appId"})
+public class DeviceStatusModel extends AbstractModel {
+    @ColumnDef
+    private String deviceId;
+
+    @ColumnDef
+    private String appId;
+
+    @ColumnDef
+    private String deviceStatus;
+
+}

--- a/openpos-devices/src/main/java/org/jumpmind/pos/devices/model/DevicesRepository.java
+++ b/openpos-devices/src/main/java/org/jumpmind/pos/devices/model/DevicesRepository.java
@@ -46,6 +46,13 @@ public class DevicesRepository {
         }
     }
 
+    public List<DeviceStatusModel> getDevicesByStatus(String status) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("deviceStatus", status);
+
+        return devSession.findByFields(DeviceStatusModel.class, params, 10000);
+    }
+
     public DeviceModel getDeviceByAuth(String auth) {
         Map<String, Object> params = new HashMap();
         params.put("authToken", auth);
@@ -101,6 +108,10 @@ public class DevicesRepository {
         params.put("appId", appId);
 
         return devSession.findByFields(DeviceParamModel.class, params, 10000);
+    }
+
+    public void updateDeviceStatus(String deviceId, String appId, String status) {
+        devSession.save(new DeviceStatusModel(deviceId, appId, status));
     }
 
 }

--- a/openpos-devices/src/main/java/org/jumpmind/pos/devices/service/AuthenticateDeviceEndpoint.java
+++ b/openpos-devices/src/main/java/org/jumpmind/pos/devices/service/AuthenticateDeviceEndpoint.java
@@ -2,6 +2,8 @@ package org.jumpmind.pos.devices.service;
 
 import org.jumpmind.pos.devices.DeviceNotAuthorizedException;
 import org.jumpmind.pos.devices.DeviceNotFoundException;
+import org.jumpmind.pos.devices.model.DeviceModel;
+import org.jumpmind.pos.devices.model.DeviceStatusConstants;
 import org.jumpmind.pos.devices.model.DevicesRepository;
 import org.jumpmind.pos.devices.service.model.AuthenticateDeviceRequest;
 import org.jumpmind.pos.devices.service.model.AuthenticateDeviceResponse;
@@ -18,8 +20,12 @@ public class AuthenticateDeviceEndpoint {
     public AuthenticateDeviceResponse authenticateDevice(@RequestBody AuthenticateDeviceRequest request){
 
         try{
+            DeviceModel device = devicesRepository.getDeviceByAuth(request.getAuthToken());
+
+            devicesRepository.updateDeviceStatus(device.getDeviceId(), device.getAppId(), DeviceStatusConstants.CONNECTED);
+
             return AuthenticateDeviceResponse.builder()
-                    .deviceModel(devicesRepository.getDeviceByAuth(request.getAuthToken()))
+                    .deviceModel(device)
                     .build();
         } catch (DeviceNotFoundException ex) {
             throw new DeviceNotAuthorizedException();

--- a/openpos-devices/src/main/java/org/jumpmind/pos/devices/service/DisconnectDeviceEndpoint.java
+++ b/openpos-devices/src/main/java/org/jumpmind/pos/devices/service/DisconnectDeviceEndpoint.java
@@ -1,0 +1,19 @@
+package org.jumpmind.pos.devices.service;
+
+import org.jumpmind.pos.devices.model.DeviceStatusConstants;
+import org.jumpmind.pos.devices.model.DevicesRepository;
+import org.jumpmind.pos.devices.service.model.DisconnectDeviceRequest;
+import org.jumpmind.pos.service.Endpoint;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Endpoint(path="/devices/disconnectDevice")
+public class DisconnectDeviceEndpoint {
+
+    @Autowired
+    DevicesRepository devicesRepository;
+
+    public void disconnectDevice(@RequestBody DisconnectDeviceRequest request) {
+        devicesRepository.updateDeviceStatus(request.getDeviceId(), request.getAppId(), DeviceStatusConstants.DISCONNECTED);
+    }
+}

--- a/openpos-devices/src/main/java/org/jumpmind/pos/devices/service/GetPersonalizationConfigEndpoint.java
+++ b/openpos-devices/src/main/java/org/jumpmind/pos/devices/service/GetPersonalizationConfigEndpoint.java
@@ -1,13 +1,20 @@
 package org.jumpmind.pos.devices.service;
 
+import org.jumpmind.pos.devices.model.*;
 import org.jumpmind.pos.devices.service.model.PersonalizationConfigResponse;
 import org.jumpmind.pos.devices.service.model.PersonalizationParameters;
 import org.jumpmind.pos.service.Endpoint;
+import org.jumpmind.pos.util.model.DeviceStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
+
+import java.util.AbstractMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Endpoint(path="/devices/personalizationConfig")
 public class GetPersonalizationConfigEndpoint {
@@ -16,6 +23,8 @@ public class GetPersonalizationConfigEndpoint {
     PersonalizationParameters personalizationParameters;
     Logger logger = LoggerFactory.getLogger(getClass());
 
+    @Autowired
+    DevicesRepository repository;
 
     public PersonalizationConfigResponse getPersonalizationConfig(){
         logger.info("Received a personalization request");
@@ -24,9 +33,19 @@ public class GetPersonalizationConfigEndpoint {
             throw new ResponseStatusException(HttpStatus.NO_CONTENT, "No personalization configuration, use default", null);
         }
 
+        List<DeviceStatusModel> disconnectedDevices = repository.getDevicesByStatus(DeviceStatusConstants.DISCONNECTED);
+        Map<String, String> availableDevices = null;
+        if( disconnectedDevices != null && disconnectedDevices.size() > 0){
+            availableDevices = disconnectedDevices.stream()
+                    .map( deviceStatusModel -> new DeviceAuthModel(deviceStatusModel.getDeviceId(), deviceStatusModel.getAppId(), repository.getDeviceAuth(deviceStatusModel.getDeviceId(), deviceStatusModel.getAppId()) ))
+                    .collect(Collectors.toMap( DeviceAuthModel::getAuthToken, m -> m.getDeviceId() + "/" + m.getAppId()));
+        }
+
+
         return PersonalizationConfigResponse.builder()
                 .devicePattern(personalizationParameters.getDevicePattern())
                 .parameters(personalizationParameters.getParameters())
+                .availableDevices(availableDevices)
                 .build();
     }
 }

--- a/openpos-devices/src/main/java/org/jumpmind/pos/devices/service/GetPersonalizationConfigEndpoint.java
+++ b/openpos-devices/src/main/java/org/jumpmind/pos/devices/service/GetPersonalizationConfigEndpoint.java
@@ -26,6 +26,9 @@ public class GetPersonalizationConfigEndpoint {
     @Autowired
     DevicesRepository repository;
 
+    @Autowired
+    List<String> loadedAppIds;
+
     public PersonalizationConfigResponse getPersonalizationConfig(){
         logger.info("Received a personalization request");
 
@@ -46,6 +49,7 @@ public class GetPersonalizationConfigEndpoint {
                 .devicePattern(personalizationParameters.getDevicePattern())
                 .parameters(personalizationParameters.getParameters())
                 .availableDevices(availableDevices)
+                .loadedAppIds(loadedAppIds)
                 .build();
     }
 }

--- a/openpos-devices/src/main/java/org/jumpmind/pos/devices/service/GetPersonalizationConfigEndpoint.java
+++ b/openpos-devices/src/main/java/org/jumpmind/pos/devices/service/GetPersonalizationConfigEndpoint.java
@@ -26,7 +26,7 @@ public class GetPersonalizationConfigEndpoint {
     @Autowired
     DevicesRepository repository;
 
-    @Autowired
+    @Autowired(required = false)
     List<String> loadedAppIds;
 
     public PersonalizationConfigResponse getPersonalizationConfig(){

--- a/openpos-devices/src/main/java/org/jumpmind/pos/devices/service/IDevicesService.java
+++ b/openpos-devices/src/main/java/org/jumpmind/pos/devices/service/IDevicesService.java
@@ -28,4 +28,7 @@ public interface IDevicesService {
     @RequestMapping(path="/authenticate", method = RequestMethod.GET)
     @ResponseBody
     public AuthenticateDeviceResponse authenticateDevice(@RequestBody AuthenticateDeviceRequest request);
+
+    @RequestMapping(path="/disconnectDevice", method = RequestMethod.POST)
+    public void disconnectDevice(@RequestBody DisconnectDeviceRequest request);
 }

--- a/openpos-devices/src/main/java/org/jumpmind/pos/devices/service/model/DisconnectDeviceRequest.java
+++ b/openpos-devices/src/main/java/org/jumpmind/pos/devices/service/model/DisconnectDeviceRequest.java
@@ -1,0 +1,13 @@
+package org.jumpmind.pos.devices.service.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class DisconnectDeviceRequest {
+    private String deviceId;
+    private String appId;
+}

--- a/openpos-devices/src/main/java/org/jumpmind/pos/devices/service/model/PersonalizationConfigResponse.java
+++ b/openpos-devices/src/main/java/org/jumpmind/pos/devices/service/model/PersonalizationConfigResponse.java
@@ -19,5 +19,6 @@ public class PersonalizationConfigResponse {
     private String devicePattern;
     private List<PersonalizationParameter> parameters = new ArrayList<>();
     private Map<String, String> availableDevices;
+    private List<String> loadedAppIds;
 
 }

--- a/openpos-devices/src/main/java/org/jumpmind/pos/devices/service/model/PersonalizationConfigResponse.java
+++ b/openpos-devices/src/main/java/org/jumpmind/pos/devices/service/model/PersonalizationConfigResponse.java
@@ -4,9 +4,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.jumpmind.pos.devices.model.DeviceAuthModel;
+import org.jumpmind.pos.devices.model.DeviceModel;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Data
 @Builder
@@ -15,4 +18,6 @@ import java.util.List;
 public class PersonalizationConfigResponse {
     private String devicePattern;
     private List<PersonalizationParameter> parameters = new ArrayList<>();
+    private Map<String, String> availableDevices;
+
 }

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/config/YamlConfigProvider.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/config/YamlConfigProvider.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.jumpmind.pos.core.flow.FlowException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.core.io.support.ResourcePatternResolver;
@@ -35,6 +36,11 @@ public class YamlConfigProvider implements IFlowConfigProvider {
     public void load(String appId, String path, String startFlowName) {
         appIdToStartFlowName.put(appId, startFlowName);
         load(appId, path);
+    }
+
+    @Bean
+    public List<String> loadedAppIds() {
+        return new ArrayList<>(appIdToStartFlowName.keySet());
     }
 
     public void load(String appId, String path) {

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/service/SessionDisconnectedListener.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/service/SessionDisconnectedListener.java
@@ -3,6 +3,8 @@ package org.jumpmind.pos.core.service;
 import lombok.extern.slf4j.Slf4j;
 import org.jumpmind.pos.core.flow.IStateManagerContainer;
 import org.jumpmind.pos.devices.model.DeviceModel;
+import org.jumpmind.pos.devices.service.IDevicesService;
+import org.jumpmind.pos.devices.service.model.DisconnectDeviceRequest;
 import org.jumpmind.pos.server.service.SessionConnectListener;
 import org.jumpmind.pos.util.event.DeviceDisconnectedEvent;
 import org.jumpmind.pos.util.event.EventPublisher;
@@ -24,6 +26,9 @@ public class SessionDisconnectedListener implements ApplicationListener<SessionD
 
     @Autowired
     EventPublisher eventPublisher;
+
+    @Autowired
+    IDevicesService devicesService;
     
     @Override
     public void onApplicationEvent(SessionDisconnectEvent event) {        
@@ -32,6 +37,7 @@ public class SessionDisconnectedListener implements ApplicationListener<SessionD
         log.info("session disconnected: {}", sessionId);
         
         DeviceModel deviceModel = sessionAuthTracker.getDeviceModel(sessionId);
+        devicesService.disconnectDevice(new DisconnectDeviceRequest(deviceModel.getDeviceId(), deviceModel.getAppId()));
 
         if (deviceModel != null) {
             try {


### PR DESCRIPTION
Reuse existing personalization if its not currently subscribed to
![image](https://user-images.githubusercontent.com/22771013/92802505-8f156c80-f384-11ea-9f80-2545ff9518bf.png)

- get list of loaded appIds and put them in a combo box
![image](https://user-images.githubusercontent.com/22771013/92802575-a2283c80-f384-11ea-8116-cf3127a4610a.png)

- move the validation message for device id so that it doesn’t bump app id
![image](https://user-images.githubusercontent.com/22771013/92802650-b0765880-f384-11ea-9ae9-2ce5ece53c9f.png)

- auto fill the hostname and port of the app and auto detect SSL

Couple of callouts for discussion
-  If the server crashes any devices that were connected at the time of the server crash need to reconnect and disconnect before anyone else can take over that device id.
-  if a device goes offline technically someone could reuse that register id but I’m not really sure that is all that different than getting access through a new register id