### PR TITLE
Sync changes from burl/0.9: Update to allow hazelcast config to be read from Spring environment

### DIFF
--- a/openpos-hazelcast/src/main/java/org/jumpmind/pos/hazelcast/HazelcastConfig.java
+++ b/openpos-hazelcast/src/main/java/org/jumpmind/pos/hazelcast/HazelcastConfig.java
@@ -3,10 +3,14 @@ package org.jumpmind.pos.hazelcast;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.SerializerConfig;
+
+import org.apache.commons.lang3.StringUtils;
 import org.jumpmind.pos.util.event.AppEvent;
 import org.jumpmind.pos.util.model.DeviceStatus;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 
 
@@ -14,28 +18,39 @@ import org.springframework.context.annotation.Profile;
 @Profile("hazelcast")
 public class HazelcastConfig {
 
+    @Autowired
+    HazelcastEnvConfig envConfig;
+    
 
     @Bean
+    @Primary
     public Config hazelCastConfig() {
-        Config config = new Config().
-                setProperty("hazelcast.logging.type", "slf4j").
-                setInstanceName("hazelcast-instance")
-                .addMapConfig(
-                        new MapConfig()
-                                .setName("configuration")
-                                .setTimeToLiveSeconds(-1));
+        if (envConfig.getProperty("hazelcast.logging.type") == null) {
+            envConfig.setProperty("hazelcast.logging.type", "slf4j");
+        }
+        
+        if (StringUtils.isBlank(envConfig.getInstanceName())) {
+            envConfig.setInstanceName("hazelcast-instance");
+        }
+        
+        envConfig.addMapConfig(
+            new MapConfig()
+                .setName("configuration")
+                .setTimeToLiveSeconds(-1)
+        );
+        
 
         SerializerConfig serializerConfig = new SerializerConfig();
         serializerConfig.setClass(AppEventStreamSerializer.class);
         serializerConfig.setTypeClass(AppEvent.class);
-        config.getSerializationConfig().getSerializerConfigs().add(serializerConfig);
+        envConfig.getSerializationConfig().getSerializerConfigs().add(serializerConfig);
 
         serializerConfig = new SerializerConfig();
         serializerConfig.setClass(DeviceStatusStreamSerializer.class);
         serializerConfig.setTypeClass(DeviceStatus.class);
 
-        config.getSerializationConfig().getSerializerConfigs().add(serializerConfig);
-        return config;
+        envConfig.getSerializationConfig().getSerializerConfigs().add(serializerConfig);
+        return envConfig;
     }
 
 }

--- a/openpos-hazelcast/src/main/java/org/jumpmind/pos/hazelcast/HazelcastEnvConfig.java
+++ b/openpos-hazelcast/src/main/java/org/jumpmind/pos/hazelcast/HazelcastEnvConfig.java
@@ -1,0 +1,14 @@
+package org.jumpmind.pos.hazelcast;
+
+import com.hazelcast.config.Config;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+
+@ConfigurationProperties(prefix = "hazelcast", ignoreUnknownFields = false)
+@Profile("hazelcast")
+@Component
+public class HazelcastEnvConfig extends Config {
+
+}

--- a/openpos-hazelcast/src/test/java/org/jumpmind/pos/hazelcast/AppEventStreamSerializerTest.java
+++ b/openpos-hazelcast/src/test/java/org/jumpmind/pos/hazelcast/AppEventStreamSerializerTest.java
@@ -15,7 +15,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import static org.junit.Assert.*;
 
 @RunWith(SpringRunner.class)
-@ContextConfiguration(classes= {HazelcastConfig.class})
+@ContextConfiguration(classes= {HazelcastConfig.class, HazelcastEnvConfig.class})
 @ActiveProfiles("hazelcast")
 public class AppEventStreamSerializerTest {
 

--- a/openpos-hazelcast/src/test/java/org/jumpmind/pos/hazelcast/DeviceStatusStreamSerializerTest.java
+++ b/openpos-hazelcast/src/test/java/org/jumpmind/pos/hazelcast/DeviceStatusStreamSerializerTest.java
@@ -16,7 +16,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 @RunWith(SpringRunner.class)
-@ContextConfiguration(classes= {HazelcastConfig.class})
+@ContextConfiguration(classes= {HazelcastConfig.class, HazelcastEnvConfig.class})
 @ActiveProfiles("hazelcast")
 public class DeviceStatusStreamSerializerTest {
 


### PR DESCRIPTION
These changes allow for reading of the hazelcast configuration from the spring environment and allows use of profiles, etc.