### PR TITLE
Feature/add initForm event to DynamicFormComponent

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/dynamic-form-part/dynamic-form-part.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/dynamic-form-part/dynamic-form-part.component.ts
@@ -59,10 +59,12 @@ export class DynamicFormPartComponent extends ScreenPartComponent<IForm> impleme
         }
 
         this.form = this.formBuilder.group(this.screenData);
+
         this.formInit.emit({
             form: this.screenData,
             formGroup: this.form
         });
+
         this.form.valueChanges.subscribe(value => {
             this.formBuilder.buildFormPayload(this.form, this.screenData);
             this.formChanges.emit({

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/dynamic-form-part/dynamic-form-part.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/dynamic-form-part/dynamic-form-part.component.ts
@@ -25,6 +25,7 @@ import {IDynamicFormPartEventArg} from './dynamic-form-part-event-arg.interface'
     styleUrls: ['./dynamic-form-part.component.scss']
 })
 export class DynamicFormPartComponent extends ScreenPartComponent<IForm> implements AfterViewInit{
+    @Output() formInit = new EventEmitter<IDynamicFormPartEventArg>();
     @Output() formChanges = new EventEmitter<IDynamicFormPartEventArg>();
     @ViewChildren(DynamicFormFieldComponent) children: QueryList<DynamicFormFieldComponent>;
     @ViewChild('formErrors') formErrors: ShowErrorsComponent;
@@ -58,6 +59,10 @@ export class DynamicFormPartComponent extends ScreenPartComponent<IForm> impleme
         }
 
         this.form = this.formBuilder.group(this.screenData);
+        this.formInit.emit({
+            form: this.screenData,
+            formGroup: this.form
+        });
         this.form.valueChanges.subscribe(value => {
             this.formBuilder.buildFormPayload(this.form, this.screenData);
             this.formChanges.emit({


### PR DESCRIPTION
## Summary
Added `initForm` event to the `DynamicFormPartComponent`. This allows other components to do initialization logic like disabling form buttons based an initial incomplete form.

Currently this is used by this PR: https://github.com/JumpMind/commerce/pull/2252