### PR TITLE
Make whereClause empty string if null

### DIFF
--- a/openpos-service/src/main/java/org/jumpmind/pos/service/AbstractRDBMSModule.java
+++ b/openpos-service/src/main/java/org/jumpmind/pos/service/AbstractRDBMSModule.java
@@ -325,6 +325,9 @@ abstract public class AbstractRDBMSModule extends AbstractServiceFactory impleme
 
     public void exportData(String format, String dir, boolean includeModuleTables, String whereClause, List<String> tableFilter, String batchId) {
         List<Table> tables = this.sessionFactory.getTables(includeModuleTables ? new Class<?>[0] : new Class[]{ModuleModel.class});
+        if (whereClause == null) {
+            whereClause = StringUtils.EMPTY;
+        }
         if(StringUtils.isEmpty(batchId)){
             batchId = "01";
         }


### PR DESCRIPTION
Make whereClause empty String if null, will cause a query to be generated `select count(*) from TABLE_NAME null` to be generated causing a SQL exception.