### PR TITLE
Feature/warn button

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/dialog/generic-dialog.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/dialog/generic-dialog.component.html
@@ -13,17 +13,7 @@
             <app-scan-part></app-scan-part>
         </mat-dialog-content>
         <mat-dialog-actions class="buttons">
-            <app-secondary-button *ngFor="let m of otherButtons; let i = index" [id]="'button-' + i" (click)="doAction(m)" 
-                [disabled]="!m.enabled" [actionItem]="m">
-                {{m.title}}
-                <span *ngIf="m.keybind && m.keybind !== 'Escape' && m.keybind !== 'Enter'" class="muted-color">({{m.keybindDisplayName}})</span>
-                <app-button-action-timer [action]="m" class="muted-color"></app-button-action-timer>
-            </app-secondary-button>
-            <app-primary-button *ngIf="primaryButton" (click)="doAction(primaryButton)" id="primaryButton"
-                [actionItem]="primaryButton">
-                {{primaryButton.title}}
-                <app-button-action-timer [action]="primaryButton" class="primary-inverse"></app-button-action-timer>
-            </app-primary-button>
+            <app-prompt-button-row></app-prompt-button-row>
         </mat-dialog-actions>
     </div>
 </div>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/dialog/generic-dialog.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/dialog/generic-dialog.component.scss
@@ -14,13 +14,7 @@
         @extend %page-spaced-content; 
 
         .buttons {
-            display: grid;
-            grid-auto-flow: column;
             justify-content: end;
-            grid-column-gap: 8px;
-            &.mobile {
-                grid-column-gap: 4px;
-            }
         }
     }
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/_component-theme-mixins.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/_component-theme-mixins.scss
@@ -20,6 +20,7 @@
 @import './instructions/instructions-theme';
 @import './primary-button/primary-button-theme';
 @import './secondary-button/secondary-button-theme';
+@import './warn-button/warn-button-theme';
 @import './content-card/content-card-theme';
 @import './option-button/option-button-theme';
 @import './order-card/order-card-theme';
@@ -50,6 +51,7 @@
     @include instructions-theme($theme);
     @include primary-button-theme($theme);
     @include secondary-button-theme($theme);
