### PR TITLE
Add ability to override states

### DIFF
--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/StateOverride.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/StateOverride.java
@@ -1,0 +1,12 @@
+package org.jumpmind.pos.core.flow;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface StateOverride {
+    public Class<? extends Object> originalState();
+}

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/config/YamlConfigConverter.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/config/YamlConfigConverter.java
@@ -11,13 +11,15 @@ import org.slf4j.LoggerFactory;
 
 
 public class YamlConfigConverter {
-    
+
     private static final Logger log = LoggerFactory.getLogger(YamlConfigConverter.class);
-    
+
     private static Map<String, Class<Object>> knownFlowClasses;
 
     private static Map<String, Class<Object>> knownOnEventClasses;
-    
+
+    private static Map<String, Class<Object>> overrideClassMap;
+
     private final static String GLOBAL_CONFIG = "Global";
 
     private List<String> additionalPackages;
@@ -33,31 +35,31 @@ public class YamlConfigConverter {
         FlowConfig flowConfig = convertFlowConfig(loadedYamlFlowConfigs, yamlFlowConfig);
         return flowConfig;
     }
-    
+
     public List<FlowConfig> convertToFlowConfig(List<YamlFlowConfig> yamlFlowConfigs) {
         List<FlowConfig> flowConfigs = new ArrayList<FlowConfig>();
-        
-        for (YamlFlowConfig yamlFlowConfig : yamlFlowConfigs) {            
+
+        for (YamlFlowConfig yamlFlowConfig : yamlFlowConfigs) {
             FlowConfig flowConfig = convertFlowConfig(yamlFlowConfigs, yamlFlowConfig);
             flowConfigs.add(flowConfig);
         }
-        
+
         return flowConfigs;
     }
-    
+
     public List<FlowConfig> convertFlowConfigs(List<YamlFlowConfig> loadedYamlFlowConfigs, List<YamlFlowConfig> yamlFlowConfigs) {
         List<FlowConfig> flowConfigs = new ArrayList<FlowConfig>();
         for (YamlFlowConfig yamlFlowConfig : yamlFlowConfigs) {
             flowConfigs.add(convertFlowConfig(loadedYamlFlowConfigs, yamlFlowConfig));
         }
-        
+
         return flowConfigs;
     }
 
     private FlowConfig convertFlowConfig(List<YamlFlowConfig> yamlFlowConfigs, YamlFlowConfig yamlFlowConfig) {
         FlowConfig flowConfig = new FlowConfig(yamlFlowConfig.getFlowName());
 
-        yamlFlowConfig.getGlobalEventHandlers().forEach((s)->{
+        yamlFlowConfig.getGlobalEventHandlers().forEach((s) -> {
             Class<?> clazz = resolveOnEventClass(s);
             if (clazz != null) {
                 flowConfig.addEventHandler(clazz);
@@ -65,17 +67,17 @@ public class YamlConfigConverter {
                 log.error("A global event handler was defined as {} but no matching class could be found", s);
             }
         });
-        
+
         Map<String, YamlStateConfig> concreteStateConfigs = getConcreteStateConfigs(yamlFlowConfig);
-        
+
         boolean initialState = true;
-        
+
         for (String stateName : concreteStateConfigs.keySet()) {
             if (GLOBAL_CONFIG.equalsIgnoreCase(stateName)) {
                 handleGlobalConfig(flowConfig, yamlFlowConfigs, concreteStateConfigs.get(stateName));
                 continue;
             }
-            
+
             StateConfig stateConfig = buildStateConfig(yamlFlowConfigs, concreteStateConfigs.get(stateName));
             if (initialState) {
                 flowConfig.setInitialState(stateConfig);
@@ -83,25 +85,25 @@ public class YamlConfigConverter {
             }
             flowConfig.add(stateConfig);
         }
-        
+
         return flowConfig;
     }
-    
+
     protected StateConfig buildStateConfig(List<YamlFlowConfig> yamlFlowConfigs, YamlStateConfig yamlStateConfig) {
         StateConfig stateConfig = new StateConfig();
         stateConfig.setStateName(yamlStateConfig.getStateName());
-        
+
         Class<? extends Object> stateClass = resolveFlowClass(yamlStateConfig.getStateName(), true);
-        
+
         if (stateClass != null) {
             stateConfig.setStateClass(resolveFlowClass(yamlStateConfig.getStateName(), true));
         } else {
             throw new FlowException("Failed to resolve state for name: \"" + yamlStateConfig.getStateName() +
-                    "\". Check that a class named \"" + stateConfig.getStateName() +"\" exists and that it has an @OnArrive method, " +
+                    "\". Check that a class named \"" + stateConfig.getStateName() + "\" exists and that it has an @OnArrive method, " +
                     "AND that it is under one of the following packages: org.jumpmind.pos " +
-                    (!CollectionUtils.isEmpty(additionalPackages) ? " OR "+additionalPackages : ""));
+                    (!CollectionUtils.isEmpty(additionalPackages) ? " OR " + additionalPackages : ""));
         }
-        
+
         stateConfig.setActionToStateMapping(buildActionToStateMapping(yamlFlowConfigs, yamlStateConfig));
         stateConfig.setActionToSubStateMapping(buildActionToSubStateMapping(yamlFlowConfigs, yamlStateConfig));
         return stateConfig;
@@ -112,7 +114,7 @@ public class YamlConfigConverter {
         for (String actionName : actionToStateMapping.keySet()) {
             flowConfig.addGlobalTransitionOrActionHandler(actionName, actionToStateMapping.get(actionName));
         }
-        
+
         Map<String, SubFlowConfig> actionToSubStateMapping = buildActionToSubStateMapping(yamlFlowConfigs, yamlStateConfig);
         for (String actionName : actionToSubStateMapping.keySet()) {
             FlowConfig subFlowConfig = actionToSubStateMapping.get(actionName).getSubFlowConfig();
@@ -122,30 +124,30 @@ public class YamlConfigConverter {
 
     protected Map<String, Class<? extends Object>> buildActionToStateMapping(List<YamlFlowConfig> yamlFlowConfigs, YamlStateConfig yamlStateConfig) {
         Map<String, Class<? extends Object>> actionToStateMapping = new LinkedHashMap<>();
-        
+
         for (String actionName : yamlStateConfig.getActionToStateConfigs().keySet()) {
             YamlStateConfig stateConfig = yamlStateConfig.getActionToStateConfigs().get(actionName);
             if (!stateConfig.isSubTransition()) {
                 Class<? extends Object> stateClass = resolveFlowClass(stateConfig.getStateName(), true);
-                
-                if (stateClass != null) {                    
+
+                if (stateClass != null) {
                     actionToStateMapping.put(actionName, stateClass);
-                } else {                    
+                } else {
                     throw new FlowException("Failed to resolve state for name: \"" + stateConfig.getStateName() +
-                            "\". Check that a class named \"" + stateConfig.getStateName() +"\" exists and that it has an @OnArrive method, " +
+                            "\". Check that a class named \"" + stateConfig.getStateName() + "\" exists and that it has an @OnArrive method, " +
                             "AND that it is under one of the following packages: org.jumpmind.pos " +
-                            (!CollectionUtils.isEmpty(additionalPackages) ? " OR "+additionalPackages : ""));
+                            (!CollectionUtils.isEmpty(additionalPackages) ? " OR " + additionalPackages : ""));
                 }
             }
         }
-        
+
         return actionToStateMapping;
     }
-    
+
     @SuppressWarnings("all")
     protected Map<String, SubFlowConfig> buildActionToSubStateMapping(List<YamlFlowConfig> yamlFlowConfigs, YamlStateConfig yamlStateConfig) {
         Map<String, SubFlowConfig> actionToSubStateMapping = new LinkedHashMap<>();
-        
+
         for (String actionName : yamlStateConfig.getActionToStateConfigs().keySet()) {
             YamlStateConfig stateConfig = yamlStateConfig.getActionToStateConfigs().get(actionName);
             if (stateConfig.isSubTransition()) {
@@ -153,7 +155,7 @@ public class YamlConfigConverter {
                 actionToSubStateMapping.put(actionName, subFlowConfig);
             }
         }
-        
+
         return actionToSubStateMapping;
     }
 
@@ -179,9 +181,9 @@ public class YamlConfigConverter {
             subFlowConfig.setSubFlowConfig(flowConfig);
         }
 
-        subFlowConfig.setReturnActionNames(stateConfig.getReturnActions().toArray(new String[] {}));
+        subFlowConfig.setReturnActionNames(stateConfig.getReturnActions().toArray(new String[]{}));
 
-        subFlowConfig.getSubFlowConfig().setConfigScope((Map)stateConfig.getConfigScope());
+        subFlowConfig.getSubFlowConfig().setConfigScope((Map) stateConfig.getConfigScope());
 
         return subFlowConfig;
 
@@ -194,31 +196,51 @@ public class YamlConfigConverter {
 
     @SuppressWarnings("rawtypes")
     protected Class<? extends Object> resolveFlowClass(String name, boolean allowGlobalActionHandler) {
-        
+
         if (knownFlowClasses == null) {
             List<Class<Object>> knownFlowClassList = ClassUtils.getClassesForPackageAndType("org.jumpmind.pos", Object.class);
-            if(additionalPackages != null) {
-                additionalPackages.forEach( p -> knownFlowClassList.addAll( ClassUtils.getClassesForPackageAndType( p, Object.class)));
+            if (additionalPackages != null) {
+                additionalPackages.forEach(p -> knownFlowClassList.addAll(ClassUtils.getClassesForPackageAndType(p, Object.class)));
             }
 
             knownFlowClasses = knownFlowClassList.stream()
                     .filter(clazz -> filterStateClass(clazz, allowGlobalActionHandler))
-                    .collect(Collectors.toMap(e -> ((Class)e).getSimpleName(), v -> v) );
+                    .collect(Collectors.toMap(e -> ((Class) e).getSimpleName(), v -> v));
         }
-        
-        return knownFlowClasses.get(name);
+
+        updateOverrideClasses();
+
+        Class<? extends Object> stateClass = knownFlowClasses.get(name);
+        if (overrideClassMap.get(name) != null) {
+            stateClass = overrideClassMap.get(name);
+        }
+        return stateClass;
+    }
+
+    private void updateOverrideClasses() {
+        if (overrideClassMap == null) {
+            List<Class<? extends Object>> overrides = ClassUtils.getClassesForPackageAndAnnotation("org.jumpmind.pos", StateOverride.class);
+            if (additionalPackages != null) {
+                additionalPackages.forEach(p -> overrides.addAll(ClassUtils.getClassesForPackageAndAnnotation(p, StateOverride.class)));
+            }
+
+            overrideClassMap = overrides.stream()
+                    .collect(Collectors.toMap(
+                            e -> e.getAnnotation(StateOverride.class).originalState().getSimpleName(),
+                            v -> (Class<Object>) v));
+        }
     }
 
     protected Class<? extends Object> resolveOnEventClass(String simpleClassName) {
         if (knownOnEventClasses == null) {
             List<Class<Object>> knownOnEventClassesList = ClassUtils.getClassesForPackageAndType("org.jumpmind.pos", Object.class);
-            if(additionalPackages != null) {
-                additionalPackages.forEach( p -> knownOnEventClassesList.addAll( ClassUtils.getClassesForPackageAndType( p, Object.class)));
+            if (additionalPackages != null) {
+                additionalPackages.forEach(p -> knownOnEventClassesList.addAll(ClassUtils.getClassesForPackageAndType(p, Object.class)));
             }
 
             knownOnEventClasses = knownOnEventClassesList.stream()
                     .filter(clazz -> FlowUtil.isEventHandler(clazz))
-                    .collect(Collectors.toMap(e -> ((Class)e).getSimpleName(), v -> v) );
+                    .collect(Collectors.toMap(e -> ((Class) e).getSimpleName(), v -> v));
         }
 
         return knownOnEventClasses.get(simpleClassName);
@@ -237,15 +259,15 @@ public class YamlConfigConverter {
 
         Map<String, YamlStateConfig> concreteStateConfigs = new LinkedHashMap<String, YamlStateConfig>();
 
-        for (YamlStateConfig yamlStateConfig : yamlFlowConfig.getFlowStateConfigs()) {            
+        for (YamlStateConfig yamlStateConfig : yamlFlowConfig.getFlowStateConfigs()) {
             getConcreteStateConfigs(concreteStateConfigs, yamlStateConfig);
         }
-        
+
         return concreteStateConfigs;
     }
 
-    protected void getConcreteStateConfigs(Map<String, YamlStateConfig> concreteStateConfigs, 
-            YamlStateConfig yamlStateConfig) {
+    protected void getConcreteStateConfigs(Map<String, YamlStateConfig> concreteStateConfigs,
+                                           YamlStateConfig yamlStateConfig) {
         if (yamlStateConfig.isConcreteStateDefinition()) {
             if (!concreteStateConfigs.containsKey(yamlStateConfig.getStateName())) {
                 concreteStateConfigs.put(yamlStateConfig.getStateName(), yamlStateConfig);
@@ -253,7 +275,7 @@ public class YamlConfigConverter {
                     getConcreteStateConfigs(concreteStateConfigs, targetState);
                 }
             } else {
-                if (!concreteStateConfigs.containsValue(yamlStateConfig)) {                    
+                if (!concreteStateConfigs.containsValue(yamlStateConfig)) {
                     throw new FlowException(String.format("State \"%s\"is defined conceretely (with actions) more than once. This is not currently supported. ", yamlStateConfig.getStateName()));
                 }
             }

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/config/YamlConfigConverter.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/config/YamlConfigConverter.java
@@ -211,8 +211,9 @@ public class YamlConfigConverter {
         updateOverrideClasses();
 
         Class<? extends Object> stateClass = knownFlowClasses.get(name);
-        if (overrideClassMap.get(name) != null) {
-            stateClass = overrideClassMap.get(name);
+        Class<? extends Object> overrideClass = overrideClassMap.get(name);
+        if (overrideClass != null) {
+            stateClass = overrideClass;
         }
         return stateClass;
     }
@@ -227,7 +228,13 @@ public class YamlConfigConverter {
             overrideClassMap = overrides.stream()
                     .collect(Collectors.toMap(
                             e -> e.getAnnotation(StateOverride.class).originalState().getSimpleName(),
-                            v -> (Class<Object>) v));
+                            v -> (Class<Object>) v)
+                    );
+
+            if (overrideClassMap != null) {
+                overrideClassMap.forEach((k, v) ->
+                        log.info("Overriding original state: {} with new state: {}", k, v.getSimpleName()));
+            }
         }
     }
 

--- a/openpos-flow/src/test/java/org/jumpmind/pos/core/flow/config/YamlConfigProviderTest.java
+++ b/openpos-flow/src/test/java/org/jumpmind/pos/core/flow/config/YamlConfigProviderTest.java
@@ -3,7 +3,7 @@ package org.jumpmind.pos.core.flow.config;
 import org.jumpmind.pos.core.flow.TestStates;
 import org.junit.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class YamlConfigProviderTest {
     
@@ -26,5 +26,15 @@ public class YamlConfigProviderTest {
 
         assertTrue(config.getStateConfig(YamlTestStates.FirstLevelState.class).getActionToStateMapping().containsKey("AddedAction"));
         assertTrue(config.getStateConfig(TestStates.StateAddedThroughFlowExtension.class) != null);
+    }
+
+    @Test
+    public void testOverrideFlow() {
+        YamlConfigProvider provider = new YamlConfigProvider();
+        provider.load("pos", "testflows");
+
+        FlowConfig config = provider.getConfigByName("pos", "11111", "TestFlow");
+        assertEquals("StateToOverride", config.getStateConfig(YamlTestStates.OverrideState.class).getStateName());
+        assertNull(config.getStateConfig(YamlTestStates.StateToOverride.class));
     }
 }

--- a/openpos-flow/src/test/java/org/jumpmind/pos/core/flow/config/YamlTestStates.java
+++ b/openpos-flow/src/test/java/org/jumpmind/pos/core/flow/config/YamlTestStates.java
@@ -1,6 +1,8 @@
 package org.jumpmind.pos.core.flow.config;
 
 import org.jumpmind.pos.core.flow.IState;
+import org.jumpmind.pos.core.flow.OnArrive;
+import org.jumpmind.pos.core.flow.StateOverride;
 import org.jumpmind.pos.server.model.Action;
 
 public class YamlTestStates {
@@ -52,5 +54,18 @@ public class YamlTestStates {
         public void arrive(Action action) {
         }
     }
+    public static class StateToOverride {
+        @OnArrive
+        public void arrive(){
+        }
+    }
+
+    @StateOverride(originalState = StateToOverride.class)
+    public static class OverrideState {
+        @OnArrive
+        public void arrive(){
+        }
+    }
+
 
 }

--- a/openpos-flow/src/test/resources/testflows/test-flow.yml
+++ b/openpos-flow/src/test/resources/testflows/test-flow.yml
@@ -10,7 +10,8 @@ TestFlow:
         InlineState2:
           GotoNestedState: 
             NestedState:
-              Back: InitialState              
+              Back: InitialState
+      Override: StateToOverride
       GotoSubstateClass: {subflow: SubstateClassTestState, ReturnAction: SubstateClassReturnAction, 
                          ConfigScope: {testKey1: value1, testKey2: value2}}
       GotoSubstateFlow: {subflow: SubstateFlow, ReturnAction: SubstateFlowReturnAction}
@@ -22,6 +23,9 @@ TestFlow:
       GotoSubstateClass: {subflow: SubstateClassTestState, ReturnActions: SubstateClassReturnAction;SomeOtherAction,
                          ConfigScope: {testKey3: value3, testKey4: value4}}
       GotoSubstateFlow: {subflow: SubstateFlow, ReturnAction: SubstateFlowReturnAction}
+
+  - StateToOverride:
+     Back: InitialState
 
   - Global:
       BackToMain: InitialState


### PR DESCRIPTION
## Summary
Add an annotation interface that allows you to override a State.  For example, using the code below, any instance of the StateToOverride state in the yml flows would be map to the OverrideState class instead:

```
    // This state will not get used
    public static class StateToOverride {
        @OnArrive
        public void arrive(){
        }
    }

    // This state will be used in place of StateToOverride in all flows
    @StateOverride(originalState = StateToOverride.class)
    public static class OverrideState {
        @OnArrive
        public void arrive(){
        }
    }
```
