### PR TITLE
Feature/updates to data table ui message

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/data-table/data-table-dialog.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/data-table/data-table-dialog.component.html
@@ -1,0 +1,26 @@
+<div class="data-table-outer">
+    <app-dialog-header></app-dialog-header>
+    <div class="data-table-body" responsive-class>
+        <app-instructions *ngIf="screen.instructions" [instructions]="screen.instructions" [instructionsSize]="'text-sm'"></app-instructions>
+        <app-content-card>
+            <mat-dialog-content class="dialog-content">
+                <app-grid-table [rows]="rows" [columnHeaders]="columnHeaders"></app-grid-table>
+            </mat-dialog-content>
+        </app-content-card>
+        <mat-dialog-actions class="buttons">
+            <div *ngFor="let m of screen.actionButtons;  let i = index">
+                <app-secondary-button *ngIf="screen.actionButtons.length-1 !== i"
+                    [actionItem]="m" (actionClick)="doAction(m)" (click)="doAction(m)">
+                    <span>{{m.title}}</span>&nbsp;
+                    <span *ngIf="keybindsEnabled(m)" class="muted-color">{{m.keybindDisplayName}}</span>
+                </app-secondary-button>
+                <app-primary-button *ngIf="screen.actionButtons.length-1 == i" 
+                    [attr.cdkFocusInitial]="screen.actionButtons.length-1 == i ? '' : null"
+                    [actionItem]="m" (actionClick)="doAction(m)" (click)="doAction(m)">
+                    <span>{{m.title}}</span>&nbsp;
+                    <span *ngIf="keybindsEnabled(m)" class="muted-color">{{m.keybindDisplayName}}</span>
+                </app-primary-button>
+            </div>
+        </mat-dialog-actions>
+    </div>
+</div>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/data-table/data-table-dialog.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/data-table/data-table-dialog.component.scss
@@ -1,0 +1,41 @@
+@import "../../styles/variables/spacing";
+
+.data-table-outer {
+    display:grid;
+    grid-auto-flow: column;
+    grid-template-rows: auto 1fr;
+    height: 100%;
+
+    .data-table-body {
+        display: grid;
+        justify-self: center;
+        align-content: center;
+        width:100%;
+        @extend %page-spaced-content; 
+
+        .dialog-content {
+            overflow: auto;
+        }
+
+        .buttons {
+            display: grid;
+            grid-auto-flow: column;
+            justify-content: end;
+            grid-column-gap: 8px;
+            &.mobile {
+                grid-column-gap: 4px;
+            }
+        }
+    }
+    
+}
+
+.mat-dialog-actions {
+    padding: 0;
+    margin: 0;
+}
+
+.mat-dialog-content {
+    padding: 0;
+    margin: 0;
+}

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/data-table/data-table-dialog.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/data-table/data-table-dialog.component.ts
@@ -1,0 +1,14 @@
+import { DialogComponent } from '../../shared/decorators/dialog-component.decorator';
+import { Component } from '@angular/core';
+import { DataTableComponent } from './data-table.component';
+
+@DialogComponent({
+    name: 'DataTable'
+})
+@Component({
+    selector: 'app-data-table-dialog',
+    templateUrl: './data-table-dialog.component.html',
+    styleUrls: ['./data-table-dialog.component.scss']
+})
+export class DataTableDialogComponent extends DataTableComponent {
+}

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/data-table/data-table-row.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/data-table/data-table-row.interface.ts
@@ -1,0 +1,3 @@
+export interface IDataTableRow {
+    columns: any;
+}

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/data-table/data-table.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/data-table/data-table.component.html
@@ -1,29 +1,26 @@
-<app-waffle>
-    <app-bacon-strip waffle-header></app-bacon-strip>
-
-    <div waffle-drawer-content class="drawer-content" fxFlex="1 1 100%" fxLayout="column" fxLayoutAlign="start stretch"
-        fxLayoutGap="4px" fxLayoutGap.lg="20px">
-        <app-sausage-links waffle-drawer-content></app-sausage-links>
-    </div>
-
-    <div waffle-body class="body-content">
-        <mat-card fxLayout="column" class="page-content-card data-table-card">
-
-            <mat-card-content fxFlex="1 1 100%">
+<div class="data-table-outer">
+    <app-bacon-strip></app-bacon-strip>
+    <div class="data-table-body" responsive-class>
+        <app-instructions *ngIf="screen.instructions" class="text-center" [instructions]="screen.instructions" [instructionsSize]="'text-md'"></app-instructions>
+        <app-content-card>
+            <div class="content">
                 <app-grid-table [rows]="rows" [columnHeaders]="columnHeaders"></app-grid-table>
