### PR TITLE
remove the outjection of module data sources

### DIFF
--- a/openpos-devices/src/main/java/org/jumpmind/pos/devices/DevicesModule.java
+++ b/openpos-devices/src/main/java/org/jumpmind/pos/devices/DevicesModule.java
@@ -51,13 +51,7 @@ public class DevicesModule extends AbstractRDBMSModule {
         return super.securityService();
     }
 
-    @Override
-    @Bean(name = NAME + "DataSource")
-    public DataSource getDataSource() {
-        return super.getDataSource();
-    }
-
-    @Override
+@Override
     @Bean(name = NAME + "SessionFactory")
     protected DBSessionFactory sessionFactory() {
         return super.sessionFactory();

--- a/openpos-service/src/main/java/org/jumpmind/pos/service/AbstractRDBMSModule.java
+++ b/openpos-service/src/main/java/org/jumpmind/pos/service/AbstractRDBMSModule.java
@@ -83,6 +83,7 @@ abstract public class AbstractRDBMSModule extends AbstractServiceFactory impleme
     @Value("${openpos.general.failStartupOnModuleLoadFailure:false}")
     boolean failStartupOnModuleLoadFailure;
 
+    @Autowired(required = false)
     protected DataSource dataSource;
 
     protected ISecurityService securityService;

--- a/openpos-symds/src/main/java/org/jumpmind/pos/symds/SymDSModule.java
+++ b/openpos-symds/src/main/java/org/jumpmind/pos/symds/SymDSModule.java
@@ -209,13 +209,7 @@ public class SymDSModule extends AbstractRDBMSModule {
         return super.securityService();
     }
 
-    @Override
-    @Bean(name = NAME + "DataSource")
-    public DataSource getDataSource() {
-        return super.getDataSource();
-    }
-
-    @Override
+@Override
     @Bean(name = NAME + "SessionFactory")
     protected DBSessionFactory sessionFactory() {
         return super.sessionFactory();


### PR DESCRIPTION
this is to allow us to use spring boot's out of the box datasource which is required when accessing GCP deployed Postgres