### PR TITLE
feature/reporting-and-logging-for-data-access-master

### DIFF
--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/driver/Driver.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/driver/Driver.java
@@ -42,11 +42,14 @@ import org.jumpmind.properties.TypedProperties;
  */
 public class Driver implements java.sql.Driver {
     
-    private static final String DRIVER_PREFIX = "jdbc:openpos:";
+    public static final String DRIVER_PREFIX = "jdbc:openpos:";
     
     public static void register(TypedProperties properties) {
         try {
             DriverManager.registerDriver(new Driver());
+            if (System.getProperty("jumpmind.commerce.disableSqlWatchdog") == null) {
+                SqlWatchdog.start();
+            }
         } catch (Exception ex) {
             throw new RuntimeException("Failed to register openpos driver", ex);
         } 

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/driver/InProgressSqlKey.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/driver/InProgressSqlKey.java
@@ -1,0 +1,16 @@
+package org.jumpmind.pos.persist.driver;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@Data
+@ToString
+@EqualsAndHashCode
+public class InProgressSqlKey {
+
+    private PreparedStatementWrapper psWrapper;
+    private String threadName;
+    private long salt;
+
+}

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/driver/InProgressSqlStatement.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/driver/InProgressSqlStatement.java
@@ -1,0 +1,28 @@
+package org.jumpmind.pos.persist.driver;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+
+@Data
+@NoArgsConstructor
+public class InProgressSqlStatement {
+
+    String sql;
+    java.util.List<Object> args;
+    long startTime;
+    long lastLoggedTime;
+    String threadName;
+
+    public InProgressSqlStatement(String sql, List<Object> args, long startTime, String threadName) {
+        this.sql = sql;
+        this.args = args;
+        this.startTime = startTime;
+        this.threadName = threadName;
+        lastLoggedTime = System.currentTimeMillis();
+    }
+
+}

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/driver/PreparedStatementWrapper.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/driver/PreparedStatementWrapper.java
@@ -44,9 +44,11 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Calendar;
 
+import lombok.EqualsAndHashCode;
 import org.jumpmind.properties.TypedProperties;
 
 @SuppressWarnings({"unused", "rawtypes", "unchecked"})
+@EqualsAndHashCode
 public class PreparedStatementWrapper implements PreparedStatement {
 
     private WrapperInterceptor interceptor;
@@ -197,13 +199,21 @@ public class PreparedStatementWrapper implements PreparedStatement {
             return (boolean) preResult.getInterceptResult();
         }
         long startTime = System.currentTimeMillis();
-        boolean value = wrapped.execute();
-        long endTime = System.currentTimeMillis();
-        InterceptResult postResult = interceptor.postExecute("execute", value,startTime, endTime );
-        if (postResult.isIntercepted()) {
-            return (boolean) postResult.getInterceptResult();
+        Exception exception = null;
+        try {
+            boolean value = wrapped.execute();
+            long endTime = System.currentTimeMillis();
+            InterceptResult postResult = interceptor.postExecute("execute", value,startTime, endTime );
+            if (postResult.isIntercepted()) {
+                return (boolean) postResult.getInterceptResult();
+            }
+            return value;
+        } catch (Exception ex) {
+            exception = ex;
+            throw ex;
+        } finally {
+            interceptor.cleanupExecute("execute", exception);
         }
-        return value;
     }
 
     public ResultSetMetaData getMetaData() throws SQLException {
@@ -227,13 +237,23 @@ public class PreparedStatementWrapper implements PreparedStatement {
             return (ResultSet) preResult.getInterceptResult();
         }
         long startTime = System.currentTimeMillis();
-        ResultSet value = wrapped.executeQuery();
-        long endTime = System.currentTimeMillis();
-        InterceptResult postResult = interceptor.postExecute("executeQuery", value,startTime, endTime );
-        if (postResult.isIntercepted()) {
-            return (ResultSet) postResult.getInterceptResult();
+
+        Exception exception = null;
+
+        try {
+            ResultSet value = wrapped.executeQuery();
+            long endTime = System.currentTimeMillis();
+            InterceptResult postResult = interceptor.postExecute("executeQuery", value,startTime, endTime );
+            if (postResult.isIntercepted()) {
+                return (ResultSet) postResult.getInterceptResult();
+            }
+            return value;
+        } catch (Exception ex) {
+            exception = ex;
+            throw ex;
+        } finally {
+            interceptor.cleanupExecute("executeQuery", exception);
         }
-        return value;
     }
 
     public int executeUpdate() throws SQLException {
@@ -241,14 +261,23 @@ public class PreparedStatementWrapper implements PreparedStatement {
         if (preResult.isIntercepted()) {
             return (int) preResult.getInterceptResult();
         }
+        Exception exception = null;
+
         long startTime = System.currentTimeMillis();
-        int value = wrapped.executeUpdate();
-        long endTime = System.currentTimeMillis();
-        InterceptResult postResult = interceptor.postExecute("executeUpdate", value,startTime, endTime );
-        if (postResult.isIntercepted()) {
-            return (int) postResult.getInterceptResult();
+        try {
+            int value = wrapped.executeUpdate();
+            long endTime = System.currentTimeMillis();
+            InterceptResult postResult = interceptor.postExecute("executeUpdate", value,startTime, endTime );
+            if (postResult.isIntercepted()) {
+                return (int) postResult.getInterceptResult();
+            }
+            return value;
+        } catch (Exception ex) {
+            exception = ex;
+            throw ex;
+        } finally {
+            interceptor.cleanupExecute("executeUpdate", exception);
         }
-        return value;
     }
 
     public void addBatch() throws SQLException {
@@ -717,13 +746,21 @@ public class PreparedStatementWrapper implements PreparedStatement {
             return (boolean) preResult.getInterceptResult();
         }
         long startTime = System.currentTimeMillis();
-        boolean value = wrapped.execute(arg1,arg2);
-        long endTime = System.currentTimeMillis();
-        InterceptResult postResult = interceptor.postExecute("execute", value,startTime, endTime ,arg1,arg2);
-        if (postResult.isIntercepted()) {
-            return (boolean) postResult.getInterceptResult();
+        Exception exception = null;
+        try {
+            boolean value = wrapped.execute(arg1,arg2);
+            long endTime = System.currentTimeMillis();
+            InterceptResult postResult = interceptor.postExecute("execute", value,startTime, endTime ,arg1,arg2);
+            if (postResult.isIntercepted()) {
+                return (boolean) postResult.getInterceptResult();
+            }
+            return value;
+        } catch (Exception ex) {
+            exception = ex;
+            throw ex;
+        } finally {
+            interceptor.cleanupExecute("execute", exception);
         }
-        return value;
     }
 
     public boolean execute(String arg1) throws SQLException {
@@ -731,14 +768,24 @@ public class PreparedStatementWrapper implements PreparedStatement {
         if (preResult.isIntercepted()) {
             return (boolean) preResult.getInterceptResult();
         }
+
+        Exception exception = null;
+
         long startTime = System.currentTimeMillis();
-        boolean value = wrapped.execute(arg1);
-        long endTime = System.currentTimeMillis();
-        InterceptResult postResult = interceptor.postExecute("execute", value,startTime, endTime ,arg1);
-        if (postResult.isIntercepted()) {
-            return (boolean) postResult.getInterceptResult();
+        try {
+            boolean value = wrapped.execute(arg1);
+            long endTime = System.currentTimeMillis();
+            InterceptResult postResult = interceptor.postExecute("execute", value,startTime, endTime ,arg1);
+            if (postResult.isIntercepted()) {
+                return (boolean) postResult.getInterceptResult();
+            }
+            return value;
+        } catch (Exception ex) {
+            exception = ex;
+            throw ex;
+        } finally {
+            interceptor.cleanupExecute("execute", exception);
         }
-        return value;
     }
 
     public boolean execute(String arg1, String[] arg2) throws SQLException {
@@ -747,13 +794,21 @@ public class PreparedStatementWrapper implements PreparedStatement {
             return (boolean) preResult.getInterceptResult();
         }
         long startTime = System.currentTimeMillis();
-        boolean value = wrapped.execute(arg1,arg2);
-        long endTime = System.currentTimeMillis();
-        InterceptResult postResult = interceptor.postExecute("execute", value,startTime, endTime ,arg1,arg2);
-        if (postResult.isIntercepted()) {
-            return (boolean) postResult.getInterceptResult();
+        Exception exception = null;
+        try {
+            boolean value = wrapped.execute(arg1,arg2);
+            long endTime = System.currentTimeMillis();
+            InterceptResult postResult = interceptor.postExecute("execute", value,startTime, endTime ,arg1,arg2);
+            if (postResult.isIntercepted()) {
+                return (boolean) postResult.getInterceptResult();
+            }
+            return value;
+        } catch (Exception ex) {
+            exception = ex;
+            throw ex;
+        } finally {
+            interceptor.cleanupExecute("execute", exception);
         }
-        return value;
     }
 
     public boolean execute(String arg1, int[] arg2) throws SQLException {
@@ -762,13 +817,21 @@ public class PreparedStatementWrapper implements PreparedStatement {
             return (boolean) preResult.getInterceptResult();
         }
         long startTime = System.currentTimeMillis();
-        boolean value = wrapped.execute(arg1,arg2);
-        long endTime = System.currentTimeMillis();
-        InterceptResult postResult = interceptor.postExecute("execute", value,startTime, endTime ,arg1,arg2);
-        if (postResult.isIntercepted()) {
-            return (boolean) postResult.getInterceptResult();
+        Exception exception = null;
+        try {
+            boolean value = wrapped.execute(arg1,arg2);
+            long endTime = System.currentTimeMillis();
+            InterceptResult postResult = interceptor.postExecute("execute", value,startTime, endTime ,arg1,arg2);
+            if (postResult.isIntercepted()) {
+                return (boolean) postResult.getInterceptResult();
+            }
+            return value;
+        } catch (Exception ex) {
+            exception = ex;
+            throw ex;
+        } finally {
+            interceptor.cleanupExecute("execute", exception);
         }
-        return value;
     }
 
     public boolean isClosed() throws SQLException {
@@ -818,13 +881,21 @@ public class PreparedStatementWrapper implements PreparedStatement {
             return (ResultSet) preResult.getInterceptResult();
         }
         long startTime = System.currentTimeMillis();
-        ResultSet value = wrapped.executeQuery(arg1);
-        long endTime = System.currentTimeMillis();
-        InterceptResult postResult = interceptor.postExecute("executeQuery", value,startTime, endTime ,arg1);
-        if (postResult.isIntercepted()) {
-            return (ResultSet) postResult.getInterceptResult();
+        Exception exception = null;
+        try {
+            ResultSet value = wrapped.executeQuery(arg1);
+            long endTime = System.currentTimeMillis();
+            InterceptResult postResult = interceptor.postExecute("executeQuery", value,startTime, endTime ,arg1);
+            if (postResult.isIntercepted()) {
+                return (ResultSet) postResult.getInterceptResult();
+            }
+            return value;
+        } catch (Exception ex) {
+            exception = ex;
+            throw ex;
+        } finally {
+            interceptor.cleanupExecute("executeQuery", exception);
         }
-        return value;
     }
 
     public int executeUpdate(String arg1, int arg2) throws SQLException {
@@ -833,13 +904,21 @@ public class PreparedStatementWrapper implements PreparedStatement {
             return (int) preResult.getInterceptResult();
         }
         long startTime = System.currentTimeMillis();
-        int value = wrapped.executeUpdate(arg1,arg2);
-        long endTime = System.currentTimeMillis();
-        InterceptResult postResult = interceptor.postExecute("executeUpdate", value,startTime, endTime ,arg1,arg2);
-        if (postResult.isIntercepted()) {
-            return (int) postResult.getInterceptResult();
+        Exception exception = null;
+        try {
+            int value = wrapped.executeUpdate(arg1,arg2);
+            long endTime = System.currentTimeMillis();
+            InterceptResult postResult = interceptor.postExecute("executeUpdate", value,startTime, endTime ,arg1,arg2);
+            if (postResult.isIntercepted()) {
+                return (int) postResult.getInterceptResult();
+            }
+            return value;
+        } catch (Exception ex) {
+            exception = ex;
+            throw ex;
+        } finally {
+            interceptor.cleanupExecute("executeUpdate", exception);
         }
-        return value;
     }
 
     public int executeUpdate(String arg1, int[] arg2) throws SQLException {
@@ -848,13 +927,21 @@ public class PreparedStatementWrapper implements PreparedStatement {
             return (int) preResult.getInterceptResult();
         }
         long startTime = System.currentTimeMillis();
-        int value = wrapped.executeUpdate(arg1,arg2);
-        long endTime = System.currentTimeMillis();
-        InterceptResult postResult = interceptor.postExecute("executeUpdate", value,startTime, endTime ,arg1,arg2);
-        if (postResult.isIntercepted()) {
-            return (int) postResult.getInterceptResult();
+        Exception exception = null;
+        try {
+            int value = wrapped.executeUpdate(arg1,arg2);
+            long endTime = System.currentTimeMillis();
+            InterceptResult postResult = interceptor.postExecute("executeUpdate", value,startTime, endTime ,arg1,arg2);
+            if (postResult.isIntercepted()) {
+                return (int) postResult.getInterceptResult();
+            }
+            return value;
+        } catch (Exception ex) {
+            exception = ex;
+            throw ex;
+        } finally {
+            interceptor.cleanupExecute("executeUpdate", exception);
         }
-        return value;
     }
 
     public int executeUpdate(String arg1, String[] arg2) throws SQLException {
@@ -863,13 +950,21 @@ public class PreparedStatementWrapper implements PreparedStatement {
             return (int) preResult.getInterceptResult();
         }
         long startTime = System.currentTimeMillis();
-        int value = wrapped.executeUpdate(arg1,arg2);
-        long endTime = System.currentTimeMillis();
-        InterceptResult postResult = interceptor.postExecute("executeUpdate", value,startTime, endTime ,arg1,arg2);
-        if (postResult.isIntercepted()) {
-            return (int) postResult.getInterceptResult();
+        Exception exception = null;
+        try {
+            int value = wrapped.executeUpdate(arg1,arg2);
+            long endTime = System.currentTimeMillis();
+            InterceptResult postResult = interceptor.postExecute("executeUpdate", value,startTime, endTime ,arg1,arg2);
+            if (postResult.isIntercepted()) {
+                return (int) postResult.getInterceptResult();
+            }
+            return value;
+        } catch (Exception ex) {
+            exception = ex;
+            throw ex;
+        } finally {
+            interceptor.cleanupExecute("executeUpdate", exception);
         }
-        return value;
     }
 
     public int executeUpdate(String arg1) throws SQLException {
@@ -878,13 +973,21 @@ public class PreparedStatementWrapper implements PreparedStatement {
             return (int) preResult.getInterceptResult();
         }
         long startTime = System.currentTimeMillis();
-        int value = wrapped.executeUpdate(arg1);
-        long endTime = System.currentTimeMillis();
-        InterceptResult postResult = interceptor.postExecute("executeUpdate", value,startTime, endTime ,arg1);
-        if (postResult.isIntercepted()) {
-            return (int) postResult.getInterceptResult();
+        Exception exception = null;
+        try {
+            int value = wrapped.executeUpdate(arg1);
+            long endTime = System.currentTimeMillis();
+            InterceptResult postResult = interceptor.postExecute("executeUpdate", value,startTime, endTime ,arg1);
+            if (postResult.isIntercepted()) {
+                return (int) postResult.getInterceptResult();
+            }
+            return value;
+        } catch (Exception ex) {
+            exception = ex;
+            throw ex;
+        } finally {
+            interceptor.cleanupExecute("executeUpdate", exception);
         }
-        return value;
     }
 
     public int getMaxFieldSize() throws SQLException {
@@ -1168,13 +1271,21 @@ public class PreparedStatementWrapper implements PreparedStatement {
             return (int[]) preResult.getInterceptResult();
         }
         long startTime = System.currentTimeMillis();
-        int[] value = wrapped.executeBatch();
-        long endTime = System.currentTimeMillis();
-        InterceptResult postResult = interceptor.postExecute("executeBatch", value,startTime, endTime );
-        if (postResult.isIntercepted()) {
-            return (int[]) postResult.getInterceptResult();
+        Exception exception = null;
+        try {
+            int[] value = wrapped.executeBatch();
+            long endTime = System.currentTimeMillis();
+            InterceptResult postResult = interceptor.postExecute("executeBatch", value,startTime, endTime );
+            if (postResult.isIntercepted()) {
+                return (int[]) postResult.getInterceptResult();
+            }
+            return value;
+        } catch (Exception ex) {
+            exception = ex;
+            throw ex;
+        } finally {
+            interceptor.cleanupExecute("executeBatch", exception);
         }
-        return value;
     }
 
     public ResultSet getGeneratedKeys() throws SQLException {

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/driver/RandomErrorInterceptor.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/driver/RandomErrorInterceptor.java
@@ -54,7 +54,7 @@ public class RandomErrorInterceptor extends StatementInterceptor {
     }
     
     @Override
-    public void preparedStatementExecute(String methodName, long elapsed, String sql) {
+    public void preparedStatementExecute(String methodName, long elapsed, String sql, Object[] objects) {
         // no op.
     }
     

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/driver/SqlWatchdog.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/driver/SqlWatchdog.java
@@ -1,0 +1,76 @@
+package org.jumpmind.pos.persist.driver;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jumpmind.db.sql.LogSqlBuilder;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Slf4j
+public class SqlWatchdog {
+
+    public static final String THREAD_NAME = "Commerce-SqlWatchdog-Thread";
+
+    private static java.util.Map<InProgressSqlKey, InProgressSqlStatement> inProgressSql = new ConcurrentHashMap<>();
+
+    private static AtomicBoolean running = new AtomicBoolean(false);
+
+    public static synchronized void start() {
+        if (running.get()) {
+            return;
+        }
+        running.set(true);
+        Thread thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                log.info(THREAD_NAME + " Started...");
+                runLoop();
+                log.info(THREAD_NAME + " Exiting...");
+            }
+        });
+
+        thread.setName(THREAD_NAME);
+        thread.setDaemon(true);
+        log.info("Starting " + THREAD_NAME + "...");
+        thread.start();
+    }
+
+    public static synchronized void stop() {
+        running.set(false);
+    }
+
+    public static void sqlBegin(InProgressSqlKey key, InProgressSqlStatement sqlStatement) {
+        inProgressSql.put(key, sqlStatement);
+    }
+
+    public static void sqlEnd(InProgressSqlKey key) {
+        inProgressSql.remove(key);
+    }
+
+    protected static void runLoop() {
+        LogSqlBuilder sqlBuilder = new LogSqlBuilder();
+
+        long pollInterval = Long.parseLong(System.getProperty("jumpmind.commerce.SqlWatchDog.pollInterval", "20000"));
+        long warnInterval = Long.parseLong(System.getProperty("jumpmind.commerce.SqlWatchDog.warnInterval", "60000"));
+
+        while (running.get()) {
+            try {
+                Thread.sleep(pollInterval);
+            } catch (InterruptedException e) {
+                log.debug("Thread interrupted.", e);
+            }
+            
+            for (InProgressSqlStatement inProgressSqlStatement : inProgressSql.values()) {
+                long now = System.currentTimeMillis();
+                long timeSinceLastLogged = now - inProgressSqlStatement.getLastLoggedTime();
+
+                if (timeSinceLastLogged >= warnInterval) {
+                    inProgressSqlStatement.setLastLoggedTime(now);
+                    String sql = sqlBuilder.buildDynamicSqlForLog(inProgressSqlStatement.getSql(), inProgressSqlStatement.getArgs().toArray(), null);
+                    long elapsed = now - inProgressSqlStatement.getStartTime();
+                    log.warn("SQL Still Running (" + elapsed + "ms.) on thread '" + inProgressSqlStatement.getThreadName() + "': " + sql.trim());
+                }
+            }
+        }
+    }
+}

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/driver/StatementBypassInterceptor.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/driver/StatementBypassInterceptor.java
@@ -63,7 +63,7 @@ public class StatementBypassInterceptor extends StatementInterceptor {
     }
     
     @Override
-    public void preparedStatementExecute(String methodName, long elapsed, String sql) {
+    public void preparedStatementExecute(String methodName, long elapsed, String sql, Object[] objects) {
         // no op.
     }
 

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/driver/StatementDelayInterceptor.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/driver/StatementDelayInterceptor.java
@@ -43,7 +43,7 @@ public class StatementDelayInterceptor extends StatementInterceptor {
     }
     
     @Override
-    public void preparedStatementExecute(String methodName, long elapsed, String sql) {
+    public void preparedStatementExecute(String methodName, long elapsed, String sql, Object[] objects) {
         if (sql.toLowerCase().startsWith("insert") || sql.toLowerCase().startsWith("update")) {
             try {
                 Thread.sleep(delay);

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/driver/StatementInterceptor.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/driver/StatementInterceptor.java
@@ -20,26 +20,36 @@
  */
 package org.jumpmind.pos.persist.driver;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 
+import io.swagger.models.auth.In;
+import org.apache.commons.lang3.StringUtils;
 import org.jumpmind.db.sql.LogSqlBuilder;
 import org.jumpmind.properties.TypedProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class StatementInterceptor extends WrapperInterceptor {
-    
+
+    public static final String LONG_RUNNING_THRESHOLD_PROPERTY = "jumpmind.commerce.longRunningThreshold";
+
     private final static Logger log = LoggerFactory.getLogger(StatementInterceptor.class);
     protected List<Object> psArgs = new ArrayList<Object>();
     protected LogSqlBuilder sqlBuilder = new LogSqlBuilder();
 
+    protected long longRunningThreshold = 20000;
+
+    private InProgressSqlKey sqlKey;
+
     public StatementInterceptor(Object wrapped, TypedProperties systemPlusEngineProperties) {
         super(wrapped);
+        String longRunningThresholString = systemPlusEngineProperties.get(LONG_RUNNING_THRESHOLD_PROPERTY);
+        if (!StringUtils.isEmpty(longRunningThresholString)) {
+            longRunningThreshold = Long.parseLong(longRunningThresholString.trim());
+            if (log.isDebugEnabled()) {
+                log.debug("Long Running SQL threshold is: " + longRunningThreshold + "ms.");
+            }
+        }
     }
 
     @Override
@@ -58,9 +68,24 @@ public class StatementInterceptor extends WrapperInterceptor {
                 psArgs.add(parameters[1]);
             }
         }
+
+        if (methodName.startsWith("execute")) {
+            sqlKey = generateKey(ps);
+            SqlWatchdog.sqlBegin(sqlKey,
+                    new InProgressSqlStatement(ps.getStatement(), psArgs, System.currentTimeMillis(), Thread.currentThread().getName() ) );
+        }
+
         return new InterceptResult();
     }
-    
+
+    private InProgressSqlKey generateKey(PreparedStatementWrapper ps) {
+        InProgressSqlKey key = new InProgressSqlKey();
+        key.setPsWrapper(ps);
+        key.setThreadName(Thread.currentThread().getName());
+        key.setSalt(new Random().nextLong());
+        return key;
+    }
+
     @Override
     public InterceptResult postExecute(String methodName, Object result, long startTime, long endTime, Object... parameters) {
         if (getWrapped() instanceof PreparedStatementWrapper) {
@@ -71,33 +96,57 @@ public class StatementInterceptor extends WrapperInterceptor {
             return new InterceptResult();
         }
     }
-    
-    
+
     public InterceptResult preparedStatementPostExecute(PreparedStatementWrapper ps, String methodName, Object result, long startTime, long endTime, Object... parameters) {
         if (methodName.startsWith("execute")) {
             long elapsed = endTime-startTime;
-            String sql = sqlBuilder.buildDynamicSqlForLog(ps.getStatement(), psArgs.toArray(), null);
-            preparedStatementExecute(methodName, elapsed, sql);
+            preparedStatementExecute(methodName, elapsed, ps.getStatement(), psArgs.toArray());
         }
-        
+
         return new InterceptResult();
     }
-    
+
     public InterceptResult statementPostExecute(StatementWrapper ps, String methodName, Object result, long startTime, long endTime, Object... parameters) {
         if (methodName.startsWith("execute")) {
             long elapsed = endTime-startTime;
             statementExecute(methodName, elapsed, parameters);
         }
-        
+
         return new InterceptResult();
     }
-    
-    public void preparedStatementExecute(String methodName, long elapsed, String sql) {
-        log.info("PreparedStatement." + methodName + " (" + elapsed + "ms.) " + sql.trim()) ;
-    }
-    
-    public void statementExecute(String methodName, long elapsed, Object... parameters) {
-        log.info("Statement." + methodName + " (" + elapsed + "ms.) " + Arrays.toString(parameters)) ;          
+
+    public void preparedStatementExecute(String methodName, long elapsed, String sql, Object[] args) {
+        if (elapsed > longRunningThreshold) {
+            String dynamicSql = sqlBuilder.buildDynamicSqlForLog(sql, args, null);
+            log.warn("Long Running (" + elapsed + "ms.) " + dynamicSql.trim());
+        }
+        if (log.isInfoEnabled()) {
+            String dynamicSql = sqlBuilder.buildDynamicSqlForLog(sql, args, null);
+            log.info("PreparedStatement." + methodName + " (" + elapsed + "ms.) " + dynamicSql.trim()) ;
+        }
     }
 
+    public void statementExecute(String methodName, long elapsed, Object... parameters) {
+        if (elapsed > longRunningThreshold) {
+            log.warn("Long Running (" + elapsed + "ms.) " + Arrays.toString(parameters));
+        }
+        if (log.isInfoEnabled()) {
+            log.info("Statement." + methodName + " (" + elapsed + "ms.) " + Arrays.toString(parameters));
+        }
+    }
+
+    @Override
+    public void cleanupExecute(String methodName, Exception thrownException) {
+        SqlWatchdog.sqlEnd(sqlKey);
+        if (thrownException != null
+            && log.isDebugEnabled()
+            && (getWrapped() instanceof PreparedStatementWrapper)) {
+
+            PreparedStatementWrapper ps = (PreparedStatementWrapper) getWrapped();
+            String sql = sqlBuilder.buildDynamicSqlForLog(ps.getStatement(), psArgs.toArray(), null);
+
+            log.debug("SQL Caused Exception " + sql, thrownException);
+        }
+    }
 }
+

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/driver/WrapperInterceptor.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/driver/WrapperInterceptor.java
@@ -64,5 +64,9 @@ public abstract class WrapperInterceptor {
         return wrapped;
     }
 
+    public void cleanupExecute(String methodName, Exception thrownException) {
+
+    }
+
     
 }

--- a/openpos-service/src/main/java/org/jumpmind/pos/service/strategy/RemoteOnlyStrategy.java
+++ b/openpos-service/src/main/java/org/jumpmind/pos/service/strategy/RemoteOnlyStrategy.java
@@ -103,7 +103,8 @@ public class RemoteOnlyStrategy extends AbstractInvocationStrategy implements II
             throw serviceException;
         }
 
-        throw new RuntimeException("We should not have gotten here - there should be a result or lastException");
+        log.warn("We should not have gotten here - there should be a result or lastException");
+        return null;
     }
 
     private void populateServiceVisits(Object result, List<ServiceVisit> serviceVisits) {

--- a/openpos-service/src/main/java/org/jumpmind/pos/service/strategy/RemoteOnlyStrategy.java
+++ b/openpos-service/src/main/java/org/jumpmind/pos/service/strategy/RemoteOnlyStrategy.java
@@ -1,10 +1,14 @@
 package org.jumpmind.pos.service.strategy;
 
+import net.bytebuddy.implementation.bytecode.Throw;
 import org.jumpmind.pos.service.PosServerException;
 import org.jumpmind.pos.service.ProfileConfig;
 import org.jumpmind.pos.service.ServiceConfig;
 import org.jumpmind.pos.service.ServiceSpecificConfig;
 import org.jumpmind.pos.util.clientcontext.ClientContext;
+import org.jumpmind.pos.util.model.ServiceException;
+import org.jumpmind.pos.util.model.ServiceResult;
+import org.jumpmind.pos.util.model.ServiceVisit;
 import org.jumpmind.pos.util.status.IStatusManager;
 import org.jumpmind.pos.util.status.IStatusReporter;
 import org.jumpmind.pos.util.status.Status;
@@ -29,6 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Component(RemoteOnlyStrategy.REMOTE_ONLY_STRATEGY)
 public class RemoteOnlyStrategy extends AbstractInvocationStrategy implements IInvocationStrategy, IStatusReporter {
@@ -53,6 +58,8 @@ public class RemoteOnlyStrategy extends AbstractInvocationStrategy implements II
     public static final String STATUS_NAME = "NETWORK.REMOTE";
     public static final String STATUS_ICON = "cloud";
 
+    private Map<String, Status> statuses = new ConcurrentHashMap<>();
+
     public String getStrategyName() {
         return REMOTE_ONLY_STRATEGY;
     }
@@ -64,19 +71,48 @@ public class RemoteOnlyStrategy extends AbstractInvocationStrategy implements II
     @Override
     public Object invoke(ServiceSpecificConfig config, Object proxy, Method method, Map<String, Object> endpoints, Object[] args) throws Throwable {
 
-        ResourceAccessException lastException=null;
+        Throwable lastException = null;
+        Object result = null;
+        List<ServiceVisit> serviceVisits = new ArrayList<>();
+
         for (String profileId : config.getProfileIds()) {
+            ServiceVisit serviceVisit = new ServiceVisit();
+            serviceVisit.setProfileId(profileId);
+            long startTime = System.currentTimeMillis();
             try {
-                return invokeProfile(serviceConfig.getProfileConfig(profileId), proxy, method, endpoints, args);
-            } catch (ResourceAccessException ex) {
+                result = invokeProfile(profileId, serviceConfig.getProfileConfig(profileId), proxy, method, endpoints, args);
+                break;
+            } catch (Throwable ex) {
+                serviceVisit.setException(ex);
                 lastException = ex;
-                logger.warn(String.format("Remote service %s unavailable.",profileId));
+                logger.warn(String.format("Remote service %s unavailable.", profileId), ex);
+            } finally {
+                serviceVisit.setElapsedTimeMillis(System.currentTimeMillis()-startTime);
+                serviceVisits.add(serviceVisit);
             }
         }
-        throw lastException;
+
+        if (result != null) {
+            populateServiceVisits(result, serviceVisits);
+            return result;
+        }
+
+        if (lastException != null) {
+            ServiceException serviceException = new ServiceException("Failed to invoke remote service(s)", lastException);
+            serviceException.setServiceVisits(serviceVisits);
+            throw serviceException;
+        }
+
+        throw new RuntimeException("We should not have gotten here - there should be a result or lastException");
     }
 
-    private Object invokeProfile(ProfileConfig profileConfig, Object proxy, Method method,
+    private void populateServiceVisits(Object result, List<ServiceVisit> serviceVisits) {
+        if (result instanceof ServiceResult) {
+            ((ServiceResult) result).setServiceVisits(serviceVisits);
+        }
+    }
+
+    private Object invokeProfile(String profileId, ProfileConfig profileConfig, Object proxy, Method method,
                                  Map<String, Object> endpoints, Object[] args) throws ResourceAccessException {
 
         int httpTimeoutInSecond = profileConfig.getHttpTimeout();
@@ -113,12 +149,14 @@ public class RemoteOnlyStrategy extends AbstractInvocationStrategy implements II
                         template.execute(serverUrl, requestBody, requestMethod, headers, newArgs);
                     } else {
                         Object result =  template.execute(serverUrl, requestBody, method.getReturnType(), requestMethod, headers, newArgs);
-                        reportStatus(Status.Online);
+                        statuses.put(profileId, Status.Online);
+                        reportStatus();
                         return result;
                     }
                 }
             } catch (Throwable ex) {
-                reportStatus(Status.Offline, ex.getMessage());
+                statuses.put(profileId, Status.Offline);
+                reportStatus(ex.getMessage());
                 throw ex;
             }
 
@@ -129,11 +167,22 @@ public class RemoteOnlyStrategy extends AbstractInvocationStrategy implements II
 
     }
 
-    private void reportStatus(Status status) {
-        reportStatus(status, "");
+    private void reportStatus() {
+        reportStatus("");
     }
-    private void reportStatus(Status status, String message) {
-        this.lastStatus = new StatusReport(STATUS_NAME, STATUS_ICON, status, message);
+
+    private void reportStatus(String message) {
+
+        Status lowestCommonDenominatorStatus = Status.Online;
+
+        for (Status status : statuses.values()) {
+            if (status == Status.Error || status == Status.Offline) {
+                lowestCommonDenominatorStatus = status;
+                break;
+            }
+        }
+
+        this.lastStatus = new StatusReport(STATUS_NAME, STATUS_ICON, lowestCommonDenominatorStatus, message);
         if (this.statusManager != null) {
             this.statusManager.reportStatus(lastStatus);
         }

--- a/openpos-util/src/main/java/org/jumpmind/pos/util/model/ServiceException.java
+++ b/openpos-util/src/main/java/org/jumpmind/pos/util/model/ServiceException.java
@@ -1,0 +1,27 @@
+package org.jumpmind.pos.util.model;
+
+import lombok.Data;
+
+import java.util.ArrayList;
+
+@Data
+public class ServiceException extends RuntimeException {
+
+    java.util.List<ServiceVisit> serviceVisits = new ArrayList<>();
+
+    public ServiceException() {
+        super();
+    }
+
+    public ServiceException(String message) {
+        super(message);
+    }
+
+    public ServiceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ServiceException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/openpos-util/src/main/java/org/jumpmind/pos/util/model/ServiceResult.java
+++ b/openpos-util/src/main/java/org/jumpmind/pos/util/model/ServiceResult.java
@@ -1,8 +1,11 @@
 package org.jumpmind.pos.util.model;
 
+import java.util.ArrayList;
+
 public class ServiceResult {
 
     private Object extension;
+    private java.util.List<ServiceVisit> serviceVisits = new ArrayList<>();
 
     @SuppressWarnings("unchecked")
     public <T> T ext() {
@@ -20,6 +23,14 @@ public class ServiceResult {
 
     public void setExtension(Object extension) {
         this.extension = extension;
+    }
+
+    public void setServiceVisits(java.util.List<ServiceVisit> serviceVisits) {
+        this.serviceVisits = serviceVisits;
+    }
+
+    public java.util.List<ServiceVisit> getServiceVisits() {
+        return serviceVisits;
     }
 
 }

--- a/openpos-util/src/main/java/org/jumpmind/pos/util/model/ServiceVisit.java
+++ b/openpos-util/src/main/java/org/jumpmind/pos/util/model/ServiceVisit.java
@@ -1,0 +1,19 @@
+package org.jumpmind.pos.util.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import net.bytebuddy.implementation.bytecode.Throw;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class ServiceVisit {
+
+    private String profileId;
+    private long elapsedTimeMillis;
+    private Throwable exception;
+
+}


### PR DESCRIPTION
**For master branch**

This PR adds the following features:
1) Log SQL that takes over 20 seconds to run as "Long Running" (this example was tuned down to 5 seconds for testing)
`2020-09-12 17:55:57.827 WARN  [server] [main] [StatementInterceptor] Long Running (5002ms.) select c0.installation_id, c0.current_version, c0.create_time, c0.create_by, c0.last_update_time, c0.last_update_by from NCR_PAY_MODULE c0 where c0.installation_id='05243' `

2) Log super long running SQL every 1 minute while it's still running.

This is an example of "SQL Still Running (set to log every 500ms - by default it will be every 1 minute):
```
2020-09-12 17:55:53.400 WARN  [-] [Commerce-SqlWatchdog-Thread] [SqlWatchdog] SQL Still Running (570ms.) on thread 'main': select c0.installation_id, c0.current_version, c0.create_time, c0.create_by, c0.last_update_time, c0.last_update_by from NCR_PAY_MODULE c0 where c0.installation_id='05243' 
2020-09-12 17:55:53.913 WARN  [-] [Commerce-SqlWatchdog-Thread] [SqlWatchdog] SQL Still Running (1088ms.) on thread 'main': select c0.installation_id, c0.current_version, c0.create_time, c0.create_by, c0.last_update_time, c0.last_update_by from NCR_PAY_MODULE c0 where c0.installation_id='05243' 
2020-09-12 17:55:54.429 WARN  [-] [Commerce-SqlWatchdog-Thread] [SqlWatchdog] SQL Still Running (1604ms.) on thread 'main': select c0.installation_id, c0.current_version, c0.create_time, c0.create_by, c0.last_update_time, c0.last_update_by from NCR_PAY_MODULE c0 where c0.installation_id='05243' 
2020-09-12 17:55:54.946 WARN  [-] [Commerce-SqlWatchdog-Thread] [SqlWatchdog] SQL Still Running (2121ms.) on thread 'main': select c0.installation_id, c0.current_version, c0.create_time, c0.create_by, c0.last_update_time, c0.last_update_by from NCR_PAY_MODULE c0 where c0.installation_id='05243' 
2020-09-12 17:55:55.454 WARN  [-] [Commerce-SqlWatchdog-Thread] [SqlWatchdog] SQL Still Running (2629ms.) on thread 'main': select c0.installation_id, c0.current_version, c0.create_time, c0.create_by, c0.last_update_time, c0.last_update_by from NCR_PAY_MODULE c0 where c0.installation_id='05243' 
2020-09-12 17:55:55.973 WARN  [-] [Commerce-SqlWatchdog-Thread] [SqlWatchdog] SQL Still Running (3148ms.) on thread 'main': select c0.installation_id, c0.current_version, c0.create_time, c0.create_by, c0.last_update_time, c0.last_update_by from NCR_PAY_MODULE c0 where c0.installation_id='05243' 
2020-09-12 17:55:56.491 WARN  [-] [Commerce-SqlWatchdog-Thread] [SqlWatchdog] SQL Still Running (3666ms.) on thread 'main': select c0.installation_id, c0.current_version, c0.create_time, c0.create_by, c0.last_update_time, c0.last_update_by from NCR_PAY_MODULE c0 where c0.installation_id='05243' 
2020-09-12 17:55:57.003 WARN  [-] [Commerce-SqlWatchdog-Thread] [SqlWatchdog] SQL Still Running (4178ms.) on thread 'main': select c0.installation_id, c0.current_version, c0.create_time, c0.create_by, c0.last_update_time, c0.last_update_by from NCR_PAY_MODULE c0 where c0.installation_id='05243' 
2020-09-12 17:55:57.518 WARN  [-] [Commerce-SqlWatchdog-Thread] [SqlWatchdog] SQL Still Running (4693ms.) on thread 'main': select c0.installation_id, c0.current_version, c0.create_time, c0.create_by, c0.last_update_time, c0.last_update_by from NCR_PAY_MODULE c0 where c0.installation_id='05243' 
2020-09-12 17:55:57.827 WARN  [server] [main] [StatementInterceptor] Long Running (5002ms.) select c0.installation_id, c0.current_version, c0.create_time, c0.create_by, c0.last_update_time, c0.last_update_by from NCR_PAY_MODULE c0 where c0.installation_id='05243' 
```

3) ServiceResult now may contain "ServiceVisit" objects which have details about which datasource were tried, time spent etc. The intent is to be able to support user prompting like "No Results - But Some Services were offline" to give the user a heads up.
![image](https://user-images.githubusercontent.com/4398634/93007492-78fbdd80-f537-11ea-9da9-33cadc3b5bc5.png)

4) Fix bug where offline CO but online BO would cause the cloud status icon to remain grey.  Now one Offline remote profile will keep the cloud yellow.