+    @include warn-button-theme($theme);
     @include content-card-theme($theme);
     @include option-button-theme($theme);
     @include order-card-theme($theme);

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/warn-button/_warn-button-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/warn-button/_warn-button-theme.scss
@@ -1,0 +1,18 @@
+@mixin warn-button-theme($theme) {
+    $warn: mat-color(map-get($theme, warn));
+    $disabled-border: map-get(map-get($theme, foreground), disabled-text);
+
+    app-warn-button {
+        button {
+            padding: 8px 16px;
+            border-color: $warn;
+            border-style: solid;
+            border-width: 2px;
+
+            &[disabled] {
+                border-color: $disabled-border;
+            }
+        }
+    }
+
+}

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/warn-button/warn-button.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/warn-button/warn-button.component.html
@@ -1,0 +1,10 @@
+<button fxFlex="1 0 auto"
+    responsive-class
+    mat-flat-button
+    color=warn
+    [disabled]="disabled"
+    (click)="clickFn()"
+    [type]="inputType"
+>
+    <ng-content></ng-content>
+</button>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/warn-button/warn-button.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/warn-button/warn-button.component.scss
@@ -1,0 +1,22 @@
+@import "../../../styles/mixins/typography";
+
+button {
+  @extend %text-md;
+  padding: 8px;
+  min-width: 150px;
+
+  &.desktop-portrait {
+    @extend %text-lg;
+    padding: 16px;
+    min-width: 100px;
+  }
+
+  &.tablet {
+    min-width: 100px;
+  }
+
+  &.mobile {
+    @extend %text-sm;
+    min-width: 75px;
+  }
+}

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/warn-button/warn-button.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/warn-button/warn-button.component.ts
@@ -1,0 +1,21 @@
+import { Component, Input, EventEmitter, Output } from '@angular/core';
+
+@Component({
+  selector: 'app-warn-button',
+  templateUrl: './warn-button.component.html',
+  styleUrls: ['./warn-button.component.scss']
+})
+export class WarnButtonComponent {
+
+  @Input() disabled: boolean;
+  @Input() inputType = 'button';
+  @Output() buttonClick = new EventEmitter();
+
+  constructor() {
+    this.disabled = false;
+  }
+
+  clickFn() {
+    this.buttonClick.emit(true);
+  }
+}

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-button-row/prompt-button-row-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-button-row/prompt-button-row-theme.scss
@@ -1,0 +1,9 @@
+@mixin prompt-button-row-theme($theme){
+    $app-primary: mat-color(map-get($theme, primary));
+    $app-accent: mat-color(map-get($theme, accent));
+    $app-warn: mat-color(map-get($theme, warn));
+
+    $foreground: map-get($theme, foreground );
+    $background: map-get($theme, background );
+
+}

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-button-row/prompt-button-row.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-button-row/prompt-button-row.component.html
@@ -1,0 +1,20 @@
+<app-warn-button *ngFor="let m of screenData.warnButtons; let i = index" [id]="'warn-' + i" (click)="doAction(m)"
+    [disabled]="!m.enabled" [actionItem]="m">
+    {{m.title}}
+    <span *ngIf="m.keybind && m.keybind !== 'Escape' && m.keybind !== 'Enter'"
+        class="muted-color">({{m.keybindDisplayName}})</span>
+    <app-button-action-timer [action]="m" class="muted-color"></app-button-action-timer>
+</app-warn-button>
+
+<app-secondary-button *ngFor="let m of screenData.secondaryButtons; let i = index" [id]="'button-' + i" (click)="doAction(m)"
+    [disabled]="!m.enabled" [actionItem]="m">
+    {{m.title}}
+    <span *ngIf="m.keybind && m.keybind !== 'Escape' && m.keybind !== 'Enter'"
+        class="muted-color">({{m.keybindDisplayName}})</span>
+    <app-button-action-timer [action]="m" class="muted-color"></app-button-action-timer>
+</app-secondary-button>
+<app-primary-button *ngIf="screenData.primaryButton" (click)="doAction(screenData.primaryButton)" id="primaryButton"
+    [actionItem]="screenData.primaryButton">
+    {{screenData.primaryButton.title}}
+    <app-button-action-timer [action]="screenData.primaryButton" class="primary-inverse"></app-button-action-timer>
+</app-primary-button>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-button-row/prompt-button-row.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-button-row/prompt-button-row.component.scss
@@ -1,0 +1,10 @@
+:host {
+    display: grid;
+    grid-auto-flow: column;
+    justify-content: end;
+    grid-column-gap: 8px;
+
+    &.mobile {
+        grid-column-gap: 4px;
+    }
+}

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-button-row/prompt-button-row.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-button-row/prompt-button-row.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core'; import { PromptButtonRowInterface } from './prompt-button-row.interface';
+import { ScreenPart } from '../../decorators/screen-part.decorator';
+import { ScreenPartComponent } from '../screen-part';
+
+
+@ScreenPart({
+    name: 'promptButtonRow'
+})
+@Component({
+    selector: 'app-prompt-button-row',
+    templateUrl: './prompt-button-row.component.html',
+    styleUrls: ['./prompt-button-row.component.scss']
+})
+export class PromptButtonRowComponent extends ScreenPartComponent<PromptButtonRowInterface> {
+
+    screenDataUpdated() { }
+
+}

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-button-row/prompt-button-row.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-button-row/prompt-button-row.interface.ts
@@ -1,0 +1,9 @@
+import { IAbstractScreen } from '../../../core/interfaces/abstract-screen.interface';
+import { IActionItem } from '../../../core/actions/action-item.interface';
+
+
+export interface PromptButtonRowInterface extends IAbstractScreen {
+    primaryButton: IActionItem;
+    secondaryButtons: IActionItem[];
+    warnButtons: IActionItem[];
+}

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/shared.module.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/shared.module.ts
@@ -152,6 +152,7 @@ import {TransactionHistoryPartComponent} from './screen-parts/transaction-histor
 import {StatusBarComponent} from '../core/status/status-bar/status-bar.component';
 import {StampComponent} from './components/stamp/stamp.component';
 import {FitTextDirective} from './directives/fit-text.directive';
