### PR TITLE
Improve the management of sql & csv scripts

### DIFF
--- a/openpos-client-libs/package-lock.json
+++ b/openpos-client-libs/package-lock.json
@@ -2070,7 +2070,8 @@
     "boolean": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.1.tgz",
-      "integrity": "sha512-HRZPIjPcbwAVQvOTxR4YE3o8Xs98NqbbL1iEZDCz7CL8ql0Lt5iOyJFxfnAB0oFs8Oh02F/lLlg30Mexv46LjA=="
+      "integrity": "sha512-HRZPIjPcbwAVQvOTxR4YE3o8Xs98NqbbL1iEZDCz7CL8ql0Lt5iOyJFxfnAB0oFs8Oh02F/lLlg30Mexv46LjA==",
+      "optional": true
     },
     "boxen": {
       "version": "1.3.0",
@@ -4431,7 +4432,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4452,12 +4454,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4472,17 +4476,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4599,7 +4606,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4611,6 +4619,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4625,6 +4634,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4632,12 +4642,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4656,6 +4668,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4736,7 +4749,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4748,6 +4762,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4833,7 +4848,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4869,6 +4885,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4888,6 +4905,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4931,12 +4949,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/DBSession.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/DBSession.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 
 import javax.sql.DataSource;
 
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -48,6 +49,7 @@ public class DBSession {
     public static final String JDBC_FETCH_SIZE = "openpos.jdbc.fetchSize";
 
     private DatabaseSchema databaseSchema;
+    @Getter
     private IDatabasePlatform databasePlatform;
     private TypedProperties sessionContext;
     private NamedParameterJdbcTemplate jdbcTemplate;

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/DatabaseScript.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/DatabaseScript.java
@@ -20,8 +20,13 @@
  */
 package org.jumpmind.pos.persist;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.core.io.Resource;
 
+@Getter
+@NoArgsConstructor
 public class DatabaseScript implements Comparable<DatabaseScript> {
 	private int major;
 	private int minor;
@@ -30,7 +35,6 @@ public class DatabaseScript implements Comparable<DatabaseScript> {
 	private int when;
 	private int order;
 	private String description;
-	
 	private Resource resource;
 	
 	public final static String DELIMITER_MAIN = "_";
@@ -41,11 +45,9 @@ public class DatabaseScript implements Comparable<DatabaseScript> {
 	public final static int WHEN_POSTINSTALL = 2;
 	
 	
-	public DatabaseScript(String fileName) {
-		parse(fileName);
-	}
-	
-	public DatabaseScript() {
+	public DatabaseScript(Resource resource) {
+		this.resource = resource;
+		parse(resource.getFilename());
 	}
 	
 	public void parse(String fileName) {
@@ -159,37 +161,5 @@ public class DatabaseScript implements Comparable<DatabaseScript> {
 			this.description = parts[0];
 		}
 	}
-	
-	public void setResource(Resource resource) {
-        this.resource = resource;
-    }
-	
-	public int getMajor() {
-		return major;
-	}
 
-	public int getMinor() {
-		return minor;
-	}
-
-	public int getBuild() {
-		return build;
-	}
-	
-	public int getWhen() {
-		return when;
-	}
-	
-	public int getOrder() {
-		return order;
-	}
-	
-	public String getDescription() {
-		return description;
-	}
-	
-	public Resource getResource() {
-		return resource;
-	}
-	
 }

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/DatabaseScriptContainer.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/DatabaseScriptContainer.java
@@ -166,9 +166,8 @@ public class DatabaseScriptContainer {
     void loadCsv(DatabaseScript script, Resource resource, boolean failOnError) throws IOException {
         try (InputStream is = resource.getInputStream()) {
             String tableName = script.getDescription().replaceAll("-", "_");
-            Table table = platform.getTableFromCache(tableName, false);
-            String truncateSql = platform.getTruncateSql(table);
-            jdbcTemplate.execute(truncateSql);
+            // delete versus truncate so symds syncs deletes
+            jdbcTemplate.execute(String.format("delete from %s", tableName));
             DbImport importer = new DbImport(platform);
             importer.setFormat(DbImport.Format.CSV);
             importer.setCommitRate(1000);

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/DatabaseScriptContainer.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/DatabaseScriptContainer.java
@@ -1,26 +1,14 @@
 package org.jumpmind.pos.persist;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.net.URL;
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.jumpmind.db.model.Table;
 import org.jumpmind.db.platform.IDatabasePlatform;
 import org.jumpmind.db.platform.h2.H2DatabasePlatform;
 import org.jumpmind.db.platform.oracle.OracleDatabasePlatform;
 import org.jumpmind.db.sql.ISqlTemplate;
 import org.jumpmind.db.sql.SqlScript;
 import org.jumpmind.exception.IoException;
+import org.jumpmind.pos.persist.model.ScriptVersionModel;
 import org.jumpmind.symmetric.io.data.DbImport;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.Resource;
@@ -28,10 +16,19 @@ import org.springframework.core.io.support.ResourcePatternUtils;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.ConnectionCallback;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.util.DigestUtils;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.*;
+
+@Slf4j
 public class DatabaseScriptContainer {
-    protected final Log logger = LogFactory.getLog(getClass());
-
     final static String IMPORT_PREFIX = "-- import:";
 
     private List<DatabaseScript> preInstallScripts = new ArrayList<DatabaseScript>();
@@ -39,30 +36,33 @@ public class DatabaseScriptContainer {
 
     private JdbcTemplate jdbcTemplate;
     private IDatabasePlatform platform;
-
+    private DBSession dbSession;
+    private String installationId;
     private Map<String, String> replacementTokens;
 
-    private String scriptLocation;
+    private List<String> scriptLocations;
 
-    public DatabaseScriptContainer(String scriptLocation, IDatabasePlatform platform) {
+    public DatabaseScriptContainer(List<String> scriptLocations, DBSession dbSession, String installationId) {
         try {
-            this.scriptLocation = scriptLocation;
-            this.platform = platform;
+            this.installationId = installationId;
+            this.dbSession = dbSession;
+            this.scriptLocations = scriptLocations;
+            this.platform = dbSession.getDatabasePlatform();
             this.jdbcTemplate = new JdbcTemplate(platform.getDataSource());
 
             replacementTokens = new HashMap<String, String>();
             // Add any replacement tokens
 
-            Resource[] resources = ResourcePatternUtils.getResourcePatternResolver(new DefaultResourceLoader())
-                    .getResources(String.format("classpath*:%s/*.*", scriptLocation));
-            for (Resource r : resources) {
-                DatabaseScript script = new DatabaseScript(r.getFilename());
-                script.setResource(r);
-
-                if (script.getWhen() == DatabaseScript.WHEN_PREINSTALL) {
-                    preInstallScripts.add(script);
-                } else if (script.getWhen() == DatabaseScript.WHEN_POSTINSTALL) {
-                    postInstallScripts.add(script);
+            for (String scriptLocation : scriptLocations) {
+                Resource[] resources = ResourcePatternUtils.getResourcePatternResolver(new DefaultResourceLoader())
+                        .getResources(String.format("classpath*:%s/*.*", scriptLocation));
+                for (Resource r : resources) {
+                    DatabaseScript script = new DatabaseScript(r);
+                    if (script.getWhen() == DatabaseScript.WHEN_PREINSTALL) {
+                        preInstallScripts.add(script);
+                    } else if (script.getWhen() == DatabaseScript.WHEN_POSTINSTALL) {
+                        postInstallScripts.add(script);
+                    }
                 }
             }
         } catch (IOException e) {
@@ -70,28 +70,42 @@ public class DatabaseScriptContainer {
         }
     }
 
-    public void executePreInstallScripts(String fromVersion, String toVersion, boolean failOnError) {
-        executeScripts(fromVersion, toVersion, this.preInstallScripts, failOnError);
+    public void executePreInstallScripts(boolean failOnError) {
+        executeScripts(this.preInstallScripts, failOnError);
     }
 
-    public void executePostInstallScripts(String fromVersion, String toVersion, boolean failOnError) {
-        executeScripts(fromVersion, toVersion, this.postInstallScripts, failOnError);
+    public void executePostInstallScripts(boolean failOnError) {
+        executeScripts(this.postInstallScripts, failOnError);
     }
 
-    public void executeScripts(String fromVersion, String toVersion, List<DatabaseScript> scripts, boolean failOnError) {
+    public void executeScripts(List<DatabaseScript> scripts, boolean failOnError) {
         if (scripts != null) {
             Collections.sort(scripts);
-            DatabaseScript from = new DatabaseScript();
-            from.parseVersion(fromVersion);
-
-            DatabaseScript to = new DatabaseScript();
-            to.parseVersion(toVersion);
-
             for (DatabaseScript s : scripts) {
-                if (isDatabaseMatch(s) && ((s.compareVersionTo(from) > 0 && s.compareVersionTo(to) <= 0) || s.getMajor() == 999)) {
+                boolean executeScript = false;
+                ScriptVersionModel version = dbSession.findByNaturalId(ScriptVersionModel.class, new ModelId("installationId", installationId, "fileName", s.getResource().getFilename()));
+                String md5Hash = null;
+                try (InputStream is = s.getResource().getInputStream()) {
+                    md5Hash = DigestUtils.md5DigestAsHex(is);
+                } catch (IOException ex) {
+                    throw new IoException(ex);
+                }
+                if (version == null) {
+                    log.info("Running {} for the first time", s.getResource().getFilename());
+                    executeScript = true;
+                } else if (!md5Hash.equals(version.getCheckSum())) {
+                    log.info("Running {} again because the content changed", s.getResource().getFilename());
+                    executeScript = true;
+
+                }
+                if (isDatabaseMatch(s) && executeScript) {
                     try {
                         executeImports(s, s.getResource(), failOnError);
                         execute(s, s.getResource(), failOnError);
+                        dbSession.save(ScriptVersionModel.builder().
+                                installationId(installationId).
+                                fileName(s.getResource().getFilename()).
+                                checkSum(md5Hash).build());
                     } catch (IOException e) {
                         throw new RuntimeException(e);
                     }
@@ -100,7 +114,7 @@ public class DatabaseScriptContainer {
         }
     }
 
-    protected void executeImports(DatabaseScript databaseScript, Resource resource, boolean failOnError) throws IOException {
+    void executeImports(DatabaseScript databaseScript, Resource resource, boolean failOnError) throws IOException {
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(resource.getInputStream()))) {
 
             String line = reader.readLine();
@@ -108,7 +122,7 @@ public class DatabaseScriptContainer {
                 if (line.startsWith(IMPORT_PREFIX)) {
                     String file = line.substring(IMPORT_PREFIX.length()).trim();
                     Resource[] resources = ResourcePatternUtils.getResourcePatternResolver(new DefaultResourceLoader())
-                            .getResources(String.format("classpath*:%s/%s", scriptLocation, file));
+                            .getResources(String.format("classpath*:%s", file));
                     for (Resource resource2 : resources) {
                         execute(databaseScript, resource2, failOnError);
                     }
@@ -118,7 +132,7 @@ public class DatabaseScriptContainer {
         }
     }
 
-    public void execute(DatabaseScript databaseScript, final Resource resource, boolean failOnError) throws IOException {
+    void execute(DatabaseScript databaseScript, final Resource resource, boolean failOnError) throws IOException {
         String compareString = resource.getFilename().toLowerCase();
         if (compareString.endsWith(".sql")) {
             loadSql(resource.getURL(), failOnError);
@@ -128,7 +142,6 @@ public class DatabaseScriptContainer {
     }
 
     void loadSql(URL script, boolean failOnError) {
-        logger.info("Executing script " + script.toString());
         jdbcTemplate.execute(new ConnectionCallback<Object>() {
             public Object doInConnection(Connection c) throws SQLException, DataAccessException {
                 ISqlTemplate template = platform.getSqlTemplate();
@@ -143,7 +156,7 @@ public class DatabaseScriptContainer {
                     if (failOnError) {
                         throw new SQLException(message, ex);
                     }
-                    logger.warn(message, ex);
+                    log.warn(message, ex);
                 }
                 return null;
             }
@@ -151,18 +164,21 @@ public class DatabaseScriptContainer {
     }
 
     void loadCsv(DatabaseScript script, Resource resource, boolean failOnError) throws IOException {
-        logger.info("Loading file " + script.toString());
         try (InputStream is = resource.getInputStream()) {
+            String tableName = script.getDescription().replaceAll("-", "_");
+            Table table = platform.getTableFromCache(tableName, false);
+            String truncateSql = platform.getTruncateSql(table);
+            jdbcTemplate.execute(truncateSql);
             DbImport importer = new DbImport(platform);
             importer.setFormat(DbImport.Format.CSV);
             importer.setCommitRate(1000);
             importer.setForceImport(!failOnError);
             importer.setAlterCaseToMatchDatabaseDefaultCase(true);
-            importer.importTables(is, script.getDescription().replaceAll("-", "_"));
+            importer.importTables(is, tableName);
         }
     }
 
-    public boolean isDatabaseMatch(DatabaseScript script) {
+    boolean isDatabaseMatch(DatabaseScript script) {
         if (script.getDescription().equals("H2Only")) {
             return platform instanceof H2DatabasePlatform;
         } else if (script.getDescription().equals("OracleOnly")) {

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/ScriptVersionModel.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/ScriptVersionModel.java
@@ -1,0 +1,30 @@
+package org.jumpmind.pos.persist.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.jumpmind.pos.persist.AbstractModel;
+import org.jumpmind.pos.persist.ColumnDef;
+import org.jumpmind.pos.persist.TableDef;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@TableDef(name="script_version", description="This table is used to track runtime information about scripts that have been applied",
+        primaryKey={"installationId","fileName"})
+public class ScriptVersionModel extends AbstractModel {
+
+    private static final long serialVersionUID = 1L;
+
+    @ColumnDef
+    String installationId;
+
+    @ColumnDef
+    String fileName;
+
+    @ColumnDef
+    String checkSum;
+
+}

--- a/openpos-persist/src/test/java/org/jumpmind/pos/persist/cars/TestPersistCarsConfig.java
+++ b/openpos-persist/src/test/java/org/jumpmind/pos/persist/cars/TestPersistCarsConfig.java
@@ -98,15 +98,10 @@ public class TestPersistCarsConfig {
     }
     
     public void updateDataModel(DBSession session) {
-        String fromVersion = null;
-
-        DatabaseScriptContainer scripts = new DatabaseScriptContainer("persist-test/sql", PersistTestUtil.testDbPlatform());
-
-        scripts.executePreInstallScripts(fromVersion, "0.0.1", true);
-
+        DatabaseScriptContainer scripts = new DatabaseScriptContainer(Arrays.asList("persist-test/sql"), session, "test");
+        scripts.executePreInstallScripts(true);
         sessionFactory.createAndUpgrade();
-
-        scripts.executePostInstallScripts(fromVersion, "0.0.1", true);
+        scripts.executePostInstallScripts(true);
     }
 
 

--- a/openpos-persist/src/test/java/org/jumpmind/pos/persist/cars/TestPersistCarsConfig.java
+++ b/openpos-persist/src/test/java/org/jumpmind/pos/persist/cars/TestPersistCarsConfig.java
@@ -80,7 +80,7 @@ public class TestPersistCarsConfig {
             sessionFactory.init(
                     PersistTestUtil.testDbPlatform(), 
                     PersistTestUtil.getSessionContext(), 
-                    Arrays.asList(CarModel.class, CarStats.class, ServiceInvoice.class, RaceCarModel.class, AugmentedCarModel.class),
+                    Arrays.asList(CarModel.class, CarStats.class, ServiceInvoice.class, RaceCarModel.class, AugmentedCarModel.class, ScriptVersionModel.class),
                     Arrays.asList(CarModelExtension.class),
                     queryTemplates,
                     DBSessionFactory.getDmlTemplates("persist-test"),

--- a/openpos-service/src/main/java/org/jumpmind/pos/service/AbstractRDBMSModule.java
+++ b/openpos-service/src/main/java/org/jumpmind/pos/service/AbstractRDBMSModule.java
@@ -39,7 +39,10 @@ import javax.sql.DataSource;
 import java.io.*;
 import java.net.URL;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.jumpmind.db.util.BasicDataSourcePropertyConstants.*;
 import static org.jumpmind.pos.service.util.ClassUtils.getClassesForPackageAndAnnotation;
@@ -78,7 +81,8 @@ abstract public class AbstractRDBMSModule extends AbstractServiceFactory impleme
     @Value("${openpos.general.datasourceBeanName:#{null}}")
     protected String dataSourceBeanName;
 
-    @Value("${openpos.general.sqlScriptProfile:test}")
+    @Deprecated
+    @Value("${openpos.general.sqlScriptProfile:not set}")
     protected String sqlScriptProfile;
 
     @Value("${openpos.general.dataModelExtensionPackages:#{null}}")
@@ -355,26 +359,32 @@ abstract public class AbstractRDBMSModule extends AbstractServiceFactory impleme
         }
 
         String currentVersion = getVersion();
-        log.info("The previous version of {} was {} and the current version is {}. sqlScriptProfile: {}", getName(),
-                fromVersion, currentVersion, sqlScriptProfile);
-        DatabaseScriptContainer scripts = new DatabaseScriptContainer(String.format("%s/sql/%s", getName(), sqlScriptProfile),
-                getDatabasePlatform());
+        log.info("The previous version of {} was {} and the current version is {}", getName(),
+                fromVersion, currentVersion);
+
+        List<String> profiles = new ArrayList(Arrays.asList(env.getActiveProfiles()));
+        if (sqlScriptProfile != null && !sqlScriptProfile.equals("not set") &&
+                !profiles.contains(sqlScriptProfile)) {
+            profiles.add(sqlScriptProfile);
+        }
+
+        List<String> scriptLocations = profiles.stream().map(p->String.format("%s/sql/%s", getName(), p)).collect(Collectors.toList());
+        DatabaseScriptContainer scripts = new DatabaseScriptContainer(scriptLocations,
+                getDBSession(), installationId);
         IDBSchemaListener schemaListener = getDbSchemaListener();
 
-        scripts.executePreInstallScripts(fromVersion, currentVersion, failStartupOnModuleLoadFailure);
+        scripts.executePreInstallScripts(failStartupOnModuleLoadFailure);
         schemaListener.beforeSchemaCreate(sessionFactory);
         sessionFactory.createAndUpgrade();
         upgradeDbFromXml();
         schemaListener.afterSchemaCreate(sessionFactory);
-        scripts.executePostInstallScripts(fromVersion, currentVersion, failStartupOnModuleLoadFailure);
+        scripts.executePostInstallScripts(failStartupOnModuleLoadFailure);
 
         ModuleModel moduleModel = session.findByNaturalId(ModuleModel.class, installationId);
         if (moduleModel == null) {
             moduleModel = new ModuleModel(installationId, currentVersion);
-        } else {
-            if (!moduleModel.getCurrentVersion().equals(currentVersion)) {
-                moduleModel.setCurrentVersion(currentVersion);
-            }
+        } else if (!moduleModel.getCurrentVersion().equals(currentVersion)) {
+            moduleModel.setCurrentVersion(currentVersion);
         }
         session.save(moduleModel);
     }

--- a/openpos-service/src/main/java/org/jumpmind/pos/service/EndpointDispatchInvocationHandler.java
+++ b/openpos-service/src/main/java/org/jumpmind/pos/service/EndpointDispatchInvocationHandler.java
@@ -4,7 +4,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
 import org.jumpmind.pos.persist.DBSession;
 import org.jumpmind.pos.service.instrumentation.Sample;
-import org.jumpmind.pos.service.instrumentation.ServiceSample;
+import org.jumpmind.pos.service.instrumentation.ServiceSampleModel;
 import org.jumpmind.pos.service.strategy.AbstractInvocationStrategy;
 import org.jumpmind.pos.service.strategy.IInvocationStrategy;
 import org.jumpmind.pos.util.AppUtils;
@@ -173,7 +173,7 @@ public class EndpointDispatchInvocationHandler implements InvocationHandler {
         } else {
             strategy = strategies.get(config.getStrategy().name());
         }
-        ServiceSample sample = startSample(strategy, config, proxy, method, args);
+        ServiceSampleModel sample = startSample(strategy, config, proxy, method, args);
         Object result = null;
         try {
             result = strategy.invoke(config, proxy, method, endPointsByPath, args);
@@ -196,15 +196,15 @@ public class EndpointDispatchInvocationHandler implements InvocationHandler {
         }
     }
 
-    protected ServiceSample startSample(
+    protected ServiceSampleModel startSample(
             IInvocationStrategy strategy,
             ServiceSpecificConfig config,
             Object proxy,
             Method method,
             Object[] args) {
-        ServiceSample sample = null;
+        ServiceSampleModel sample = null;
         if (method.isAnnotationPresent(Sample.class)) {
-            sample = new ServiceSample();
+            sample = new ServiceSampleModel();
             sample.setSampleId(installationId + System.currentTimeMillis());
             sample.setInstallationId(installationId);
             sample.setHostname(AppUtils.getHostName());
@@ -216,7 +216,7 @@ public class EndpointDispatchInvocationHandler implements InvocationHandler {
     }
 
     protected void endSampleSuccess(
-            ServiceSample sample,
+            ServiceSampleModel sample,
             ServiceSpecificConfig config,
             Object proxy,
             Method method,
@@ -229,7 +229,7 @@ public class EndpointDispatchInvocationHandler implements InvocationHandler {
     }
 
     protected void endSampleError(
-            ServiceSample sample,
+            ServiceSampleModel sample,
             ServiceSpecificConfig config,
             Object proxy,
             Method method,
@@ -244,7 +244,7 @@ public class EndpointDispatchInvocationHandler implements InvocationHandler {
         }
     }
 
-    protected void endSample(ServiceSample sample, ServiceSpecificConfig config, Object proxy, Method method, Object[] args) {
+    protected void endSample(ServiceSampleModel sample, ServiceSpecificConfig config, Object proxy, Method method, Object[] args) {
         if (sample != null) {
             sample.setEndTime(new Date());
             sample.setDurationMs(sample.getEndTime().getTime() - sample.getStartTime().getTime());

--- a/openpos-service/src/main/java/org/jumpmind/pos/service/instrumentation/ServiceSampleModel.java
+++ b/openpos-service/src/main/java/org/jumpmind/pos/service/instrumentation/ServiceSampleModel.java
@@ -8,7 +8,7 @@ import org.jumpmind.pos.persist.TableDef;
 
 @TableDef(name = "service_sample", description="This table records statistics about service calls within openpos.",
         primaryKey = "sampleId")
-public class ServiceSample extends AbstractModel {
+public class ServiceSampleModel extends AbstractModel {
 
     @ColumnDef
     String sampleId; // TODO need sequence generator for deviceId+sequence.

--- a/openpos-service/src/main/java/org/jumpmind/pos/service/util/ClassUtils.java
+++ b/openpos-service/src/main/java/org/jumpmind/pos/service/util/ClassUtils.java
@@ -4,8 +4,9 @@ import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.List;
 
-import org.jumpmind.pos.service.instrumentation.ServiceSample;
+import org.jumpmind.pos.service.instrumentation.ServiceSampleModel;
 import org.jumpmind.pos.service.model.ModuleModel;
+import org.jumpmind.pos.persist.model.ScriptVersionModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,7 +18,7 @@ public final class ClassUtils extends org.jumpmind.pos.util.ClassUtils {
     protected static final Logger logger = LoggerFactory.getLogger(ClassUtils.class);
 
     public static List<Class<?>> getClassesForPackageAndAnnotation(String packageName, Class<? extends Annotation> annotation) {
-        List<Class<?>> classes = Arrays.asList(new Class[] {ModuleModel.class, ServiceSample.class});
+        List<Class<?>> classes = Arrays.asList(new Class[] {ModuleModel.class, ServiceSampleModel.class, ScriptVersionModel.class });
 
         return org.jumpmind.pos.util.ClassUtils.getClassesForPackageAndAnnotation(packageName, annotation, classes, null);
     }

--- a/openpos-test-module/src/test/java/org/jumpmind/pos/test/TestModuleTest.java
+++ b/openpos-test-module/src/test/java/org/jumpmind/pos/test/TestModuleTest.java
@@ -15,12 +15,14 @@ import org.junit.runner.RunWith;
 import org.junit.runners.MethodSorters;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes= {TestConfig.class})
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@ActiveProfiles("test")
 public class TestModuleTest {
     
     @Autowired
@@ -44,13 +46,6 @@ public class TestModuleTest {
         ModuleModel info = testSession.findByNaturalId(ModuleModel.class, installationId);
         assertNotNull(info);
         assertEquals("0.0.1", info.getCurrentVersion());
-    }
-    
-    @Test
-    public void test02SqlScript001WasRun() {
-        List<TestTableModel> rows = testSession.findAll(TestTableModel.class, 1000);
-        assertNotNull(rows);
-        assertEquals(2, rows.size());
     }
     
     @Test


### PR DESCRIPTION
### Summary
We now support running sql scripts again if they have changed.  The name of the file and the md5 checksum is stored in a {module_prefix}_script_version table.  If a file has changed (its checksum changed) then it is run again.   This means that if files change they need to be rerunnable.   For CSV files, if they have changed then the table is truncated and reloaded.

### Parameter Changes
- The `openpos.general.sqlScriptProfile` parameter has been deprecated.

### Database Changes
- A new table was added that tracks files that have been run. `{module_prefix}_script_version`