### PR TITLE
Feature/config driven columns

### DIFF
--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/Augmented.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/Augmented.java
@@ -9,4 +9,5 @@ import java.lang.annotation.Target;
 @Target({ElementType.TYPE})
 public @interface Augmented {
     String name();
+    String indexPrefix() default "";
 }

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/Augmented.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/Augmented.java
@@ -8,5 +8,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE})
 public @interface Augmented {
-    String group();
+    String name();
 }

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/Augmented.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/Augmented.java
@@ -1,0 +1,12 @@
+package org.jumpmind.pos.persist;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface Augmented {
+    String group();
+}

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/DBSession.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/DBSession.java
@@ -29,10 +29,7 @@ import org.jumpmind.db.sql.DmlStatement.DmlType;
 import org.jumpmind.db.sql.LogSqlBuilder;
 import org.jumpmind.db.sql.Row;
 import org.jumpmind.pos.persist.impl.*;
-import org.jumpmind.pos.persist.model.ITaggedModel;
-import org.jumpmind.pos.persist.model.SearchCriteria;
-import org.jumpmind.pos.persist.model.TagHelper;
-import org.jumpmind.pos.persist.model.TagModel;
+import org.jumpmind.pos.persist.model.*;
 import org.jumpmind.pos.util.ReflectUtils;
 import org.jumpmind.pos.util.model.ITypeCode;
 import org.jumpmind.properties.TypedProperties;