-            </mat-card-content>
-
-            <mat-card-actions *ngIf="screen.actionButton" align="end">
-                <button mat-button color="primary-inverse" (click)="doAction(screen.actionButton)">
-                    <span *ngIf="screen.actionButton.title">{{screen.actionButton.title}}</span>
-                    <app-icon *ngIf="screen.actionButton.icon" [iconName]="screen.actionButton.icon"
-                        [iconClass]="'material-icons'"></app-icon>
-                </button>
-            </mat-card-actions>
-
-        </mat-card>
-
-        <app-status-strip waffle-footer></app-status-strip>
+            </div>
+        </app-content-card>
+        <section class="buttons">
+            <div *ngFor="let m of screen.actionButtons;  let i = index">
+                <app-secondary-button *ngIf="screen.actionButtons.length-1 !== i"
+                    [actionItem]="m" (actionClick)="doAction(m)" (click)="doAction(m)">
+                    <span>{{m.title}}</span>&nbsp;
+                    <span *ngIf="keybindsEnabled(m)" class="muted-color">{{m.keybindDisplayName}}</span>
+                </app-secondary-button>
+                <app-primary-button *ngIf="screen.actionButtons.length-1 == i" 
+                    [attr.cdkFocusInitial]="screen.actionButtons.length-1 == i ? '' : null"
+                    [actionItem]="m" (actionClick)="doAction(m)" (click)="doAction(m)">
+                    <span>{{m.title}}</span>&nbsp;
+                    <span *ngIf="keybindsEnabled(m)" class="muted-color">{{m.keybindDisplayName}}</span>
+                </app-primary-button>
+            </div>
+        </section>
     </div>