+import { WarnButtonComponent } from './components/warn-button/warn-button.component';
 
 const screenParts = [
     TenderPartComponent,
@@ -210,6 +211,7 @@ const components = [
     DatePartChooserDialogComponent,
     PrimaryButtonComponent,
     SecondaryButtonComponent,
+    WarnButtonComponent,
     SideNavComponent,
     TrainingDialogComponent,
     TrainingWrapperComponent,

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/shared.module.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/shared.module.ts
@@ -152,6 +152,7 @@ import {TransactionHistoryPartComponent} from './screen-parts/transaction-histor
 import {StatusBarComponent} from '../core/status/status-bar/status-bar.component';
 import {StampComponent} from './components/stamp/stamp.component';
 import {FitTextDirective} from './directives/fit-text.directive';
+import { PromptButtonRowComponent } from './screen-parts/prompt-button-row/prompt-button-row.component';
 import { WarnButtonComponent } from './components/warn-button/warn-button.component';
 
 const screenParts = [
@@ -183,6 +184,7 @@ const screenParts = [
     BasicBaconStripComponent,
     ImageTextPanelComponent,
     TransactionHistoryPartComponent,
+    PromptButtonRowComponent
 ];
 
 const components = [

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/DialogUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/DialogUIMessage.java
@@ -1,13 +1,12 @@
 package org.jumpmind.pos.core.ui.message;
 
-import lombok.Builder;
 import org.jumpmind.pos.core.ui.ActionItem;
 import org.jumpmind.pos.core.ui.DialogProperties;
 import org.jumpmind.pos.core.ui.data.Line;
 import org.jumpmind.pos.core.ui.UIMessage;
 import org.jumpmind.pos.core.ui.messagepart.DialogHeaderPart;
 import org.jumpmind.pos.core.ui.messagepart.MessagePartConstants;
-import org.jumpmind.pos.util.model.Message;
+import org.jumpmind.pos.core.ui.messagepart.PromptButtonRowPart;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -16,11 +15,11 @@ import java.util.List;
 public class DialogUIMessage extends UIMessage {
     private static final long serialVersionUID = 1L;
 
-    private List<ActionItem> buttons = new ArrayList<>();
-
     private List<String> message = new ArrayList<>();
 
     private List<Line> messageLines = new ArrayList<>();
+
+    private PromptButtonRowPart promptButtonRow = new PromptButtonRowPart();
 
     public DialogUIMessage() {
         this(null);
@@ -53,7 +52,7 @@ public class DialogUIMessage extends UIMessage {
 
 
     public DialogHeaderPart getDialogHeaderPart() {
-        DialogHeaderPart dialogHeader = (DialogHeaderPart)get(MessagePartConstants.DialogHeader);
+        DialogHeaderPart dialogHeader = (DialogHeaderPart) get(MessagePartConstants.DialogHeader);
         if (dialogHeader == null) {
             dialogHeader = new DialogHeaderPart();
             addMessagePart(MessagePartConstants.DialogHeader, dialogHeader);
@@ -61,16 +60,22 @@ public class DialogUIMessage extends UIMessage {
         return dialogHeader;
     }
 
-    public List<ActionItem> getButtons() {
-        return buttons;
-    }
-
     public void setButtons(List<ActionItem> buttons) {
-        this.buttons = buttons;
+        if (buttons != null && buttons.size() > 0) {
+            promptButtonRow.setPrimaryButton(buttons.get(0));
+
+            for (int b = 1; b < buttons.size(); b++) {
+                promptButtonRow.addSecondaryButton(buttons.get(b));
+            }
+        }
     }
 
     public void addButton(ActionItem button) {
-        this.buttons.add(button);
+        if (promptButtonRow.getPrimaryButton() == null) {
+            promptButtonRow.setPrimaryButton(button);
+        } else {
+            promptButtonRow.addSecondaryButton(button);
+        }
     }
 
     public List<String> getMessage() {
@@ -80,7 +85,7 @@ public class DialogUIMessage extends UIMessage {
     public void setMessage(String... messages) {
         this.setMessage(Arrays.asList(messages));
     }
-    
+
     public void setMessage(List<String> message) {
         this.message = message;
     }
@@ -99,11 +104,19 @@ public class DialogUIMessage extends UIMessage {
     }
 
     public DialogProperties getDialogProperties() {
-        return (DialogProperties)get("dialogProperties");
+        return (DialogProperties) get("dialogProperties");
     }
 
     public DialogUIMessage addMessageLine(Line line) {
         this.messageLines.add(line);
         return this;
+    }
+
+    public PromptButtonRowPart getPromptButtonRow() {
+        return promptButtonRow;
+    }
+
+    public void setPromptButtonRow(PromptButtonRowPart promptButtonRow) {
+        this.promptButtonRow = promptButtonRow;
     }
 }

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/messagepart/MessagePartConstants.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/messagepart/MessagePartConstants.java
@@ -1,16 +1,17 @@
 package org.jumpmind.pos.core.ui.messagepart;
 
 public final class MessagePartConstants {
-    public static final String BaconStrip="baconStrip";
-    public static final String BasicBaconStrip="basicBaconStrip";
-    public static final String ScanOrSearchPart ="scanOrSearch";
+    public static final String BaconStrip = "baconStrip";
+    public static final String BasicBaconStrip = "basicBaconStrip";
+    public static final String ScanOrSearchPart = "scanOrSearch";
     public static final String ScanPart = "scan";
-    public static final String StatusStrip="statusStrip";
-    public static final String DialogHeader= "dialogHeader";
-    public static final String ImageTextPanel="imageTextPanel";
-    public static final String SausageLinks="sausageLinks";
-    public static final String Notifications="notifications";
-    public static final String Banner="banner";
+    public static final String StatusStrip = "statusStrip";
+    public static final String DialogHeader = "dialogHeader";
+    public static final String ImageTextPanel = "imageTextPanel";
+    public static final String SausageLinks = "sausageLinks";
+    public static final String Notifications = "notifications";
+    public static final String Banner = "banner";
     public static final String ProgressBar = "progressBar";
-    public static final String OptionsList="optionsList";
+    public static final String OptionsList = "optionsList";
+    public static final String PromptButtonRow = "promptButtonRow";
 }

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/messagepart/PromptButtonRowPart.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/messagepart/PromptButtonRowPart.java
@@ -1,0 +1,29 @@
+package org.jumpmind.pos.core.ui.messagepart;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.jumpmind.pos.core.ui.ActionItem;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PromptButtonRowPart implements Serializable {
+    ActionItem primaryButton;
+    List<ActionItem> secondaryButtons = new ArrayList<>();
+    List<ActionItem> warnButtons = new ArrayList<>();
+
+    public void addSecondaryButton(ActionItem button) {
+        this.secondaryButtons.add(button);
+    }
+
+    public void addWarnButton(ActionItem button) {
+        this.warnButtons.add(button);
+    }
+}

--- a/openpos-flow/src/test/java/org/jumpmind/pos/core/ui/DialogBuilderTest.java
+++ b/openpos-flow/src/test/java/org/jumpmind/pos/core/ui/DialogBuilderTest.java
@@ -21,22 +21,23 @@ public class DialogBuilderTest {
 
     /**
      * Ensure that if the dialog type is set to OK_CANCEL_TYPE, and no customizations
-     * are made, that the dialog generated just has Ok and Cancel buttons with 
+     * are made, that the dialog generated just has Ok and Cancel buttons with
      * default titles (Ok, Cancel) and actions (Ok, Cancel).
      */
     @Test
     public void testDefaultOkCancelDialogBuild() {
         DialogBuilder config = new DialogBuilder(DialogBuilder.OK_CANCEL_TYPE, "Message Line 1");
         DialogUIMessage screen = config.build();
-        
-        assertEquals(2, screen.getButtons().size());
-        assertEquals(1, screen.getButtons().stream().filter(
-            m -> DialogBuilder.CANCEL_BUTTON_KEY.equals(m.getTitle()) && DialogBuilder.CANCEL_BUTTON_KEY.equals(m.getAction())).count()
+
+        assertEquals(1, screen.getPromptButtonRow().getSecondaryButtons().size());
+        assertEquals(1, screen.getPromptButtonRow().getSecondaryButtons().stream().filter(
+                m -> DialogBuilder.CANCEL_BUTTON_KEY.equals(m.getTitle()) && DialogBuilder.CANCEL_BUTTON_KEY.equals(m.getAction())).count()
         );
-        assertEquals(1, screen.getButtons().stream().filter(
-                m -> DialogBuilder.OK_BUTTON_KEY.equals(m.getTitle()) && DialogBuilder.OK_BUTTON_KEY.equals(m.getAction())).count()
-        );
-        DialogHeaderPart headerPart = (DialogHeaderPart)screen.get(MessagePartConstants.DialogHeader);
+        assertEquals(DialogBuilder.OK_BUTTON_KEY, screen.getPromptButtonRow().getPrimaryButton().getTitle());
+        assertEquals(DialogBuilder.OK_BUTTON_KEY, screen.getPromptButtonRow().getPrimaryButton().getAction());
+
+
+        DialogHeaderPart headerPart = (DialogHeaderPart) screen.get(MessagePartConstants.DialogHeader);
         assertNull(headerPart.getHeaderText());
         assertEquals(1, screen.getMessage().size());
         assertEquals("Message Line 1", screen.getMessage().get(0));
@@ -44,26 +45,25 @@ public class DialogBuilderTest {
 
     /**
      * Ensure that if the dialog type is set to OK_TYPE, and no customizations
-     * are made, that the dialog generated just has Ok button with 
+     * are made, that the dialog generated just has Ok button with
      * default title (Ok) and actions (Ok).
      */
+
     @Test
     public void testDefaultOkDialogBuild() {
         DialogBuilder config = new DialogBuilder(DialogBuilder.OK_TYPE, "Message Line 1", "Message Line 2");
         DialogUIMessage screen = config.build();
-        
-        assertEquals(1, screen.getButtons().size());
-        assertEquals(1, screen.getButtons().stream().filter(
-                m -> DialogBuilder.OK_BUTTON_KEY.equals(m.getTitle()) && DialogBuilder.OK_BUTTON_KEY.equals(m.getAction())).count()
-        );
 
-        DialogHeaderPart headerPart = (DialogHeaderPart)screen.get(MessagePartConstants.DialogHeader);
+        assertEquals(0, screen.getPromptButtonRow().getSecondaryButtons().size());
+        assertEquals(DialogBuilder.OK_BUTTON_KEY, screen.getPromptButtonRow().getPrimaryButton().getTitle());
+
+        DialogHeaderPart headerPart = (DialogHeaderPart) screen.get(MessagePartConstants.DialogHeader);
         assertNull(headerPart.getHeaderText());
         assertEquals(2, screen.getMessage().size());
         assertEquals("Message Line 1", screen.getMessage().get(0));
         assertEquals("Message Line 2", screen.getMessage().get(1));
     }
-    
+
     /**
      * Ensure that if the dialog type is set to OK_CANCEL_TYPE, and the Ok button is customized
      * with a custom action name, that the dialog generated has the custom
@@ -74,24 +74,24 @@ public class DialogBuilderTest {
         DialogBuilder config = new DialogBuilder(DialogBuilder.OK_CANCEL_TYPE, "Message Line 1")
                 .title("My title").putAction(DialogBuilder.OK_BUTTON_KEY, "customOkAction");
         DialogUIMessage screen = config.build();
-        
-        assertEquals(2, screen.getButtons().size());
-        assertEquals(1, screen.getButtons().stream().filter(
-            m -> DialogBuilder.CANCEL_BUTTON_KEY.equals(m.getTitle()) && DialogBuilder.CANCEL_BUTTON_KEY.equals(m.getAction())).count()
+
+        assertEquals(1, screen.getPromptButtonRow().getSecondaryButtons().size());
+        assertEquals(1, screen.getPromptButtonRow().getSecondaryButtons().stream().filter(
+                m -> DialogBuilder.CANCEL_BUTTON_KEY.equals(m.getTitle()) && DialogBuilder.CANCEL_BUTTON_KEY.equals(m.getAction())).count()
         );
-        assertEquals(1, screen.getButtons().stream().filter(
-                m -> DialogBuilder.OK_BUTTON_KEY.equals(m.getTitle()) && "customOkAction".equals(m.getAction())).count()
-        );
-        DialogHeaderPart headerPart = (DialogHeaderPart)screen.get(MessagePartConstants.DialogHeader);
+        assertEquals(DialogBuilder.OK_BUTTON_KEY, screen.getPromptButtonRow().getPrimaryButton().getTitle());
+        assertEquals("customOkAction", screen.getPromptButtonRow().getPrimaryButton().getAction());
+
+        DialogHeaderPart headerPart = (DialogHeaderPart) screen.get(MessagePartConstants.DialogHeader);
         assertEquals("My title", headerPart.getHeaderText());
         assertEquals(1, screen.getMessage().size());
         assertEquals("Message Line 1", screen.getMessage().get(0));
-        
+
     }
-    
+
     /**
      * Ensure that if the dialog type is set to OK_CANCEL_TYPE, and the Ok button is customized
-     * with a custom action title and action, that the ok button in the  dialog generated has
+     * with a custom action title and action, that the ok button in the dialog generated has
      * both custom title and action.
      */
     @Test
@@ -100,10 +100,9 @@ public class DialogBuilderTest {
                 .title("My title").putAction(DialogBuilder.OK_BUTTON_KEY, "Yes", "customOkAction");
         DialogUIMessage screen = config.build();
 
-        assertEquals(1, screen.getButtons().stream().filter(
-                m -> "Yes".equals(m.getTitle()) && "customOkAction".equals(m.getAction())).count()
-        );
+        assertEquals("Yes", screen.getPromptButtonRow().getPrimaryButton().getTitle());
+        assertEquals("customOkAction", screen.getPromptButtonRow().getPrimaryButton().getAction());
 
     }
-    
+
 }


### PR DESCRIPTION
This is a change to support showing a "Warning" button type on a DialogUIMessage.  I've changed the following:

- New angular component `warn-button-component`
- New screen part for the dialog/prompt buttons `prompt-button-row`
- Refactor DialogUIMessage/generic-dialog-component to use the new screen part

In some flows, there are cases where we want to make it obvious that we shouldn't be hitting certain buttons under normal circumstances.  This is helpful particularly in cases where the customer is interacting with a pinpad and we don't want the cashier to cancel out of the operation accidentally by clicking through dialogs too quickly.

As a side effect, you also have more deliberate control over which buttons are warning/secondary/primary rather than always having the first button in the list be the primary button.  However, I've updated the methods so that it should still be backwards compatible in all the places where that was expected.

Example that shows the button types/locations:
![image](https://user-images.githubusercontent.com/17070252/93133935-9e0a6080-f69d-11ea-985d-aeac9175f176.png)