@@ -57,10 +54,11 @@ public class DBSession {
     private Map<String, QueryTemplate> queryTemplates;
     private Map<String, DmlTemplate> dmlTemplates;
     private TagHelper tagHelper;
+    private AugmenterHelper augmenterHelper;
 
     public DBSession(String catalogName, String schemaName, DatabaseSchema databaseSchema, IDatabasePlatform databasePlatform,
                      TypedProperties sessionContext, Map<String, QueryTemplate> queryTemplates, Map<String, DmlTemplate> dmlTemplates,
-                     TagHelper tagHelper) {
+                     TagHelper tagHelper, AugmenterHelper augmenterHelper) {
         super();
         this.dmlTemplates = dmlTemplates;
         this.databaseSchema = databaseSchema;
@@ -72,6 +70,7 @@ public class DBSession {
         this.jdbcTemplate = new NamedParameterJdbcTemplate(baseTemplate);
         this.queryTemplates = queryTemplates;
         this.tagHelper = tagHelper;
+        this.augmenterHelper = augmenterHelper;
     }
 
     public <T extends AbstractModel> List<T> findAll(Class<T> clazz, int maxResults) {
@@ -283,7 +282,7 @@ public class DBSession {
     }
 
     public ModelWrapper wrap(AbstractModel model) {
-        ModelWrapper wrapper = new ModelWrapper(model, databaseSchema.getModelMetaData(model.getClass()));
+        ModelWrapper wrapper = new ModelWrapper(model, databaseSchema.getModelMetaData(model.getClass()), augmenterHelper);
         return wrapper;
     }
 
@@ -398,7 +397,8 @@ public class DBSession {
             for (String property: queryParamKeys) {
                 boolean isPropertyMapped = entityModelClasses.stream().anyMatch(modelClass -> {
                     ModelMetaData modelMetaData = this.databaseSchema.getModelMetaData(modelClass);
-                    return modelMetaData.getColumnNameForProperty(modelClass, property) != null;
+                    return modelMetaData.getColumnNameForProperty(modelClass, property) != null ||
+                            isAugmentedProperty(modelClass, property);
                 });
 
                 if (! isPropertyMapped) {
@@ -414,12 +414,16 @@ public class DBSession {
         }
     }
 
+    private boolean isAugmentedProperty(Class<?> modelClass, String property) {
+        AugmenterConfig config = augmenterHelper.getAugmenterConfig(modelClass);
+        return config != null && config.getAugmenter(property) != null;
+    }
 
     public void save(AbstractModel argModel) {
         List<Table> tables = getValidatedTables(argModel);
 
         ModelWrapper model =
-                new ModelWrapper(argModel, databaseSchema.getModelMetaData(argModel.getClass()));
+                new ModelWrapper(argModel, databaseSchema.getModelMetaData(argModel.getClass()), augmenterHelper);
 
         setMaintenanceValues(model);
         setTagValues(model);
@@ -452,7 +456,7 @@ public class DBSession {
         List<Table> tables = getValidatedTables(argModel);
 
         ModelWrapper model =
-                new ModelWrapper(argModel, databaseSchema.getModelMetaData(argModel.getClass()));
+                new ModelWrapper(argModel, databaseSchema.getModelMetaData(argModel.getClass()), augmenterHelper);
 
         model.load();
         model.loadValues();
@@ -493,7 +497,7 @@ public class DBSession {
         if (models.size() > 0) {
             AbstractModel exampleModel = models.get(0);
 
-            ModelWrapper model = new ModelWrapper(exampleModel, databaseSchema.getModelMetaData(exampleModel.getClass()));
+            ModelWrapper model = new ModelWrapper(exampleModel, databaseSchema.getModelMetaData(exampleModel.getClass()), augmenterHelper);
             setMaintenanceValues(model);
             setTagValues(model);
             model.load();
@@ -527,7 +531,7 @@ public class DBSession {
         List<Object[]> values = new ArrayList<>(models.size());
         final ModelMetaData meta = databaseSchema.getModelMetaData(models.get(0).getClass());
         models.forEach(m -> {
-            ModelWrapper model = new ModelWrapper(m, meta);
+            ModelWrapper model = new ModelWrapper(m, meta, augmenterHelper);
             setMaintenanceValues(model);
             setTagValues(model);
             model.load();
@@ -650,7 +654,7 @@ public class DBSession {
         ModelMetaData modelMetaData = databaseSchema.getModelMetaData(resultClass);
 
         T object = resultClass.newInstance();
-        ModelWrapper model = new ModelWrapper((AbstractModel) object, modelMetaData);
+        ModelWrapper model = new ModelWrapper((AbstractModel) object, modelMetaData, augmenterHelper);
         model.load();
 
         LinkedCaseInsensitiveMap<String> matchedColumns = new LinkedCaseInsensitiveMap<String>();
@@ -664,6 +668,7 @@ public class DBSession {
         }
 
         addTags(row, matchedColumns, (AbstractModel) object);
+        addAugments(row, matchedColumns, (AbstractModel) object);
         addUnmatchedColumns(row, matchedColumns, (AbstractModel) object);
         decorateRetrievedModel(model);
 
@@ -715,6 +720,24 @@ public class DBSession {
                 }
             }
             tagHelper.addTags((ITaggedModel) model, tagValues);
+        }
+    }
+
+    protected void addAugments(Row row, LinkedCaseInsensitiveMap<String> matchedColumns, AbstractModel model) {
+        if (model instanceof IAugmentedModel) {
+            AugmenterConfig config = augmenterHelper.getAugmenterConfig(model);
+            if (config == null) {
+                log.warn("Missing config for model class" + model.getClass().getSimpleName());
+                return;
+            }
+            Map<String, Object> augmentsValues = new HashMap<>();
+            for (String columnName : row.keySet()) {
+                if (columnName.toUpperCase().startsWith(config.getPrefix())) {
+                    matchedColumns.put(columnName, null);
+                    augmentsValues.put(columnName, row.getString(columnName));
+                }
+                augmenterHelper.addAugments((IAugmentedModel) model, augmentsValues);
+            }
         }
     }
 

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/DBSessionFactory.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/DBSessionFactory.java
@@ -39,6 +39,8 @@ public class DBSessionFactory {
     TagHelper tagHelper;
     AugmenterHelper augmenterHelper;
 
+    private static final String DEFAULT_COLUMN_SIZE = "32";
+
     public void init(IDatabasePlatform databasePlatform, TypedProperties sessionContext, List<Class<?>> entities, List<Class<?>> extensionEntities, TagHelper tagHelper, AugmenterHelper augmenterHelper) {
 
         QueryTemplates queryTemplates = getQueryTemplates(sessionContext.get("module.tablePrefix"));
@@ -163,12 +165,12 @@ public class DBSessionFactory {
             for (Class<?> clazz : modelClazzes) {
                 Augmented[] annotations = clazz.getAnnotationsByType(Augmented.class);
                 if (annotations.length > 0) {
-                    AugmenterConfig augmenterConfig = augmenterConfigs.getConfig(annotations[0].group());
+                    AugmenterConfig augmenterConfig = augmenterConfigs.getConfigByName(annotations[0].name());
                     if (augmenterConfig != null) {
                         augmentTable(clazz, augmenterConfig);
                     }
                     else {
-                        log.warn("Missing group " + annotations[0].group() + " defined in augmenter configuration");
+                        log.info("Missing augmenter name " + annotations[0].name() + " defined in augmenter configuration");
                     }
                 }
             }
@@ -208,12 +210,12 @@ public class DBSessionFactory {
 
     protected Column setColumnInfo(Column column, String prefix, AugmenterModel augmenter) {
         column.setName(getColumnName(prefix, augmenter));
-        column.setDefaultValue(prefix);
+        column.setDefaultValue(augmenter.getDefaultValue());
         column.setTypeCode(Types.VARCHAR);
-        if (augmenter.getSize() > 0) {
+        if (augmenter.getSize() != null && augmenter.getSize() > 0) {
             column.setSize(String.valueOf(augmenter.getSize()));
         } else {
-            column.setSize("32");
+            column.setSize(DEFAULT_COLUMN_SIZE);
         }
         return column;
     }
@@ -315,7 +317,7 @@ public class DBSessionFactory {
         if (tag.getSize() > 0) {
             column.setSize(String.valueOf(tag.getSize()));
         } else {
-            column.setSize("32");
+            column.setSize(DEFAULT_COLUMN_SIZE);
         }
         return column;
     }

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/DBSessionFactory.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/DBSessionFactory.java
@@ -21,9 +21,7 @@ import org.jumpmind.pos.persist.impl.DmlTemplate;
 import org.jumpmind.pos.persist.impl.DmlTemplates;
 import org.jumpmind.pos.persist.impl.QueryTemplate;
 import org.jumpmind.pos.persist.impl.QueryTemplates;
-import org.jumpmind.pos.persist.model.ITaggedModel;
-import org.jumpmind.pos.persist.model.TagHelper;
-import org.jumpmind.pos.persist.model.TagModel;
+import org.jumpmind.pos.persist.model.*;
 import org.jumpmind.properties.TypedProperties;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
@@ -39,13 +37,14 @@ public class DBSessionFactory {
     List<Class<?>> modelClazzes;
     List<Class<?>> modelExtensionClasses;
     TagHelper tagHelper;
+    AugmenterHelper augmenterHelper;
 
-    public void init(IDatabasePlatform databasePlatform, TypedProperties sessionContext, List<Class<?>> entities, List<Class<?>> extensionEntities, TagHelper tagHelper) {
+    public void init(IDatabasePlatform databasePlatform, TypedProperties sessionContext, List<Class<?>> entities, List<Class<?>> extensionEntities, TagHelper tagHelper, AugmenterHelper augmenterHelper) {
 
         QueryTemplates queryTemplates = getQueryTemplates(sessionContext.get("module.tablePrefix"));
         DmlTemplates dmlTemplates = getDmlTemplates(sessionContext.get("module.tablePrefix"));
 
-        init(databasePlatform, sessionContext, entities, extensionEntities, queryTemplates, dmlTemplates, tagHelper);
+        init(databasePlatform, sessionContext, entities, extensionEntities, queryTemplates, dmlTemplates, tagHelper, augmenterHelper);
     }
 
     public void init(
@@ -55,7 +54,8 @@ public class DBSessionFactory {
             List<Class<?>> extensionEntities,
             QueryTemplates queryTemplatesObject,
             DmlTemplates dmlTemplates,
-            TagHelper tagHelper) {
+            TagHelper tagHelper,
+            AugmenterHelper augmenterHelper) {
 
         this.queryTemplates = buildQueryTemplatesMap(queryTemplatesObject);
         this.dmlTemplates = buildDmlTemplatesMap(dmlTemplates);
@@ -65,6 +65,7 @@ public class DBSessionFactory {
         this.modelClazzes = entities;
         this.modelExtensionClasses = extensionEntities;
         this.tagHelper = tagHelper;
+        this.augmenterHelper = augmenterHelper;
 
         this.initSchema();
     }
@@ -74,11 +75,13 @@ public class DBSessionFactory {
         databaseSchema.init(sessionContext.get("module.tablePrefix"), databasePlatform,
                 this.modelClazzes.stream().filter(e -> e.getAnnotation(org.jumpmind.pos.persist.TableDef.class) != null)
                         .collect(Collectors.toList()),
-                this.modelExtensionClasses);
+                this.modelExtensionClasses,
+                this.augmenterHelper);
     }
 
     public void createAndUpgrade() {
         enhanceTaggedModels();
+        augmentModels();
         databaseSchema.createAndUpgrade();
     }
 
@@ -95,7 +98,7 @@ public class DBSessionFactory {
     }
 
     public DBSession createDbSession() {
-        return new DBSession(null, null, databaseSchema, databasePlatform, sessionContext, queryTemplates, dmlTemplates, tagHelper);
+        return new DBSession(null, null, databaseSchema, databasePlatform, sessionContext, queryTemplates, dmlTemplates, tagHelper, augmenterHelper);
     }
 
     public org.jumpmind.db.model.Table getTableForEnhancement(Class<?> entityClazz) {
@@ -151,6 +154,88 @@ public class DBSessionFactory {
             dmlTemplates.getDmls().stream().forEach((q) -> dmlTemplatesMap.put(q.getName(), q));
         }
         return dmlTemplatesMap;
+    }
+    
+    protected void augmentModels() {
+        if (augmenterHelper != null) {
+            AugmenterConfigs augmenterConfigs = augmenterHelper.getAugmenterConfigs();
+            
+            for (Class<?> clazz : modelClazzes) {
+                Augmented[] annotations = clazz.getAnnotationsByType(Augmented.class);
+                if (annotations.length > 0) {
+                    AugmenterConfig augmenterConfig = augmenterConfigs.getConfig(annotations[0].group());
+                    if (augmenterConfig != null) {
+                        augmentTable(clazz, augmenterConfig);
+                    }
+                    else {
+                        log.warn("Missing group " + annotations[0].group() + " defined in augmenter configuration");
+                    }
+                }
+            }
+        }
+    }
+
+    protected void augmentTable(Class<?> entityClass, AugmenterConfig augmenterConfig) {
+        Table table = getTableForEnhancement(entityClass);
+        warnOrphanedAugmentedColumns(augmenterConfig, table);
+        modifyAugmentColumns(augmenterConfig, table);
+        addAugmentColumns(augmenterConfig, table);
+    }
+
+    protected void addAugmentColumns(AugmenterConfig augmenterConfig, Table table) {
+        for (AugmenterModel augmenter : augmenterConfig.getAugmenters()) {
+            if (table.getColumnIndex(getColumnName(augmenterConfig.getPrefix(), augmenter)) == -1) {
+                Column tagColumn = generateAugmentColumn(augmenterConfig, augmenter);
+                table.addColumn(tagColumn);
+            }
+        }
+    }
+
+    protected Column generateAugmentColumn(AugmenterConfig augmenterConfig, AugmenterModel augmenter) {
+        return setColumnInfo(new Column(), augmenterConfig.getPrefix(), augmenter);
+    }
+
+    protected void modifyAugmentColumns(AugmenterConfig augmenterConfig, Table table) {
+        for (Column existingColumn : table.getColumns()) {
+            for (AugmenterModel augmenter : augmenterConfig.getAugmenters()) {
+                if (StringUtils.equalsIgnoreCase(getColumnName(augmenterConfig.getPrefix(), augmenter), existingColumn.getName())) {
+                    setColumnInfo(existingColumn, augmenterConfig.getPrefix(), augmenter);
+                    break;
+                }
+            }
+        }
+    }
+
+    protected Column setColumnInfo(Column column, String prefix, AugmenterModel augmenter) {
+        column.setName(getColumnName(prefix, augmenter));
+        column.setDefaultValue(prefix);
+        column.setTypeCode(Types.VARCHAR);
+        if (augmenter.getSize() > 0) {
+            column.setSize(String.valueOf(augmenter.getSize()));
+        } else {
+            column.setSize("32");
+        }
+        return column;
+    }
+
+    private void warnOrphanedAugmentedColumns(AugmenterConfig augmenterConfig, Table table) {
+        for (Column existingColumn : table.getColumns()) {
+            if (!existingColumn.getName().toUpperCase().startsWith(augmenterConfig.getPrefix())) {
+                continue;
+            }
+
+            boolean matched = false;
+            for (AugmenterModel augmenter : augmenterConfig.getAugmenters()) {
+                if (StringUtils.equalsIgnoreCase(getColumnName(augmenterConfig.getPrefix(), augmenter), existingColumn.getName())) {
+                    matched = true;
+                    break;
+                }
+            }
+            if (!matched) {
+                log.info("Orphaned tag column detected.  This column should be manually dropped if no longer needed: " + table + " "
+                        + existingColumn);
+            }
+        }
     }
 
     protected void enhanceTaggedModels() {
@@ -237,6 +322,10 @@ public class DBSessionFactory {
 
     protected String getColumnName(TagModel tag) {
         return databasePlatform.alterCaseToMatchDatabaseDefaultCase(TagModel.TAG_PREFIX + tag.getName().toUpperCase());
+    }
+
+    protected String getColumnName(String prefix, AugmenterModel augmenter) {
+        return databasePlatform.alterCaseToMatchDatabaseDefaultCase(prefix + augmenter.getName().toUpperCase());
     }
 
 }

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/DatabaseSchema.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/DatabaseSchema.java
@@ -2,10 +2,7 @@ package org.jumpmind.pos.persist.impl;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
-import java.io.File;
-import java.io.FileOutputStream;
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 import java.sql.Types;
 import java.util.*;
@@ -31,6 +28,8 @@ import org.jumpmind.db.sql.SqlScript;
 import org.jumpmind.pos.persist.*;
 import org.jumpmind.pos.persist.model.AugmenterConfig;
 import org.jumpmind.pos.persist.model.AugmenterHelper;
+import org.jumpmind.pos.persist.model.AugmenterIndexConfig;
+import org.jumpmind.pos.persist.model.AugmenterModel;
 import org.jumpmind.pos.util.model.ITypeCode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -222,12 +221,12 @@ public class DatabaseSchema {
         }
     }
 
-    public static ModelMetaData createMetaData(Class<?> clazz, List<Class<?>> entityExtensionClasses) {
+    public ModelMetaData createMetaData(Class<?> clazz, List<Class<?>> entityExtensionClasses) {
         return createMetaData(clazz, entityExtensionClasses, null);
     }
 
     @SneakyThrows
-    public static ModelMetaData createMetaData(Class<?> clazz, List<Class<?>> entityExtensionClasses, IDatabasePlatform databasePlatform) {
+    public ModelMetaData createMetaData(Class<?> clazz, List<Class<?>> entityExtensionClasses, IDatabasePlatform databasePlatform) {
         List<ModelClassMetaData> list = new ArrayList<>();
         Class<?> entityClass = clazz;
         boolean ignoreSuperClasses = false;
@@ -255,7 +254,7 @@ public class DatabaseSchema {
                 for (Class<?> extensionClass : myExtensions) {
                     createClassFieldsMetadata(extensionClass, meta, true, columns, databasePlatform);
                 }
-
+                createAugmentedFieldsMetaData(meta, columns, databasePlatform);
                 meta.init();
 
                 for (Column column : meta.getPrimaryKeyColumns()) {
@@ -280,12 +279,31 @@ public class DatabaseSchema {
             for (IIndex index : indices.values()) {
                 dbTable.addIndex(index);
             }
+            Map<String, IIndex> augmentedIndices = createAugmentedIndices(currentClass, dbTable, meta, platform);
+            for (IIndex index : augmentedIndices.values()) {
+                dbTable.addIndex(index);
+            }
         }
 
         ModelMetaData metaData = new ModelMetaData();
         metaData.setModelClassMetaData(list);
         metaData.init();
         return metaData;
+    }
+
+    private void createAugmentedFieldsMetaData(ModelClassMetaData meta, List<Column> columns, IDatabasePlatform databasePlatform) {
+        AugmenterConfig config = augmenterHelper.getAugmenterConfig(meta.getClazz());
+        if (config != null) {
+            for (AugmenterModel augmenterModel : config.getAugmenters()) {
+                meta.getAugmentedFieldNames().add(augmenterModel.getName());
+                Column column = new Column();
+                column.setName(alterCaseToMatchDatabaseDefaultCase(config.getPrefix(), databasePlatform) + alterCaseToMatchDatabaseDefaultCase(camelToSnakeCase(augmenterModel.getName()), databasePlatform));
+                column.setDefaultValue(augmenterModel.getDefaultValue());
+                column.setSize(augmenterModel.getSize() != null ? Integer.toString(augmenterModel.getSize()) : "32");
+                column.setTypeCode(Types.VARCHAR);
+                columns.add(column);
+            }
+        }
     }
 
     public static Set<String> getPrimaryKeyNames(TableDef tblAnnotation) {
@@ -312,7 +330,7 @@ public class DatabaseSchema {
     }
 
     @SneakyThrows
-    private static void createClassFieldsMetadata(Class<?> clazz, ModelClassMetaData metaData,
+    private void createClassFieldsMetadata(Class<?> clazz, ModelClassMetaData metaData,
                                                   boolean includeAllFields, List<Column> columns, IDatabasePlatform platform) {
 
         Field[] fields = clazz.getDeclaredFields();
@@ -343,7 +361,7 @@ public class DatabaseSchema {
         }
     }
 
-    private static Map<String, IIndex> createIndices(IndexDefs indexDefs, Table table,
+    private Map<String, IIndex> createIndices(IndexDefs indexDefs, Table table,
                                                      ModelClassMetaData metaData, IDatabasePlatform platform) {
         Map<String, IIndex> indices = new HashMap<>();
         if (indexDefs != null && indexDefs.value() != null) {
@@ -355,7 +373,7 @@ public class DatabaseSchema {
         return indices;
     }
 
-    private static void parseIndexDef(IndexDef indexDef, Table table, Map<String, IIndex> indices, ModelClassMetaData metaData, IDatabasePlatform platform) {
+    private void parseIndexDef(IndexDef indexDef, Table table, Map<String, IIndex> indices, ModelClassMetaData metaData, IDatabasePlatform platform) {
         if (indexDef.column() != null && !indexDef.column().isEmpty()) {
             Column column = findColumn(indexDef.column(), table, platform);
             createIndex(indexDef, column, indexDef.column(), indices, metaData.getIdxPrefix());
@@ -369,13 +387,18 @@ public class DatabaseSchema {
         }
     }
 
-    private static Column findColumn(String columnName, Table table, IDatabasePlatform platform) {
+    private Column findColumn(String columnName, String augmentedPrefix, Table table, IDatabasePlatform platform) {
+        String augmentedColumnName = alterCaseToMatchDatabaseDefaultCase(augmentedPrefix + camelToSnakeCase(columnName), platform);
+        return table.getColumnWithName(augmentedColumnName);
+    }
+
+    private Column findColumn(String columnName, Table table, IDatabasePlatform platform) {
         String snakeCase = alterCaseToMatchDatabaseDefaultCase(camelToSnakeCase(columnName), platform);
         Column column = table.getColumnWithName(snakeCase);
         return column;
     }
 
-    private static void createIndex(IndexDef indexDef, Column column, String columnName, Map<String, IIndex> indices, String idxPrefix) {
+    private void createIndex(IndexDef indexDef, Column column, String columnName, Map<String, IIndex> indices, String idxPrefix) {
         if (column != null && indexDef != null) {
             String indexName = idxPrefix != null && !idxPrefix.isEmpty() ? idxPrefix + "_" + indexDef.name() : indexDef.name();
             boolean unique = indexDef.unique();
@@ -392,7 +415,7 @@ public class DatabaseSchema {
         }
     }
 
-    private static boolean isPrimaryKey(Field field, ModelClassMetaData metaData) {
+    private boolean isPrimaryKey(Field field, ModelClassMetaData metaData) {
         if (field != null) {
             ColumnDef colAnnotation = field.getAnnotation(ColumnDef.class);
             if (colAnnotation != null) {
@@ -403,14 +426,14 @@ public class DatabaseSchema {
         return false;
     }
 
-    private static String alterCaseToMatchDatabaseDefaultCase(String name, IDatabasePlatform platform) {
+    private String alterCaseToMatchDatabaseDefaultCase(String name, IDatabasePlatform platform) {
         if (platform != null) {
             name = platform.alterCaseToMatchDatabaseDefaultCase(name);
         }
         return name;
     }
 
-    private static Column createColumn(Field field, IDatabasePlatform platform, ModelClassMetaData metaData) {
+    private Column createColumn(Field field, IDatabasePlatform platform, ModelClassMetaData metaData) {
         Column dbCol = null;
         ColumnDef colAnnotation = field.getAnnotation(ColumnDef.class);
 
@@ -456,7 +479,7 @@ public class DatabaseSchema {
         return dbCol;
     }
 
-    private static boolean platformMatches(String name, IDatabasePlatform platform) {
+    private boolean platformMatches(String name, IDatabasePlatform platform) {
         return platform != null && name != null && platform.getName().equals(name);
     }
 
@@ -587,7 +610,7 @@ public class DatabaseSchema {
         return classToModelMetaData.get(modelClass);
     }
 
-    private static int getDefaultType(Field field) {
+    private int getDefaultType(Field field) {
         if (field.getType().isAssignableFrom(String.class) || field.getType().isEnum() || ITypeCode.class.isAssignableFrom(field.getType())) {
             return Types.VARCHAR;
         } else if (field.getType().isAssignableFrom(long.class) || field.getType().isAssignableFrom(Long.class)) {
@@ -622,4 +645,44 @@ public class DatabaseSchema {
 
         return buff.toString().toLowerCase();
     }
+
+    private Map<String, IIndex> createAugmentedIndices(Class<?> currentClass, Table table,
+                                                       ModelClassMetaData metaData, IDatabasePlatform platform) {
+        Map<String, IIndex> indices = new HashMap<>();
+        Augmented augmented = currentClass.getAnnotation(Augmented.class);
+        if (augmented != null) {
+            AugmenterConfig config = augmenterHelper.getAugmenterConfig(augmented.name());
+            if (config != null && config.getIndexConfigs() != null) {
+                List<AugmenterIndexConfig> indexConfigs = config.getIndexConfigs();
+                for (AugmenterIndexConfig indexConfig : indexConfigs) {
+                    createIndex(indexConfig, table, indices, metaData.getIdxPrefix(), platform, config.getPrefix());
+                }
+            }
+        }
+        return indices;
+    }
+
+    private void createIndex(AugmenterIndexConfig indexConfig, Table table, Map<String, IIndex> indices, String idxPrefix, IDatabasePlatform platform, String augmentedColumnPrefix) {
+        String indexName = idxPrefix != null && !idxPrefix.isEmpty() ? idxPrefix + "_" + indexConfig.getName() : indexConfig.getName();
+        indexName += (indexConfig.isUnique() ? "_unq" : "");
+        IIndex index = indices.get(indexName);
+        if (index == null) {
+            index = indexConfig.isUnique() ? new UniqueIndex(indexConfig.getName()) : new NonUniqueIndex(indexConfig.getName());
+            indices.put(indexName, index);
+        }
+        for (String columnName : indexConfig.getColumnNames()) {
+            Column column = findColumn(columnName, augmentedColumnPrefix, table, platform);
+            if (column == null) {
+                column = findColumn(columnName, table, platform);
+            }
+            if (column != null) {
+                index.addColumn(new IndexColumn(column));
+            }
+            if (column == null) {
+                log.warn("No column {} found for index {} on augmented table {}", columnName, indexName, table.getName());
+            }
+        }
+    }
+
+
 }

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/DatabaseSchema.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/DatabaseSchema.java
@@ -655,7 +655,7 @@ public class DatabaseSchema {
             if (config != null && config.getIndexConfigs() != null) {
                 List<AugmenterIndexConfig> indexConfigs = config.getIndexConfigs();
                 for (AugmenterIndexConfig indexConfig : indexConfigs) {
-                    createIndex(indexConfig, table, indices, metaData.getIdxPrefix(), platform, config.getPrefix());
+                    createIndex(indexConfig, table, indices, augmented.indexPrefix(), platform, config.getPrefix());
                 }
             }
         }
@@ -667,7 +667,7 @@ public class DatabaseSchema {
         indexName += (indexConfig.isUnique() ? "_unq" : "");
         IIndex index = indices.get(indexName);
         if (index == null) {
-            index = indexConfig.isUnique() ? new UniqueIndex(indexConfig.getName()) : new NonUniqueIndex(indexConfig.getName());
+            index = indexConfig.isUnique() ? new UniqueIndex(indexName) : new NonUniqueIndex(indexName);
             indices.put(indexName, index);
         }
         for (String columnName : indexConfig.getColumnNames()) {

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/ModelClassMetaData.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/ModelClassMetaData.java
@@ -21,6 +21,7 @@ public class ModelClassMetaData {
     private Map<String, FieldMetaData> entityFieldMetaDatas = new LinkedHashMap<>();
     private List<Column> primaryKeyColumns = new ArrayList<Column>();
     private Set<String> primaryKeyFieldNames = new LinkedHashSet<>();
+    private Set<String> augmentedFieldNames = new LinkedHashSet<>();
 
     public ModelClassMetaData() {
     }

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/ModelWrapper.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/ModelWrapper.java
@@ -160,7 +160,7 @@ public class ModelWrapper {
                 }
             }
             if (IAugmentedModel.class.isAssignableFrom(clazz) && clazz.getAnnotation(Augmented.class) != null) {
-                AugmenterConfig config = augmenterHelper.getAugmenterConfig(clazz.getAnnotation(Augmented.class).group());
+                AugmenterConfig config = augmenterHelper.getAugmenterConfig(clazz.getAnnotation(Augmented.class).name());
                 if (config != null && config.getPrefix() != null) {
                     Column[] columns = classMetaData.getTable().getColumns();
                     for (Column column : columns) {
@@ -170,7 +170,7 @@ public class ModelWrapper {
                     }
                 }
                 else {
-                    log.warn("Missing augmenterConfig for " + clazz.getAnnotation(Augmented.class).group() + " skipping columns");
+                    log.info("Missing augmenterConfig for name: " + clazz.getAnnotation(Augmented.class).name() + " skipping columns");
                 }
 
             }
@@ -237,9 +237,12 @@ public class ModelWrapper {
     }
 
     protected AugmenterConfig getAugmenterConfig(AbstractModel model) {
-        AugmenterConfig config = augmenterHelper.getAugmenterConfig(model);
-        if (config == null) {
-            log.warn("Missing augmenter config for class " + model.getClass().getSimpleName());
+        AugmenterConfig config = null;
+        if (model.getClass().getAnnotation(Augmented.class) != null) {
+            config = augmenterHelper.getAugmenterConfig(model);
+            if (config == null) {
+                log.info("Missing augmenter config for class " + model.getClass().getSimpleName());
+            }
         }
         return config;
     }

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/ModelWrapper.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/ModelWrapper.java
@@ -1,30 +1,22 @@
 package org.jumpmind.pos.persist.impl;
 
-import java.beans.IntrospectionException;
-import java.beans.PropertyDescriptor;
-
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.math.BigDecimal;
-import java.util.*;
-import java.util.Map.Entry;
-
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.beanutils.PropertyUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.money.CurrencyUnit;
 import org.joda.money.Money;
 import org.jumpmind.db.model.Column;
 import org.jumpmind.db.model.Table;
-import org.jumpmind.pos.persist.AbstractModel;
-import org.jumpmind.pos.persist.ColumnDef;
-import org.jumpmind.pos.persist.CompositeDef;
-import org.jumpmind.pos.persist.PersistException;
-import org.jumpmind.pos.persist.model.ITaggedModel;
-import org.jumpmind.pos.persist.model.TagModel;
+import org.jumpmind.pos.persist.*;
+import org.jumpmind.pos.persist.model.*;
 import org.jumpmind.pos.util.ReflectUtils;
-import org.jumpmind.pos.util.ReflectionException;
 import org.jumpmind.pos.util.model.ITypeCode;
+
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
+import java.util.*;
+import java.util.Map.Entry;
 
 @Slf4j
 public class ModelWrapper {
@@ -33,6 +25,7 @@ public class ModelWrapper {
 
     private ModelMetaData modelMetaData;
     private AbstractModel model;
+    private AugmenterHelper augmenterHelper;
     
     private Map<String, Object> systemData;
 
@@ -40,9 +33,10 @@ public class ModelWrapper {
     private LinkedHashMap<String, Object> columnNamesToValues;
     
     @SuppressWarnings("unchecked")
-    public ModelWrapper(AbstractModel model, ModelMetaData modelMetaData) {
+    public ModelWrapper(AbstractModel model, ModelMetaData modelMetaData, AugmenterHelper augmenterHelper) {
         this.model = model;
         this.modelMetaData = modelMetaData;
+        this.augmenterHelper = augmenterHelper;
 
         modelMetaData.getModelClassMetaData().forEach( modelClassMetaData -> {
             if(modelClassMetaData.getExtensionClazzes() != null){
@@ -165,6 +159,21 @@ public class ModelWrapper {
                     }
                 }
             }
+            if (IAugmentedModel.class.isAssignableFrom(clazz) && clazz.getAnnotation(Augmented.class) != null) {
+                AugmenterConfig config = augmenterHelper.getAugmenterConfig(clazz.getAnnotation(Augmented.class).group());
+                if (config != null && config.getPrefix() != null) {
+                    Column[] columns = classMetaData.getTable().getColumns();
+                    for (Column column : columns) {
+                        if (column.getName().toUpperCase().startsWith(config.getPrefix())) {
+                            fieldColumnMap.put(column.getName(), column);
+                        }
+                    }
+                }
+                else {
+                    log.warn("Missing augmenterConfig for " + clazz.getAnnotation(Augmented.class).group() + " skipping columns");
+                }
+
+            }
         }
     }
 
@@ -199,11 +208,14 @@ public class ModelWrapper {
         try {
             LinkedHashMap<String, Object> columnNamesToObjectValues = new LinkedHashMap<String, Object>();
             Set<String> fieldNames = fieldsToColumns.keySet();
+            AugmenterConfig config = getAugmenterConfig(model);
             for (String fieldName : fieldNames) {
-
                 if (fieldName.toUpperCase().startsWith(TagModel.TAG_PREFIX)) {
                     String tagValue = ((ITaggedModel) model).getTagValue(fieldName.substring(TagModel.TAG_PREFIX.length()));
                     columnNamesToObjectValues.put(fieldName, tagValue);
+                } else if (config != null && fieldName.toUpperCase().startsWith(config.getPrefix())) {
+                    String agumentValue = ((IAugmentedModel) model).getAugmentValue(fieldName.substring(config.getPrefix().length()));
+                    columnNamesToObjectValues.put(fieldName, ObjectUtils.defaultIfNull(agumentValue, augmenterHelper.getDefaultValue(fieldName, model)));
                 } else {
                     Column column = fieldsToColumns.get(fieldName);
                     Object value = getFieldValue(fieldName);
@@ -222,7 +234,15 @@ public class ModelWrapper {
             throw new PersistException(
                     "Failed to getObjectValuesByColumnName on model " + model + " fieldsToColumns: " + fieldsToColumns, ex);
         }
-    }    
+    }
+
+    protected AugmenterConfig getAugmenterConfig(AbstractModel model) {
+        AugmenterConfig config = augmenterHelper.getAugmenterConfig(model);
+        if (config == null) {
+            log.warn("Missing augmenter config for class " + model.getClass().getSimpleName());
+        }
+        return config;
+    }
 
     public Object getFieldValue(String fieldName) {
         Object fieldValue=null;

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AbstractAugmentedModel.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AbstractAugmentedModel.java
@@ -1,0 +1,23 @@
+package org.jumpmind.pos.persist.model;
+
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
+import org.jumpmind.pos.persist.AbstractModel;
+
+import java.util.Map;
+
+public abstract class AbstractAugmentedModel extends AbstractModel implements IAugmentedModel {
+
+    private static final long serialVersionUID = 1L;
+
+    private Map<String, String> augments = new CaseInsensitiveMap<String, String>();
+
+    @Override
+    public Map<String, String> getAugments() {
+        return augments;
+    }
+
+    @Override
+    public void setAugments(Map<String, String> augments) {
+        this.augments = augments;
+    }
+}

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AbstractTaggedAugmentedModel.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AbstractTaggedAugmentedModel.java
@@ -1,0 +1,20 @@
+package org.jumpmind.pos.persist.model;
+
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
+
+import java.util.Map;
+
+public class AbstractTaggedAugmentedModel extends AbstractTaggedModel implements IAugmentedModel {
+
+    private Map<String, String> augments = new CaseInsensitiveMap<>();
+
+    @Override
+    public void setAugments(Map<String, String> augments) {
+        this.augments = augments;
+    }
+
+    @Override
+    public Map<String, String> getAugments() {
+        return augments;
+    }
+}

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AugmenterConfig.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AugmenterConfig.java
@@ -12,7 +12,7 @@ import java.util.stream.Collectors;
 @Data
 @NoArgsConstructor
 public class AugmenterConfig {
-    private String group;
+    private String name;
     private String prefix;
     private List<AugmenterModel> augmenters;
 

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AugmenterConfig.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AugmenterConfig.java
@@ -15,6 +15,7 @@ public class AugmenterConfig {
     private String name;
     private String prefix;
     private List<AugmenterModel> augmenters;
+    private List<AugmenterIndexConfig> indexConfigs;
 
     public AugmenterModel getAugmenter(String name) {
         return Optional.ofNullable(augmenters).orElse(Collections.emptyList()).stream()

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AugmenterConfig.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AugmenterConfig.java
@@ -1,0 +1,31 @@
+package org.jumpmind.pos.persist.model;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Data
+@NoArgsConstructor
+public class AugmenterConfig {
+    private String group;
+    private String prefix;
+    private List<AugmenterModel> augmenters;
+
+    public AugmenterModel getAugmenter(String name) {
+        return Optional.ofNullable(augmenters).orElse(Collections.emptyList()).stream()
+                .filter(a -> StringUtils.equalsIgnoreCase(a.getName(), name))
+                .findFirst()
+                .orElse(null);
+    }
+
+    public List<String> getAugmenterNames() {
+        return Optional.ofNullable(augmenters).orElse(Collections.emptyList()).stream()
+                .map(AugmenterModel::getName)
+                .collect(Collectors.toList());
+    }
+}

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AugmenterConfigs.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AugmenterConfigs.java
@@ -15,25 +15,21 @@ import java.util.stream.Collectors;
 public class AugmenterConfigs {
     private List<AugmenterConfig> configs;
 
-    public List<String> getGroups() {
+    public List<String> getConfigsNames() {
         return Optional.ofNullable(configs).orElse(Collections.emptyList())
                 .stream()
-                .map(AugmenterConfig::getGroup)
+                .map(AugmenterConfig::getName)
                 .collect(Collectors.toList());
     }
 
-    public List<AugmenterConfig> getConfigsByGroups(String... groups) {
+    public List<AugmenterConfig> getConfigsByNames(String... names) {
         return Optional.ofNullable(configs).orElse(Collections.emptyList())
                 .stream()
-                .filter(group -> Arrays.stream(groups).anyMatch(g -> g.equals(group.getGroup())))
+                .filter(config -> Arrays.stream(names).anyMatch(g -> g.equals(config.getName())))
                 .collect(Collectors.toList());
     }
 
-    public AugmenterConfig getConfig(String group) {
-        return Optional.ofNullable(configs).orElse(Collections.emptyList())
-                .stream()
-                .filter(config -> Objects.equals(config.getGroup(), group))
-                .findFirst()
-                .orElse(null);
+    public AugmenterConfig getConfigByName(String name) {
+        return getConfigsByNames(name).stream().findFirst().orElse(null);
     }
 }

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AugmenterConfigs.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AugmenterConfigs.java
@@ -1,0 +1,39 @@
+package org.jumpmind.pos.persist.model;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Data
+@NoArgsConstructor
+@Component
+@ConfigurationProperties(prefix="openpos.augmenterconfigs")
+public class AugmenterConfigs {
+    private List<AugmenterConfig> configs;
+
+    public List<String> getGroups() {
+        return Optional.ofNullable(configs).orElse(Collections.emptyList())
+                .stream()
+                .map(AugmenterConfig::getGroup)
+                .collect(Collectors.toList());
+    }
+
+    public List<AugmenterConfig> getConfigsByGroups(String... groups) {
+        return Optional.ofNullable(configs).orElse(Collections.emptyList())
+                .stream()
+                .filter(group -> Arrays.stream(groups).anyMatch(g -> g.equals(group.getGroup())))
+                .collect(Collectors.toList());
+    }
+
+    public AugmenterConfig getConfig(String group) {
+        return Optional.ofNullable(configs).orElse(Collections.emptyList())
+                .stream()
+                .filter(config -> Objects.equals(config.getGroup(), group))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AugmenterHelper.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AugmenterHelper.java
@@ -23,7 +23,7 @@ public class AugmenterHelper {
     private AugmenterConfigs augmenterConfigs;
 
     public AugmenterConfig getAugmenterConfig(String group) {
-        return augmenterConfigs.getConfig(group);
+        return augmenterConfigs.getConfigByName(group);
     }
 
     public AugmenterConfig getAugmenterConfig(Object object) {
@@ -33,7 +33,7 @@ public class AugmenterHelper {
     public AugmenterConfig getAugmenterConfig(Class<?> clazz) {
         Augmented augmented = clazz.getAnnotation(Augmented.class);
         if (augmented != null) {
-            return augmenterConfigs.getConfig(augmented.group());
+            return augmenterConfigs.getConfigByName(augmented.name());
         }
         return null;
     }

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AugmenterHelper.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AugmenterHelper.java
@@ -22,8 +22,8 @@ public class AugmenterHelper {
     @Autowired
     private AugmenterConfigs augmenterConfigs;
 
-    public AugmenterConfig getAugmenterConfig(String group) {
-        return augmenterConfigs.getConfigByName(group);
+    public AugmenterConfig getAugmenterConfig(String name) {
+        return augmenterConfigs.getConfigByName(name);
     }
 
     public AugmenterConfig getAugmenterConfig(Object object) {
@@ -77,6 +77,4 @@ public class AugmenterHelper {
         }
         return null;
     }
-
-//    public Map<String, String>
 }

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AugmenterHelper.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AugmenterHelper.java
@@ -1,0 +1,82 @@
+package org.jumpmind.pos.persist.model;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
+import org.jumpmind.pos.persist.AbstractModel;
+import org.jumpmind.pos.persist.Augmented;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+@Slf4j
+@Component
+@Getter
+@Setter
+public class AugmenterHelper {
+
+    @Autowired
+    private AugmenterConfigs augmenterConfigs;
+
+    public AugmenterConfig getAugmenterConfig(String group) {
+        return augmenterConfigs.getConfig(group);
+    }
+
+    public AugmenterConfig getAugmenterConfig(Object object) {
+        return getAugmenterConfig(object.getClass());
+    }
+
+    public AugmenterConfig getAugmenterConfig(Class<?> clazz) {
+        Augmented augmented = clazz.getAnnotation(Augmented.class);
+        if (augmented != null) {
+            return augmenterConfigs.getConfig(augmented.group());
+        }
+        return null;
+    }
+
+    public void addAugments(IAugmentedModel augmentedModel, Map<String, Object> fields) {
+        if (augmentedModel != null) {
+            Map<String, String> augments = additionalFieldsToAugments(augmentedModel, fields);
+            augmentedModel.setAugments(augments);
+        }
+    }
+
+    protected Map<String, String> additionalFieldsToAugments(IAugmentedModel augmentedModel, Map<String, Object> additionalFields) {
+        Map<String, String> augments = new CaseInsensitiveMap<>();
+        AugmenterConfig config = getAugmenterConfig(augmentedModel);
+        if (config == null) {
+            log.warn("Missing augmenter config for class " + augmentedModel.getClass().getSimpleName());
+            return Collections.emptyMap();
+        }
+        for (String columnName : additionalFields.keySet()) {
+            String columnUpper = columnName.toUpperCase();
+            if (columnUpper.startsWith(config.getPrefix())) {
+                Object value = additionalFields.get(columnName);
+                String augmentName = columnUpper.substring(config.getPrefix().length());
+                augments.put(augmentName, Objects.toString(value ,null));
+            }
+        }
+
+        return augments;
+    }
+
+    public Object getDefaultValue(String fieldName, AbstractModel model) {
+        AugmenterConfig config = getAugmenterConfig(model);
+        if (config != null) {
+            AugmenterModel augmenter = config.getAugmenter(fieldName.substring(config.getPrefix().length()));
+            if (augmenter != null) {
+                return augmenter.getDefaultValue();
+            }
+            else {
+                log.info("No augmenter found for field name " + fieldName + " in AugmenterConfig " + config);
+            }
+        }
+        return null;
+    }
+
+//    public Map<String, String>
+}

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AugmenterIndexConfig.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AugmenterIndexConfig.java
@@ -1,0 +1,14 @@
+package org.jumpmind.pos.persist.model;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class AugmenterIndexConfig {
+    private String name;
+    private boolean unique;
+    private List<String> columnNames;
+}

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AugmenterModel.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AugmenterModel.java
@@ -9,5 +9,4 @@ public class AugmenterModel {
     private String name;
     private String defaultValue;
     private Integer size;
-    private int order;
 }

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AugmenterModel.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AugmenterModel.java
@@ -8,6 +8,6 @@ import lombok.NoArgsConstructor;
 public class AugmenterModel {
     private String name;
     private String defaultValue;
-    private int size;
+    private Integer size;
     private int order;
 }

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AugmenterModel.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AugmenterModel.java
@@ -1,0 +1,13 @@
+package org.jumpmind.pos.persist.model;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class AugmenterModel {
+    private String name;
+    private String defaultValue;
+    private int size;
+    private int order;
+}

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/IAugmentedModel.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/IAugmentedModel.java
@@ -1,0 +1,22 @@
+package org.jumpmind.pos.persist.model;
+
+import java.util.Map;
+
+public interface IAugmentedModel {
+
+    default String getAugmentValue(String augmentName) {
+        return getAugments().get(augmentName);
+    }
+
+    default void setAugmentValue(String augmentName, String value) {
+        getAugments().put(augmentName, value);
+    }
+
+    default void clearAugmentValue(String augmentName) {
+        getAugments().remove(augmentName);
+    }
+
+    void setAugments(Map<String, String> augments);
+
+    Map<String, String> getAugments();
+}

--- a/openpos-persist/src/test/java/org/jumpmind/pos/persist/DBSessionAugmenterTest.java
+++ b/openpos-persist/src/test/java/org/jumpmind/pos/persist/DBSessionAugmenterTest.java
@@ -103,7 +103,7 @@ public class DBSessionAugmenterTest {
         DBSession db = sessionFactory.createDbSession();
         Map<String, Object> params = new HashMap<>();
         params.put("tableName", "CAR_AUGMENTED_CAR");
-        params.put("indexName", "CAR_IDX_OPTION_COLOR");
+        params.put("indexName", "CAR_AUG_IDX_OPTION_COLOR");
         List<Row> results = db.query("select * from INFORMATION_SCHEMA.INDEXES where " +
                 "TABLE_NAME = :tableName and INDEX_NAME = :indexName", params);
         assertEquals(1, results.size());
@@ -115,7 +115,7 @@ public class DBSessionAugmenterTest {
         DBSession db = sessionFactory.createDbSession();
         Map<String, Object> params = new HashMap<>();
         params.put("tableName", "CAR_AUGMENTED_CAR");
-        params.put("indexName", "CAR_IDX_MAKE_MODEL_COLOR");
+        params.put("indexName", "CAR_AUG_IDX_MAKE_MODEL_COLOR");
         List<Row> results = db.query("select * from INFORMATION_SCHEMA.INDEXES where " +
                 "TABLE_NAME = :tableName and INDEX_NAME = :indexName", params);
         assertEquals(3, results.size());

--- a/openpos-persist/src/test/java/org/jumpmind/pos/persist/DBSessionAugmenterTest.java
+++ b/openpos-persist/src/test/java/org/jumpmind/pos/persist/DBSessionAugmenterTest.java
@@ -86,4 +86,11 @@ public class DBSessionAugmenterTest {
         List<CarModel> cars = db.findByCriteria(searchCriteria);
         assertEquals(0, cars.size());
     }
+
+    @Test
+    public void testDefaultValueIsSetWhenCreatingNewItem() {
+        DBSession db = sessionFactory.createDbSession();
+        AugmentedCarModel car = db.findByNaturalId(AugmentedCarModel.class, VIN);
+        assertEquals("standard", car.getAugmentValue("transmission"));
+    }
 }

--- a/openpos-persist/src/test/java/org/jumpmind/pos/persist/DBSessionAugmenterTest.java
+++ b/openpos-persist/src/test/java/org/jumpmind/pos/persist/DBSessionAugmenterTest.java
@@ -1,0 +1,89 @@
+package org.jumpmind.pos.persist;
+
+import org.jumpmind.pos.persist.cars.AugmentedCarModel;
+import org.jumpmind.pos.persist.cars.CarModel;
+import org.jumpmind.pos.persist.cars.TestPersistCarsConfig;
+import org.jumpmind.pos.persist.model.SearchCriteria;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes= {TestPersistCarsConfig.class})
+public class DBSessionAugmenterTest {
+
+    @Autowired
+    private DBSessionFactory sessionFactory;
+
+    final String VIN = "KMHCN46C58U242743";
+
+    @Before
+    public void setup() {
+        {
+            DBSession db = sessionFactory.createDbSession();
+            db.executeSql("TRUNCATE TABLE CAR_CAR");
+        }
+
+        {
+            DBSession db = sessionFactory.createDbSession();
+            AugmentedCarModel someHyundai = new AugmentedCarModel();
+            someHyundai.setVin(VIN);
+            someHyundai.setMake("Hyundai");
+            someHyundai.setModel("Accent");
+            someHyundai.setModelYear("2005");
+            someHyundai.setAugmentValue("color", "blue");
+            db.save(someHyundai);
+        }
+    }
+
+    @Test
+    public void testQueryByIdHasAugmentedValues() {
+        DBSession db = sessionFactory.createDbSession();
+        AugmentedCarModel hyundaiLookupedUp = db.findByNaturalId(AugmentedCarModel.class, VIN);
+        assertNotNull(hyundaiLookupedUp);
+        assertEquals(VIN, hyundaiLookupedUp.getVin());
+        assertEquals("Hyundai", hyundaiLookupedUp.getMake());
+        assertEquals("Accent", hyundaiLookupedUp.getModel());
+        assertEquals("2005", hyundaiLookupedUp.getModelYear());
+        assertEquals("blue", hyundaiLookupedUp.getAugmentValue("color"));
+        assertEquals("standard", hyundaiLookupedUp.getAugmentValue("transmission"));
+    }
+
+    @Test
+    public void testQueryByIdSaveAndRequery() {
+        DBSession db = sessionFactory.createDbSession();
+        AugmentedCarModel hyundaiLookedUp = db.findByNaturalId(AugmentedCarModel.class, VIN);
+        assertNotNull(hyundaiLookedUp);
+        assertEquals("blue", hyundaiLookedUp.getAugmentValue("color"));
+        hyundaiLookedUp.setAugmentValue("color", "green");
+        db.save(hyundaiLookedUp);
+        AugmentedCarModel relookupModel = db.findByNaturalId(AugmentedCarModel.class, VIN);
+        assertNotNull(relookupModel);
+        assertEquals("green", relookupModel.getAugmentValue("color"));
+    }
+
+    @Test
+    public void testQueryBySearchCriteriaWithAugmentedFields() {
+        DBSession db = sessionFactory.createDbSession();
+        SearchCriteria searchCriteria = new SearchCriteria(AugmentedCarModel.class);
+        searchCriteria.addCriteria("color", "blue");
+        List<CarModel> cars = db.findByCriteria(searchCriteria);
+        assertEquals(1, cars.size());
+    }
+
+    @Test
+    public void testQueryBySearchCriteriaWithAugmentedFieldsNonFieldsMatch() {
+        DBSession db = sessionFactory.createDbSession();
+        SearchCriteria searchCriteria = new SearchCriteria(AugmentedCarModel.class);
+        searchCriteria.addCriteria("color", "green");
+        List<CarModel> cars = db.findByCriteria(searchCriteria);
+        assertEquals(0, cars.size());
+    }
+}

--- a/openpos-persist/src/test/java/org/jumpmind/pos/persist/DBSessionQueryConcurrentTest.java
+++ b/openpos-persist/src/test/java/org/jumpmind/pos/persist/DBSessionQueryConcurrentTest.java
@@ -14,6 +14,7 @@ import org.jumpmind.pos.persist.cars.CarModel;
 import org.jumpmind.pos.persist.impl.DatabaseSchema;
 import org.jumpmind.pos.persist.impl.DmlTemplate;
 import org.jumpmind.pos.persist.impl.QueryTemplate;
+import org.jumpmind.pos.persist.model.AugmenterHelper;
 import org.jumpmind.pos.persist.model.TagHelper;
 import org.jumpmind.properties.TypedProperties;
 import org.junit.Test;
@@ -41,6 +42,7 @@ public class DBSessionQueryConcurrentTest {
         DatabaseSchema databaseSchema = Mockito.mock(DatabaseSchema.class);
         IDatabasePlatform databasePlatform = Mockito.mock(IDatabasePlatform.class);
         TagHelper tagHelper = Mockito.mock(TagHelper.class);
+        AugmenterHelper augmenterHelper = Mockito.mock(AugmenterHelper.class);
         DataSource dataSource = Mockito.mock(DataSource.class);
         Connection connection = Mockito.mock(Connection.class);
         PreparedStatement ps = Mockito.mock(PreparedStatement.class);
@@ -59,7 +61,7 @@ public class DBSessionQueryConcurrentTest {
         Map<String, QueryTemplate> queryTemplates = new HashMap<>();
         Map<String, DmlTemplate> dmlTemplates = new HashMap<>();
         
-        DBSession db = new DBSession("catalog", "schema", databaseSchema, databasePlatform, new TypedProperties(), queryTemplates, dmlTemplates, tagHelper);
+        DBSession db = new DBSession("catalog", "schema", databaseSchema, databasePlatform, new TypedProperties(), queryTemplates, dmlTemplates, tagHelper, augmenterHelper);
         
         for (int i = 0; i < 1000; i++) {            
             db.query(carLookup);

--- a/openpos-persist/src/test/java/org/jumpmind/pos/persist/cars/AugmentedCarModel.java
+++ b/openpos-persist/src/test/java/org/jumpmind/pos/persist/cars/AugmentedCarModel.java
@@ -17,7 +17,7 @@ import org.jumpmind.pos.persist.model.IAugmentedModel;
         @IndexDef(name = "idx_aug_car_year", column = "modelYear"),
         @IndexDef(name = "idx_aug_car_make_model", columns = {"make", "model"})
 })
-@Augmented(name = "options")
+@Augmented(name = "options", indexPrefix = "aug")
 public class AugmentedCarModel extends AbstractAugmentedModel implements IAugmentedModel {
 
     @ColumnDef

--- a/openpos-persist/src/test/java/org/jumpmind/pos/persist/cars/AugmentedCarModel.java
+++ b/openpos-persist/src/test/java/org/jumpmind/pos/persist/cars/AugmentedCarModel.java
@@ -11,13 +11,13 @@ import org.jumpmind.pos.persist.model.IAugmentedModel;
 @Data
 @NoArgsConstructor
 @TableDef(name="augmented_car",
-        description = "A basic concept of an automobile fit to drive down the road, with optional augments.",
+        description = "A basic concept of an automobile fit to drive down the road, with options augments.",
         primaryKey = "vin")
 @IndexDefs({
         @IndexDef(name = "idx_aug_car_year", column = "modelYear"),
         @IndexDef(name = "idx_aug_car_make_model", columns = {"make", "model"})
 })
-@Augmented(group = "options")
+@Augmented(name = "options")
 public class AugmentedCarModel extends AbstractAugmentedModel implements IAugmentedModel {
 
     @ColumnDef

--- a/openpos-persist/src/test/java/org/jumpmind/pos/persist/cars/AugmentedCarModel.java
+++ b/openpos-persist/src/test/java/org/jumpmind/pos/persist/cars/AugmentedCarModel.java
@@ -1,0 +1,41 @@
+package org.jumpmind.pos.persist.cars;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.joda.money.Money;
+import org.jumpmind.pos.persist.*;
+import org.jumpmind.pos.persist.model.AbstractAugmentedModel;
+import org.jumpmind.pos.persist.model.IAugmentedModel;
+
+
+@Data
+@NoArgsConstructor
+@TableDef(name="augmented_car",
+        description = "A basic concept of an automobile fit to drive down the road, with optional augments.",
+        primaryKey = "vin")
+@IndexDefs({
+        @IndexDef(name = "idx_aug_car_year", column = "modelYear"),
+        @IndexDef(name = "idx_aug_car_make_model", columns = {"make", "model"})
+})
+@Augmented(group = "options")
+public class AugmentedCarModel extends AbstractAugmentedModel implements IAugmentedModel {
+
+    @ColumnDef
+    private String vin;
+    @ColumnDef
+    private String modelYear;
+    @ColumnDef
+    private String make;
+    @ColumnDef
+    private String model;
+    @ColumnDef(crossReference="isoCurrencyCode")
+    private Money estimatedValue;
+    @ColumnDef
+    private String isoCurrencyCode;
+    @ColumnDef
+    private CarTrimTypeCode carTrimTypeCode;
+    @ColumnDef
+    private byte[] image;
+    @ColumnDef
+    private boolean antique;
+}

--- a/openpos-persist/src/test/java/org/jumpmind/pos/persist/cars/DelegateTestContextConfig.java
+++ b/openpos-persist/src/test/java/org/jumpmind/pos/persist/cars/DelegateTestContextConfig.java
@@ -47,7 +47,7 @@ public class DelegateTestContextConfig {
 
             AugmenterConfigs augmenterConfigs = new AugmenterConfigs();
             AugmenterConfig augmenterConfig = new AugmenterConfig();
-            augmenterConfig.setGroup("options");
+            augmenterConfig.setName("options");
             augmenterConfig.setPrefix("OPTION_");
 
             List<AugmenterModel> augmenterModels = new ArrayList<>();
@@ -58,6 +58,7 @@ public class DelegateTestContextConfig {
             augmenterModel = new AugmenterModel();
             augmenterModel.setName("transmission");
             augmenterModel.setOrder(1);
+            augmenterModel.setDefaultValue("standard");
             augmenterModels.add(augmenterModel);
             augmenterConfig.setAugmenters(augmenterModels);
             augmenterConfigs.setConfigs(Arrays.asList(augmenterConfig));

--- a/openpos-persist/src/test/java/org/jumpmind/pos/persist/cars/DelegateTestContextConfig.java
+++ b/openpos-persist/src/test/java/org/jumpmind/pos/persist/cars/DelegateTestContextConfig.java
@@ -53,11 +53,9 @@ public class DelegateTestContextConfig {
             List<AugmenterModel> augmenterModels = new ArrayList<>();
             AugmenterModel augmenterModel = new AugmenterModel();
             augmenterModel.setName("color");
-            augmenterModel.setOrder(0);
             augmenterModels.add(augmenterModel);
             augmenterModel = new AugmenterModel();
             augmenterModel.setName("transmission");
-            augmenterModel.setOrder(1);
             augmenterModel.setDefaultValue("standard");
             augmenterModels.add(augmenterModel);
             augmenterConfig.setAugmenters(augmenterModels);

--- a/openpos-persist/src/test/java/org/jumpmind/pos/persist/cars/DelegateTestContextConfig.java
+++ b/openpos-persist/src/test/java/org/jumpmind/pos/persist/cars/DelegateTestContextConfig.java
@@ -1,18 +1,14 @@
 package org.jumpmind.pos.persist.cars;
 
 import java.io.InputStream;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import org.jumpmind.pos.persist.DBSession;
 import org.jumpmind.pos.persist.DBSessionFactory;
 import org.jumpmind.pos.persist.DatabaseScriptContainer;
 import org.jumpmind.pos.persist.driver.Driver;
 import org.jumpmind.pos.persist.impl.QueryTemplates;
-import org.jumpmind.pos.persist.model.TagConfig;
-import org.jumpmind.pos.persist.model.TagHelper;
-import org.jumpmind.pos.persist.model.TagModel;
+import org.jumpmind.pos.persist.model.*;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.PropertySource;
@@ -49,6 +45,26 @@ public class DelegateTestContextConfig {
             TagHelper tagHelper = new TagHelper();
             tagHelper.setTagConfig(tagConfig);
 
+            AugmenterConfigs augmenterConfigs = new AugmenterConfigs();
+            AugmenterConfig augmenterConfig = new AugmenterConfig();
+            augmenterConfig.setGroup("options");
+            augmenterConfig.setPrefix("OPTION_");
+
+            List<AugmenterModel> augmenterModels = new ArrayList<>();
+            AugmenterModel augmenterModel = new AugmenterModel();
+            augmenterModel.setName("color");
+            augmenterModel.setOrder(0);
+            augmenterModels.add(augmenterModel);
+            augmenterModel = new AugmenterModel();
+            augmenterModel.setName("transmission");
+            augmenterModel.setOrder(1);
+            augmenterModels.add(augmenterModel);
+            augmenterConfig.setAugmenters(augmenterModels);
+            augmenterConfigs.setConfigs(Arrays.asList(augmenterConfig));
+
+            AugmenterHelper augmenterHelper = new AugmenterHelper();
+            augmenterHelper.setAugmenterConfigs(augmenterConfigs);
+
 
             sessionFactory.init(
                     PersistTestUtil.testDbPlatform(),
@@ -56,7 +72,7 @@ public class DelegateTestContextConfig {
                     Arrays.asList(CarExtendedWarrantyServiceModel.class),
                     null,
                     queryTemplates,
-                    DBSessionFactory.getDmlTemplates("persist-test"), tagHelper);
+                    DBSessionFactory.getDmlTemplates("persist-test"), tagHelper, augmenterHelper);
 
             DBSession session = sessionFactory.createDbSession();
 

--- a/openpos-persist/src/test/java/org/jumpmind/pos/persist/cars/TestPersistCarsConfig.java
+++ b/openpos-persist/src/test/java/org/jumpmind/pos/persist/cars/TestPersistCarsConfig.java
@@ -53,12 +53,10 @@ public class TestPersistCarsConfig {
             List<AugmenterModel> augmenterModels = new ArrayList<>();
             AugmenterModel augmenterModel = new AugmenterModel();
             augmenterModel.setName("color");
-            augmenterModel.setOrder(0);
             augmenterModels.add(augmenterModel);
             augmenterModel = new AugmenterModel();
             augmenterModel.setName("transmission");
             augmenterModel.setDefaultValue("standard");
-            augmenterModel.setOrder(1);
             augmenterModels.add(augmenterModel);
 
             List<AugmenterIndexConfig> indexConfigs = new ArrayList<>();

--- a/openpos-persist/src/test/java/org/jumpmind/pos/persist/cars/TestPersistCarsConfig.java
+++ b/openpos-persist/src/test/java/org/jumpmind/pos/persist/cars/TestPersistCarsConfig.java
@@ -47,7 +47,7 @@ public class TestPersistCarsConfig {
 
             AugmenterConfigs augmenterConfigs = new AugmenterConfigs();
             AugmenterConfig augmenterConfig = new AugmenterConfig();
-            augmenterConfig.setGroup("options");
+            augmenterConfig.setName("options");
             augmenterConfig.setPrefix("OPTION_");
 
             List<AugmenterModel> augmenterModels = new ArrayList<>();

--- a/openpos-persist/src/test/java/org/jumpmind/pos/persist/cars/TestPersistCarsConfig.java
+++ b/openpos-persist/src/test/java/org/jumpmind/pos/persist/cars/TestPersistCarsConfig.java
@@ -60,6 +60,19 @@ public class TestPersistCarsConfig {
             augmenterModel.setDefaultValue("standard");
             augmenterModel.setOrder(1);
             augmenterModels.add(augmenterModel);
+
+            List<AugmenterIndexConfig> indexConfigs = new ArrayList<>();
+
+            AugmenterIndexConfig indexConfig = new AugmenterIndexConfig();
+            indexConfig.setName("idx_option_color");
+            indexConfig.setColumnNames(Arrays.asList("color"));
+            indexConfigs.add(indexConfig);
+
+            indexConfig = new AugmenterIndexConfig();
+            indexConfig.setName("idx_make_model_color");
+            indexConfig.setColumnNames(Arrays.asList("make", "model", "color"));
+            indexConfigs.add(indexConfig);
+            augmenterConfig.setIndexConfigs(indexConfigs);
             augmenterConfig.setAugmenters(augmenterModels);
             augmenterConfigs.setConfigs(Arrays.asList(augmenterConfig));
 

--- a/openpos-persist/src/test/java/org/jumpmind/pos/persist/cars/TestPersistCarsConfig.java
+++ b/openpos-persist/src/test/java/org/jumpmind/pos/persist/cars/TestPersistCarsConfig.java
@@ -1,18 +1,14 @@
 package org.jumpmind.pos.persist.cars;
 
 import java.io.InputStream;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import org.jumpmind.pos.persist.DBSession;
 import org.jumpmind.pos.persist.DBSessionFactory;
 import org.jumpmind.pos.persist.DatabaseScriptContainer;
 import org.jumpmind.pos.persist.driver.Driver;
 import org.jumpmind.pos.persist.impl.QueryTemplates;
-import org.jumpmind.pos.persist.model.TagConfig;
-import org.jumpmind.pos.persist.model.TagHelper;
-import org.jumpmind.pos.persist.model.TagModel;
+import org.jumpmind.pos.persist.model.*;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.PropertySource;
@@ -48,15 +44,37 @@ public class TestPersistCarsConfig {
             
             TagHelper tagHelper = new TagHelper();
             tagHelper.setTagConfig(tagConfig);
-            
-            
+
+            AugmenterConfigs augmenterConfigs = new AugmenterConfigs();
+            AugmenterConfig augmenterConfig = new AugmenterConfig();
+            augmenterConfig.setGroup("options");
+            augmenterConfig.setPrefix("OPTION_");
+
+            List<AugmenterModel> augmenterModels = new ArrayList<>();
+            AugmenterModel augmenterModel = new AugmenterModel();
+            augmenterModel.setName("color");
+            augmenterModel.setOrder(0);
+            augmenterModels.add(augmenterModel);
+            augmenterModel = new AugmenterModel();
+            augmenterModel.setName("transmission");
+            augmenterModel.setDefaultValue("standard");
+            augmenterModel.setOrder(1);
+            augmenterModels.add(augmenterModel);
+            augmenterConfig.setAugmenters(augmenterModels);
+            augmenterConfigs.setConfigs(Arrays.asList(augmenterConfig));
+
+            AugmenterHelper augmenterHelper = new AugmenterHelper();
+            augmenterHelper.setAugmenterConfigs(augmenterConfigs);
+
             sessionFactory.init(
                     PersistTestUtil.testDbPlatform(), 
                     PersistTestUtil.getSessionContext(), 
-                    Arrays.asList(CarModel.class, CarStats.class, ServiceInvoice.class, RaceCarModel.class),
+                    Arrays.asList(CarModel.class, CarStats.class, ServiceInvoice.class, RaceCarModel.class, AugmentedCarModel.class),
                     Arrays.asList(CarModelExtension.class),
                     queryTemplates,
-                    DBSessionFactory.getDmlTemplates("persist-test"), tagHelper);
+                    DBSessionFactory.getDmlTemplates("persist-test"),
+                    tagHelper,
+                    augmenterHelper);
             
 
             DBSession session = sessionFactory.createDbSession();

--- a/openpos-persist/src/test/java/org/jumpmind/pos/persist/model/AugmenterConfigTest.java
+++ b/openpos-persist/src/test/java/org/jumpmind/pos/persist/model/AugmenterConfigTest.java
@@ -1,0 +1,49 @@
+package org.jumpmind.pos.persist.model;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class AugmenterConfigTest {
+
+    private AugmenterConfig augmenterConfig;
+    private List<AugmenterModel> augmenters;
+
+    @Before
+    public void setUp() {
+        this.augmenterConfig = new AugmenterConfig();
+        augmenterConfig.setName("junit");
+        augmenterConfig.setPrefix("JUNIT_");
+        augmenters = new ArrayList<>();
+        AugmenterModel augmenter1 = new AugmenterModel();
+        augmenter1.setName("aug1");
+        augmenter1.setOrder(1);
+        augmenters.add(augmenter1);
+        AugmenterModel augmenter2 = new AugmenterModel();
+        augmenter2.setName("aug2");
+        augmenter2.setOrder(2);
+        augmenters.add(augmenter2);
+        augmenterConfig.setAugmenters(augmenters);
+    }
+
+    @Test
+    public void testGetAugmenterReturnsNullIfMissingAugmenterName() {
+        assertNull(augmenterConfig.getAugmenter("missing"));
+    }
+
+    @Test
+    public void testGetAugmenterReturnsCorrectAugmenter() {
+        assertEquals(augmenters.get(0), augmenterConfig.getAugmenter("aug1"));
+    }
+
+    @Test
+    public void testGetAugmenterNamesReturnsListOfNames() {
+        assertEquals(Arrays.asList("aug1", "aug2"), augmenterConfig.getAugmenterNames());
+    }
+}

--- a/openpos-persist/src/test/java/org/jumpmind/pos/persist/model/AugmenterConfigTest.java
+++ b/openpos-persist/src/test/java/org/jumpmind/pos/persist/model/AugmenterConfigTest.java
@@ -23,11 +23,9 @@ public class AugmenterConfigTest {
         augmenters = new ArrayList<>();
         AugmenterModel augmenter1 = new AugmenterModel();
         augmenter1.setName("aug1");
-        augmenter1.setOrder(1);
         augmenters.add(augmenter1);
         AugmenterModel augmenter2 = new AugmenterModel();
         augmenter2.setName("aug2");
-        augmenter2.setOrder(2);
         augmenters.add(augmenter2);
         augmenterConfig.setAugmenters(augmenters);
     }

--- a/openpos-persist/src/test/java/org/jumpmind/pos/persist/model/AugmenterConfigsTest.java
+++ b/openpos-persist/src/test/java/org/jumpmind/pos/persist/model/AugmenterConfigsTest.java
@@ -1,0 +1,76 @@
+package org.jumpmind.pos.persist.model;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class AugmenterConfigsTest {
+
+    private AugmenterConfigs augmenterConfigs;
+    private List<AugmenterConfig> configs;
+
+    @Before
+    public void setUp() throws Exception {
+        augmenterConfigs = new AugmenterConfigs();
+
+        configs = new ArrayList<>();
+        AugmenterConfig config1 = new AugmenterConfig();
+        config1.setName("options");
+        config1.setPrefix("OPTION_");
+        List<AugmenterModel> augmenters1 = new ArrayList<>();
+        AugmenterModel augmenter = new AugmenterModel();
+        augmenter.setName("size");
+        augmenters1.add(augmenter);
+        augmenter = new AugmenterModel();
+        augmenter.setName("style");
+        augmenters1.add(augmenter);
+        config1.setAugmenters(augmenters1);
+        configs.add(config1);
+        AugmenterConfig config2 = new AugmenterConfig();
+        config2.setName("classifiers");
+        config2.setPrefix("CLASSIFIER_");
+        List<AugmenterModel> augmenters2 = new ArrayList<>();
+        augmenter = new AugmenterModel();
+        augmenter.setName("department");
+        augmenters2.add(augmenter);
+        configs.add(config2);
+        augmenterConfigs.setConfigs(configs);
+    }
+
+    @Test
+    public void testGetConfigsNames() {
+        assertEquals(Arrays.asList("options", "classifiers"), augmenterConfigs.getConfigsNames());
+    }
+
+    @Test
+    public void testGetConfigsByNamesWhenNoNamesMatch() {
+        assertEquals(Collections.emptyList(), augmenterConfigs.getConfigsByNames("test", "test2"));
+    }
+
+    @Test
+    public void testGetConfigsByNamesWhenSingleNameMatches() {
+        assertEquals(Arrays.asList(configs.get(0)), augmenterConfigs.getConfigsByNames("test", "options"));
+    }
+
+    @Test
+    public void testGetConfigsByNamesWhenAllNamesMatch() {
+        assertEquals(Arrays.asList(configs.get(0), configs.get(1)), augmenterConfigs.getConfigsByNames("classifiers", "options"));
+    }
+
+    @Test
+    public void testGetConfigByNameReturnNullWhenNoMatchingName() {
+        assertNull(augmenterConfigs.getConfigByName("nothing"));
+    }
+
+    @Test
+    public void testGetConfigByNameReturnsMatchingConfig() {
+        assertEquals(configs.get(1), augmenterConfigs.getConfigByName("classifiers"));
+    }
+}

--- a/openpos-service/src/main/java/org/jumpmind/pos/service/AbstractRDBMSModule.java
+++ b/openpos-service/src/main/java/org/jumpmind/pos/service/AbstractRDBMSModule.java
@@ -11,6 +11,8 @@ import org.jumpmind.db.util.ConfigDatabaseUpgrader;
 import org.jumpmind.exception.IoException;
 import org.jumpmind.pos.persist.*;
 import org.jumpmind.pos.persist.driver.Driver;
+import org.jumpmind.pos.persist.model.AugmenterConfigs;
+import org.jumpmind.pos.persist.model.AugmenterHelper;
 import org.jumpmind.pos.persist.model.TagHelper;
 import org.jumpmind.pos.service.model.ModuleModel;
 import org.jumpmind.properties.TypedProperties;
@@ -42,7 +44,7 @@ import static org.jumpmind.db.util.BasicDataSourcePropertyConstants.*;
 import static org.jumpmind.pos.service.util.ClassUtils.getClassesForPackageAndAnnotation;
 
 @EnableTransactionManagement
-@DependsOn({"tagConfig"})
+@DependsOn({"tagConfig", "augmenterConfigs"})
 abstract public class AbstractRDBMSModule extends AbstractServiceFactory implements IModule, IRDBMSModule {
 
     protected final Logger log = LoggerFactory.getLogger(getClass());
@@ -60,6 +62,9 @@ abstract public class AbstractRDBMSModule extends AbstractServiceFactory impleme
 
     @Autowired
     protected TagHelper tagHelper;
+
+    @Autowired
+    protected AugmenterHelper augmenterHelper;
 
     @Autowired
     protected ApplicationContext applicationContext;
@@ -279,7 +284,7 @@ abstract public class AbstractRDBMSModule extends AbstractServiceFactory impleme
             sessionContext.put(DBSession.JDBC_FETCH_SIZE, env.getProperty(DBSession.JDBC_FETCH_SIZE));
             sessionContext.put(DBSession.JDBC_QUERY_TIMEOUT, env.getProperty(DBSession.JDBC_QUERY_TIMEOUT));
 
-            sessionFactory.init(getDatabasePlatform(), sessionContext, tableClasses, tableExtensionClasses, tagHelper);
+            sessionFactory.init(getDatabasePlatform(), sessionContext, tableClasses, tableExtensionClasses, tagHelper, augmenterHelper);
 
         }
 


### PR DESCRIPTION
Adding ability to configure optional columns and indexes using configuration.
- Adding new annotation _augmented_ which will define the table to be augmented with additional fields in the configuration.
- AugmenterConfigs defines the new columns and/or indexes for the table.
- DBSessionAugmenterTest shows an example of this feature being used.

Example configuration for commerce for augmented item table.

``` 
augmenterconfigs:
    configs:
      - name: itemoptions
        prefix: OPTION_
        augmenters:
          - name: size
            order: 0
          - name: color
            order: 1
          - name: style
            order: 2
        indexConfigs:
          - name: idx_item_aug_size
            columnNames:
              - size
          - name: idx_item_aug_size_color_type
            columnNames:
              - size
              - color
              - typeCode
```