-
-</app-waffle>
+</div>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/data-table/data-table.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/data-table/data-table.component.scss
@@ -1,14 +1,35 @@
-.body-content {
+@import "../../styles/variables/spacing";
+
+.data-table-outer {
+    display:grid;
+    grid-auto-flow: column;
+    grid-template-rows: auto auto 1fr;
     height: 100%;
-    display: flex;
-    flex-direction: column;
-    padding: 24px 24px 8px 24px;
-}
 
-.data-table-card {
-    flex: 1 1 100%;
-}
+    .data-table-body {
+        grid-area: 3/1/3/1;
+        display: grid;
+        grid-template-rows: auto 1fr auto;
+        justify-self: center;
+        align-content: center;
+        width: 75%;
+        overflow-y: auto;
+        min-height: 100px;
+        @extend %page-element;
+        @extend %page-spaced-content; 
 
-.drawer-content{
-    padding: 8px;
+        .content {
+            overflow: auto;
+        }
+
+        .buttons {
+            display: grid;
+            grid-auto-flow: column;
+            justify-content: end;
+            grid-column-gap: 8px;
+            &.mobile {
+                grid-column-gap: 4px;
+            }
+        }
+    }
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/data-table/data-table.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/data-table/data-table.component.ts
@@ -1,6 +1,9 @@
 import { Component } from '@angular/core';
 import { PosScreen } from '../pos-screen/pos-screen.component';
 import { ScreenComponent } from '../../shared/decorators/screen-component.decorator';
+import { IActionItem } from '../../core/actions/action-item.interface';
+import { Configuration } from '../../configuration/configuration';
+import { DataTableInterface } from './data-table.interface';
 
 @ScreenComponent({
     name: 'DataTable'
@@ -10,7 +13,7 @@ import { ScreenComponent } from '../../shared/decorators/screen-component.decora
     templateUrl: './data-table.component.html',
     styleUrls: ['./data-table.component.scss']
 })
-export class DataTableComponent extends PosScreen<any> {
+export class DataTableComponent extends PosScreen<DataTableInterface> {
 
     rows = [];
     columnHeaders = [];
@@ -22,6 +25,10 @@ export class DataTableComponent extends PosScreen<any> {
         if (this.screen.columnHeaders) {
             this.columnHeaders = this.screen.columnHeaders;
         }
+    }
+
+    public keybindsEnabled(menuItem: IActionItem): boolean {
+        return Configuration.enableKeybinds && menuItem.keybind && menuItem.keybind !== 'Enter';
     }
 
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/data-table/data-table.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/data-table/data-table.interface.ts
@@ -1,0 +1,10 @@
+import { IAbstractScreen } from '../../core/interfaces/abstract-screen.interface';
+import { IDataTableRow } from './data-table-row.interface';
+import { IActionItem } from '../../core/actions/action-item.interface';
+
+export interface DataTableInterface extends IAbstractScreen {
+    instructions: string;
+    columnHeaders: string[];
+    rows: IDataTableRow[];
+    actionButtons: IActionItem[];
+}

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/screens-with-parts.module.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/screens-with-parts.module.ts
@@ -18,6 +18,7 @@ import { LoadingDialogComponent } from './loading-dialog/loading-dialog.componen
 import { PromptWithInfoScreenComponent } from './prompt-with-info/prompt-with-info-screen.component';
 import { PromptWithInfoScreenDialogComponent } from './prompt-with-info/prompt-with-info-screen-dialog.component';
 import { DataTableComponent } from './data-table/data-table.component';
+import { DataTableDialogComponent } from './data-table/data-table-dialog.component';
 import { AutoCompleteAddressComponent } from './auto-complete-address/auto-complete-address.component';
 import { SaleComponent } from './sale/sale.component';
 import { ItemDetailComponent } from './item-detail/item-detail.component';
@@ -30,7 +31,7 @@ import { MobileReturnReceiptsSheetComponent } from './return/mobile-return-recei
 import { OptionsScreenComponent } from './options/options-screen.component';
 import { OptionsScreenDialogComponent } from './options/options-screen-dialog.component';
 import { MobileSaleOrdersSheetComponent } from './sale/mobile-sale-orders-sheet/mobile-sale-orders-sheet.component';
-import {ErrorDialogComponent} from "./error-dialog/error-dialog.component";
+import {ErrorDialogComponent} from './error-dialog/error-dialog.component';
 import { TransactionSearchComponent } from './transaction-search/transaction-search.component';
 import { TransactionDetailsComponent } from './transaction-details/transaction-details.component';
 
@@ -69,7 +70,8 @@ const dialogs = [
     DynamicFormDialogComponent,
     ScanInputDialogComponent,
     AutoCompleteAddressDialogComponent,
-    ErrorDialogComponent
+    ErrorDialogComponent,
+    DataTableDialogComponent
 ];
 
 @NgModule({

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/DataTableUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/DataTableUIMessage.java
@@ -9,13 +9,23 @@ import java.util.List;
 
 public class DataTableUIMessage extends UIMessage {
 
+    private String instructions;
+
     private List<String> columnHeaders = new ArrayList<String>();
     private List<DataTableRow> rows = new ArrayList<>();
 
-    private ActionItem actionButton;
+    private List<ActionItem> actionButtons;
 
     public DataTableUIMessage() {
         this.setScreenType(UIMessageType.DATA_TABLE);
+    }
+
+    public String getInstructions() {
+        return instructions;
+    }
+
+    public void setInstructions(String instructions) {
+        this.instructions = instructions;
     }
 
     public List<String> getColumnHeaders() {
@@ -53,12 +63,19 @@ public class DataTableUIMessage extends UIMessage {
         this.rows.add(row);
     }
 
-    public ActionItem getActionButton() {
-        return actionButton;
+    public List<ActionItem> getActionButtons() {
+        return actionButtons;
     }
 
-    public void setActionButton(ActionItem actionButton) {
-        this.actionButton = actionButton;
+    public void setActionButtons(List<ActionItem> actionButtons) {
+        this.actionButtons = actionButtons;
+    }
+
+    public void addActionButton(ActionItem actionButton) {
+        if(this.actionButtons == null) {
+            this.actionButtons = new ArrayList<>();
+        }
+        this.actionButtons.add(actionButton);
     }
 
 }


### PR DESCRIPTION
updates the data-table screen to include instructions and allow more than one button and updates the existing component to match the look and feel of the pos and additionally adds a component for data-table-dialog.

screen:
<img width="1671" alt="Screen Shot 2020-09-10 at 5 16 44 PM" src="https://user-images.githubusercontent.com/6811136/92808270-9ab76200-f389-11ea-9384-a254053f567f.png">

dialog:
<img width="1667" alt="Screen Shot 2020-09-10 at 5 12 04 PM" src="https://user-images.githubusercontent.com/6811136/92808308-a3a83380-f389-11ea-82d1-ebb053fc35ff.png">
