### PR TITLE
Updated UI to support all transaction types

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/core.module.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/core.module.ts
@@ -64,6 +64,7 @@ import { TimeZoneContext } from './client-context/time-zone-context';
 import {UIDataMessageService} from './ui-data-message/ui-data-message.service';
 import { HelpTextService } from './help-text/help-text.service';
 import {ErrorStateMatcher, ShowOnDirtyErrorStateMatcher} from "@angular/material/core";
+import {TransactionService} from './services/transaction.service';
 
 registerLocaleData(locale_enCA, 'en-CA');
 registerLocaleData(locale_frCA, 'fr-CA');
@@ -139,7 +140,8 @@ registerLocaleData(locale_frCA, 'fr-CA');
         { provide: LOGGERS, useExisting: ServerLogger, multi: true, deps: [HttpClient, PersonalizationService, ConsoleIntercepter] },
         HelpTextService,
         { provide: CLIENTCONTEXT, useClass: TimeZoneContext, multi: true },
-        { provide: ErrorStateMatcher, useClass: ShowOnDirtyErrorStateMatcher }
+        { provide: ErrorStateMatcher, useClass: ShowOnDirtyErrorStateMatcher },
+        TransactionService
     ]
 })
 export class CoreModule {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/services/icon.service.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/services/icon.service.ts
@@ -28,6 +28,7 @@ export class IconService {
         this.icons.set('Back', ['keyboard_arrow_left.svg', this.defaultIconProvider]);
         this.icons.set('BankIn', ['bank_transfer_in.svg', this.defaultIconProvider]);
         this.icons.set('Barcode', ['barcode.svg', this.defaultIconProvider]);
+        this.icons.set('Broken', ['broken_image.svg', this.defaultIconProvider]);
         this.icons.set('BusinessCustomer', ['business.svg', this.defaultIconProvider]);
         this.icons.set('BypassAction', ['low_priority.svg', this.defaultIconProvider]);
         this.icons.set('Calendar', ['today.svg', this.defaultIconProvider]);

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/services/transaction.service.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/services/transaction.service.ts
@@ -1,0 +1,25 @@
+import {Injectable} from '@angular/core';
+import {TransactionStatusEnum} from '../../shared/transaction-status.enum';
+
+@Injectable({
+    providedIn: 'root',
+})
+export class TransactionService {
+    mapStatusToCssClass(status: TransactionStatusEnum): string {
+        switch(status) {
+            case TransactionStatusEnum.InProgress:
+            case TransactionStatusEnum.Completed:
+                return 'success';
+            case TransactionStatusEnum.Suspended:
+            case TransactionStatusEnum.SuspendRetrieved:
+            case TransactionStatusEnum.SuspendCancelled:
+                return 'warn-light';
+            case TransactionStatusEnum.Orphaned:
+            case TransactionStatusEnum.Aborted:
+            case TransactionStatusEnum.Cancelled:
+            case TransactionStatusEnum.Failed:
+            case TransactionStatusEnum.Voided:
+                return 'warn';
+        }
+    }
+}

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/transaction-search/_transaction-search-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/transaction-search/_transaction-search-theme.scss
@@ -1,17 +1,18 @@
 @mixin transaction-search-theme($theme) {
-
-    $app-primary: mat-color(map-get($theme, primary));
-    $app-accent: mat-color(map-get($theme, accent));
-    $app-warn: mat-color(map-get($theme, warn));
-
     $foreground: map-get($theme, foreground);
     $background: map-get($theme, background);
+
+    $app-border: mat-color($foreground, border, .35);
+    $app-card-background: map-get($background, card);
 
     app-transaction-search {
         app-infinite-scroll {
             @extend .mat-elevation-z2;
-            background: map-get($background, card);
+            background: $app-card-background;
+        }
+
+        .transaction-summary {
+            border-color: $app-border;
         }
     }
-
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/transaction-search/transaction-search.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/transaction-search/transaction-search.component.html
@@ -21,7 +21,7 @@
             virtualScrollMaxBufferPx="400" [itemHeightPx]="150">
 
             <ng-template #itemTemplate let-item>
-                <app-transaction-summary [transactionSummary]="item" class="transaction-summary-list">
+                <app-transaction-summary [transactionSummary]="item" class="transaction-summary" responsive-class>
                 </app-transaction-summary>
             </ng-template>
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/transaction-search/transaction-search.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/transaction-search/transaction-search.component.scss
@@ -31,4 +31,21 @@
         margin: 16px;
     }
 
+    .transaction-summary {
+        display: block;
+        border-bottom-width: 1px;
+        border-bottom-style: solid;
+        margin: 0 32px;
+
+        &:last-child {
+            border-bottom: none;
+        }
+
+        &.tablet-landscape,
+        &.mobile-landscape,
+        &.mobile-portrait,
+        &.desktop-portrait {
+            margin: 0 16px;
+        }
+    }
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/transaction-summary/_transaction-summary-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/transaction-summary/_transaction-summary-theme.scss
@@ -1,15 +1,31 @@
 @mixin transaction-summary-theme($theme) {
     $app-primary: mat-color(map-get($theme, primary));
+    $app-primary-light: mat-color(map-get($theme, primary), default, .5);
     $app-accent: mat-color(map-get($theme, accent));
     $app-warn: mat-color(map-get($theme, warn));
-
-    $foreground: map-get($theme, foreground);
-    $background: map-get($theme, background);
+    $app-disabled: mat-color(map-get($theme, foreground), disabled);
+    $app-text: mat-color(map-get($theme, foreground), text);
+    $app-text-light: mat-color(map-get($theme, foreground), text, .5);
 
     app-transaction-summary {
-        .transaction-summary-outer {
-            border-bottom: solid 1px map_get($foreground, divider);
+        .summary-field-group {
+            color: $app-disabled;
+        }
+
+        .summary-attention {
+            color: $app-text;
+        }
+
+        .summary-icon-text {
+            color: $app-text-light;
+        }
+
+        .trans-icon {
+            color: $app-disabled;
+        }
+
+        .trans-icon-primary {
+            color: $app-primary-light;
         }
     }
-
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/transaction-summary/_transaction-summary-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/transaction-summary/_transaction-summary-theme.scss
@@ -20,12 +20,8 @@
             color: $app-text-light;
         }
 
-        .trans-icon {
+        .trans-icon-secondary {
             color: $app-disabled;
-        }
-
-        .trans-icon-primary {
-            color: $app-primary-light;
         }
     }
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/transaction-summary/_transaction-summary-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/transaction-summary/_transaction-summary-theme.scss
@@ -8,12 +8,12 @@
     $app-text-light: mat-color(map-get($theme, foreground), text, .5);
 
     app-transaction-summary {
-        .summary-field-group {
-            color: $app-disabled;
+        .summary-trans {
+            color: $app-text;
         }
 
-        .summary-attention {
-            color: $app-text;
+        .summary-details {
+            color: $app-disabled;
         }
 
         .summary-icon-text {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/transaction-summary/transaction-summary.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/transaction-summary/transaction-summary.component.html
@@ -1,63 +1,62 @@
-<div *ngIf="transactionSummary" class="transaction-summary-outer">
-    <div class="summary-icon">
-        <app-icon *ngIf="transactionSummary.icon" [iconName]="transactionSummary.icon" iconClass="mat-64"></app-icon>
+<div *ngIf="transactionSummary" class="summary-container" responsive-class>
+    <div class="summary-trans-type trans-icon-primary" responsive-class>
+        <app-icon *ngIf="transactionSummary.transactionTypeIcon" [iconName]="transactionSummary.transactionTypeIcon"
+                  iconClass="mat-64"></app-icon>
         <span *ngIf="transactionSummary.transactionType">{{transactionSummary.transactionType}}</span>
     </div>
-    <div class="summary-main">
-        <div responsive-class class="summary-trans">
-            <div>
-                <span *ngIf="transactionSummary.labels"
-                    class="summary-label">{{transactionSummary.labels.sequenceNumber}}</span>
-                <span>{{transactionSummary.sequenceNumber}}</span>
-                <mat-chip *ngIf="transactionSummary.status" responsive-class class="summary-status">{{transactionSummary.status}}</mat-chip>
+    <div class="summary-field-group summary-attention summary-trans">
+        <div class="summary-field with-icon" responsive-class>
+            <app-icon class="summary-field-icon" iconClass="mat-36 {{statusClass}}"
+                      *ngIf="transactionSummary.statusIcon" [iconName]="transactionSummary.statusIcon"></app-icon>
+            <span class="summary-field-label summary-important">
+                {{transactionSummary.statusText}}
+                {{transactionSummary.sequenceNumberFormatted}}
+            </span>
+        </div>
+        <div class="summary-field with-icon" responsive-class>
+            <span class="summary-field-label">
+                <ng-container *ngIf="transactionSummary.labels">{{transactionSummary.labels.customerName}}</ng-container>
+                {{transactionSummary.customerName}}
+            </span>
+        </div>
+        <div class="summary-field with-icon" responsive-class>
+            <span class="summary-field-label">{{transactionSummary.itemsFormatted}}</span>
+        </div>
+    </div>
+    <div class="summary-details" responsive-class>
+        <div class="summary-field-group">
+            <div class="summary-field" responsive-class>
+                <span class="summary-field-label" *ngIf="transactionSummary.labels">{{transactionSummary.labels.transactionDate}}</span>
+                <span class="summary-field-value">{{transactionSummary.transactionDate | date:'M/d/yyy h:mm a'}}</span>
             </div>
-            <div>
-                <span *ngIf="transactionSummary.labels"
-                    class="summary-label">{{transactionSummary.labels.customerName}}</span>
-                <span>{{transactionSummary.customerName}}</span>
-            </div>
-            <div>
-                <span>{{transactionSummary.items}}</span>
-                <span *ngIf="transactionSummary.labels"
-                    class="summary-items-label">{{transactionSummary.labels.items}}</span>
+            <div class="summary-field" responsive-class>
+                <span class="summary-field-label" *ngIf="transactionSummary.labels">{{transactionSummary.labels.username}}</span>
+                <span class="summary-field-value">{{transactionSummary.username}}</span>
             </div>
         </div>
-        <div responsive-class class="summary-details">
-            <div class="summary-detail-column">
-                <div>
-                    <span *ngIf="transactionSummary.labels"
-                        class="summary-label">{{transactionSummary.labels.transactionDate}}:</span>
-                    <span>{{transactionSummary.transactionDate}}</span>
-                </div>
-                <div>
-                    <span *ngIf="transactionSummary.labels"
-                        class="summary-label">{{transactionSummary.labels.username}}:</span>
-                    <span>{{transactionSummary.username}}</span>
-                </div>
+        <div class="summary-field-group">
+            <div class="summary-field" responsive-class>
+                <span class="summary-field-label" *ngIf="transactionSummary.labels">{{transactionSummary.labels.deviceId}}</span>
+                <span class="summary-field-value">{{transactionSummary.deviceId}}</span>
             </div>
-            <div class="summary-detail-column">
-                <div>
-                    <span *ngIf="transactionSummary.labels"
-                        class="summary-label">{{transactionSummary.labels.deviceId}}:</span>
-                    <span>{{transactionSummary.deviceId}}</span>
-                </div>
-                <div>
-                    <span *ngIf="transactionSummary.labels"
-                        class="summary-label">{{transactionSummary.labels.storeId}}:</span>
-                    <span>{{transactionSummary.storeId}}</span>
-                </div>
+            <div class="summary-field" responsive-class>
+                <span class="summary-field-label" *ngIf="transactionSummary.labels">{{transactionSummary.labels.storeId}}</span>
+                <span class="summary-field-value">{{transactionSummary.storeId}}</span>
             </div>
         </div>
-        <div class="summary-details-total-group">
-            <app-currency-text [amountText]="transactionSummary.total" responsive-class class="summary-total"></app-currency-text>
-            <div class="summary-tendertype-icons"><app-icon *ngFor="let tenderTypeIcon of transactionSummary.tenderTypeIcons" [iconName]="tenderTypeIcon" iconClass="mat-24"></app-icon></div>
+    </div>
+    <div class="summary-total">
+        <app-currency-text [amountText]="transactionSummary.total" class="summary-total-amount" responsive-class></app-currency-text>
+        <div class="summary-tender-type-icons">
+            <app-icon *ngFor="let tenderTypeIcon of transactionSummary.tenderTypeIcons" [iconName]="tenderTypeIcon"
+                      iconClass="trans-icon-primary mat-36"></app-icon>
         </div>
-        <div responsive-class class="transaction-buttons">
-            <button *ngFor="let button of transactionSummary.actions" mat-button color="primary" responsive-class
-                class="transaction-button" (click)="onClick(button)" [disabled]="! button.enabled">
-                <span class="transaction-button-text">{{button.title}}</span>
-                <app-icon [iconName]="button.icon" iconClass="mat-24"></app-icon>
-            </button>
-        </div>
+    </div>
+    <div class="summary-actions" responsive-class>
+        <button *ngFor="let button of transactionSummary.actions" (click)="onClick(button)" [disabled]="!button.enabled"
+                class="transaction-button" mat-button color="primary" responsive-class>
+            <span class="transaction-button-text">{{button.title}}</span>
+            <app-icon [iconName]="button.icon" iconClass="mat-24"></app-icon>
+        </button>
     </div>
 </div>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/transaction-summary/transaction-summary.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/transaction-summary/transaction-summary.component.html
@@ -1,32 +1,25 @@
 <div *ngIf="transactionSummary" class="summary-container" responsive-class>
     <div class="summary-trans-type trans-icon-primary" responsive-class>
         <app-icon *ngIf="transactionSummary.transactionTypeIcon" [iconName]="transactionSummary.transactionTypeIcon"
-                  iconClass="mat-64"></app-icon>
+                  iconClass="mat-64" class="trans-type-icon" responsive-class></app-icon>
         <span *ngIf="transactionSummary.transactionType">{{transactionSummary.transactionType}}</span>
     </div>
-    <div class="summary-field-group summary-attention summary-trans">
-        <div class="summary-field with-icon" responsive-class>
-            <app-icon class="summary-field-icon" iconClass="mat-36 {{statusClass}}"
-                      *ngIf="transactionSummary.statusIcon" [iconName]="transactionSummary.statusIcon"></app-icon>
-            <span class="summary-field-label summary-very-important">
-                {{transactionSummary.statusText}}
-                {{transactionSummary.sequenceNumberFormatted}}
-            </span>
+    <div class="summary-attention summary-trans" responsive-class>
+        <app-icon class="summary-trans-status-icon" iconClass="mat-36 {{statusClass}}"
+                  *ngIf="transactionSummary.statusIcon" [iconName]="transactionSummary.statusIcon"></app-icon>
+        <div class="summary-trans-status-text">
+            {{transactionSummary.statusText}} {{transactionSummary.sequenceNumberFormatted}}
         </div>
-        <div class="summary-field with-icon" responsive-class>
-            <span class="summary-field-label">
-                <ng-container *ngIf="transactionSummary.labels">{{transactionSummary.labels.customerName}}</ng-container>
-                <span class="summary-customer">{{transactionSummary.customerName}}</span>
-            </span>
-        </div>
-        <div class="summary-field with-icon" responsive-class>
-            <span class="summary-field-label">{{transactionSummary.itemsFormatted}}</span>
+        <div class="summary-trans-properties">
+            <span *ngIf="transactionSummary.labels">{{transactionSummary.labels.customerName}}</span>
+            <span class="summary-customer">{{transactionSummary.customerName}}</span>
+            <div>{{transactionSummary.itemsFormatted}}</div>
         </div>
     </div>
     <div class="summary-details" responsive-class>
-        <div class="summary-field-group">
+        <div>
             <div class="summary-field" responsive-class>
-                <span class="summary-field-label" *ngIf="transactionSummary.labels">{{transactionSummary.labels.transactionDate}}</span>
+                <span class="summary-field-label"  *ngIf="transactionSummary.labels">{{transactionSummary.labels.transactionDate}}</span>
                 <span class="summary-field-value">{{transactionSummary.transactionDate | date:'M/d/yyy h:mm a'}}</span>
             </div>
             <div class="summary-field" responsive-class>
@@ -34,7 +27,7 @@
                 <span class="summary-field-value">{{transactionSummary.username}}</span>
             </div>
         </div>
-        <div class="summary-field-group">
+        <div>
             <div class="summary-field" responsive-class>
                 <span class="summary-field-label" *ngIf="transactionSummary.labels">{{transactionSummary.labels.deviceId}}</span>
                 <span class="summary-field-value">{{transactionSummary.deviceId}}</span>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/transaction-summary/transaction-summary.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/transaction-summary/transaction-summary.component.html
@@ -8,7 +8,7 @@
         <div class="summary-field with-icon" responsive-class>
             <app-icon class="summary-field-icon" iconClass="mat-36 {{statusClass}}"
                       *ngIf="transactionSummary.statusIcon" [iconName]="transactionSummary.statusIcon"></app-icon>
-            <span class="summary-field-label summary-important">
+            <span class="summary-field-label summary-very-important">
                 {{transactionSummary.statusText}}
                 {{transactionSummary.sequenceNumberFormatted}}
             </span>
@@ -16,7 +16,7 @@
         <div class="summary-field with-icon" responsive-class>
             <span class="summary-field-label">
                 <ng-container *ngIf="transactionSummary.labels">{{transactionSummary.labels.customerName}}</ng-container>
-                {{transactionSummary.customerName}}
+                <span class="summary-customer">{{transactionSummary.customerName}}</span>
             </span>
         </div>
         <div class="summary-field with-icon" responsive-class>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/transaction-summary/transaction-summary.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/transaction-summary/transaction-summary.component.html
@@ -1,5 +1,5 @@
 <div *ngIf="transactionSummary" class="summary-container" responsive-class>
-    <div class="summary-trans-type trans-icon-primary" responsive-class>
+    <div class="summary-trans-type trans-icon-secondary" responsive-class>
         <app-icon *ngIf="transactionSummary.transactionTypeIcon" [iconName]="transactionSummary.transactionTypeIcon"
                   iconClass="mat-64" class="trans-type-icon" responsive-class></app-icon>
         <span *ngIf="transactionSummary.transactionType">{{transactionSummary.transactionType}}</span>
@@ -42,7 +42,7 @@
         <app-currency-text [amountText]="transactionSummary.total" class="summary-total-amount" responsive-class></app-currency-text>
         <div class="summary-tender-type-icons">
             <app-icon *ngFor="let tenderTypeIcon of transactionSummary.tenderTypeIcons" [iconName]="tenderTypeIcon"
-                      iconClass="trans-icon-primary mat-36"></app-icon>
+                      iconClass="trans-icon-secondary mat-36"></app-icon>
         </div>
     </div>
     <div class="summary-actions" responsive-class>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/transaction-summary/transaction-summary.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/transaction-summary/transaction-summary.component.scss
@@ -2,7 +2,7 @@
 
 .summary-container {
     display: grid;
-    grid-template-columns: min-content minmax(min-content, 1fr) minmax(min-content, 1fr) .5fr;
+    grid-template-columns: min-content minmax(min-content, 1fr) minmax(min-content, 1.5fr) .5fr;
     column-gap: 32px;
     grid-template-areas:
         'trans-type trans details total'
@@ -10,13 +10,15 @@
     padding: 16px 0;
 
     &.tablet-landscape,
+    &.tablet-portrait,
     &.mobile-landscape,
     &.mobile-portrait,
     &.desktop-portrait {
+        grid-template-columns: min-content minmax(min-content, 1fr) minmax(min-content, 1fr) .5fr;
+        column-gap: 16px;
         grid-template-areas:
             'trans-type trans   details total'
             'trans-type actions actions actions';
-        column-gap: 16px;
     }
 }
 
@@ -28,18 +30,67 @@
     grid-area: trans-type;
 }
 
+.trans-type-icon {
+    &.tablet-landscape,
+    &.tablet-portrait,
+    &.mobile-landscape,
+    &.mobile-portrait,
+    &.desktop-portrait {
+        width: 48px;
+        height: 48px;
+    }
+}
+
 .summary-trans {
     @extend %text-md;
+
     grid-area: trans;
+    display: grid;
+    grid-template-areas:
+            'icon content'
+            '.    properties';
+    grid-template-columns: 32px auto;
+    grid-column-gap: 8px;
+    align-items: center;
+
+    &.tablet-landscape,
+    &.tablet-portrait,
+    &.mobile-landscape,
+    &.mobile-portrait,
+    &.desktop-portrait {
+        column-gap: 4px;
+        font-size: 1.25rem;
+    }
+
+    &.tablet-portrait,
+    &.mobile-landscape,
+    &.mobile-portrait {
+        font-size: 1rem;
+    }
+}
+
+.summary-trans-status-text {
+    font-weight: bold;
+    text-transform: uppercase;
+    grid-area: content;
+}
+
+.summary-trans-properties {
+    grid-area: properties;
+}
+
+.summary-trans-status-icon {
+    grid-area: icon;
 }
 
 .summary-details {
     @extend %text-sm;
 
+    font-size: 1rem;
     grid-area: details;
     display: grid;
-    grid-template-columns: auto auto;
-    gap: 16px;
+    grid-template-columns: 1fr 1fr;
+    column-gap: 16px;
 }
 
 .summary-total {
@@ -63,59 +114,48 @@
 
 .summary-field {
     display: grid;
-    grid-template-columns: max-content 1fr;
+    grid-template-columns: 1fr 1fr;
     grid-template-areas: 'label value';
-    align-items: center;
-    gap: .5rem;
-    margin-bottom: 4px;
+    column-gap: 16px;
+    margin-bottom: 16px;
 
     &:last-child {
         margin-bottom: 0;
     }
 
+    &.tablet-portrait,
     &.mobile-landscape,
     &.mobile-portrait,
     &.desktop-portrait {
-        display: block;
-        margin-bottom: 8px;
+        grid-template-columns: 1fr;
+        grid-template-areas:
+                'label'
+                'value';
+    }
 
-        &:last-child {
-            margin-bottom: 0;
+    .summary-field-label {
+        display: block;
+        grid-area: label;
+        justify-self: end;
+
+        .tablet-portrait &,
+        .mobile-landscape &,
+        .mobile-portrait &,
+        .desktop-portrait & {
+            justify-self: start;
         }
     }
-}
 
-.summary-field.with-icon {
-    grid-template-columns: 32px max-content 1fr;
-    grid-template-areas: 'icon label value';
-
-    &.mobile-landscape,
-    &.mobile-portrait,
-    &.desktop-portrait {
-        display: grid;
-        margin-bottom: 0;
+    .summary-field-value {
+        display: block;
+        font-weight: bold;
+        grid-area: value;
     }
 }
 
-.summary-field-label {
-    display: block;
-    grid-area: label;
-}
-
-.summary-field-value {
-    display: block;
-    font-weight: bold;
-    grid-area: value;
-}
-
-.summary-customer{
+.summary-customer {
     font-weight: bold;
     margin-left: 4px;
-}
-
-.summary-very-important {
-    font-weight: bold;
-    text-transform: uppercase;
 }
 
 .summary-actions {
@@ -139,6 +179,7 @@
         margin-right: 8px;
     }
 
+    &.tablet-portrait,
     &.mobile-landscape,
     &.mobile-portrait,
     &.desktop-portrait {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/transaction-summary/transaction-summary.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/transaction-summary/transaction-summary.component.scss
@@ -1,76 +1,52 @@
 @import "../../../styles/mixins/typography";
 
-.transaction-summary-outer {
-    margin: 0px 16px;
-    padding: 16px 0px;
+.summary-container {
     display: grid;
-    grid-template-columns: auto 1fr;
-    gap: 8px;
+    grid-template-columns: min-content minmax(min-content, 1fr) minmax(min-content, 1fr) .5fr;
+    column-gap: 32px;
+    grid-template-areas:
+        'trans-type trans details total'
+        'trans-type trans actions actions';
+    padding: 16px 0;
+
+    &.tablet-landscape,
+    &.mobile-landscape,
+    &.mobile-portrait,
+    &.desktop-portrait {
+        grid-template-areas:
+            'trans-type trans   details total'
+            'trans-type actions actions actions';
+        column-gap: 16px;
+    }
 }
 
-.summary-icon {
-    align-items: center;
-    align-content: center;
-    justify-content: center;
-    justify-items: center;
-    display: grid;
-}
+.summary-trans-type {
+    @extend %text-sm;
 
-.summary-main {
-    display: grid;
-    grid-template-columns: auto .5fr auto .5fr auto;
-    grid-template-rows: auto auto;
-    grid-template-areas: 
-        "trans .       details .       total"
-        "trans buttons buttons buttons buttons"
-    ;
-    column-gap: 8px;
-
-}
-
-.summary-tendertype-icons {
-    display: grid;
-    grid-auto-flow: column;
-    justify-content: left;
-    column-gap: 4px;
-}
-
-
-.summary-status {
-    @extend %text-md;
-    margin-left: .5em;
-    padding-left: 4px;
-    padding-right: 4px;
+    text-align: center;
+    font-weight: bold;
+    grid-area: trans-type;
 }
 
 .summary-trans {
     @extend %text-md;
     grid-area: trans;
-    display: grid;
-    grid-template-rows: auto auto auto;
-    gap: 8px;
 }
 
 .summary-details {
     @extend %text-sm;
+
     grid-area: details;
     display: grid;
     grid-template-columns: auto auto;
     gap: 16px;
 }
 
-.summary-detail-column {
-    display: grid;
-    grid-template-rows: auto auto;
-    gap: 16px 32px;
-}
+.summary-total {
+    @extend %text-lg;
 
-.summary-details-info {
-    display: grid;
-    grid-template-columns: auto auto;
-}
-
-.summary-details-total-group {
+    font-weight: bold;
+    text-align: end;
     grid-area: total;
     display: grid;
     grid-template-columns: auto;
@@ -78,30 +54,93 @@
     justify-items: right;
 }
 
-.summary-total {
-    @extend %text-lg;
+.summary-tender-type-icons {
+    display: grid;
+    grid-auto-flow: column;
+    justify-content: left;
+    column-gap: 4px;
+}
+
+.summary-field {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    grid-template-areas: 'label value';
+    align-items: center;
+    gap: .5rem;
+    margin-bottom: 4px;
+
+    &:last-child {
+        margin-bottom: 0;
+    }
+
+    &.mobile-landscape,
+    &.mobile-portrait,
+    &.desktop-portrait {
+        display: block;
+        margin-bottom: 8px;
+
+        &:last-child {
+            margin-bottom: 0;
+        }
+    }
+}
+
+.summary-field.with-icon {
+    grid-template-columns: 32px max-content 1fr;
+    grid-template-areas: 'icon label value';
+
+    &.mobile-landscape,
+    &.mobile-portrait,
+    &.desktop-portrait {
+        display: grid;
+        margin-bottom: 0;
+    }
+}
+
+.summary-field-label {
+    display: block;
+    grid-area: label;
+}
+
+.summary-field-value {
+    display: block;
     font-weight: bold;
-    text-align: end;
+    grid-area: value;
 }
 
-.summary-label {
-    padding-right: 4px;
+.summary-important {
+    font-weight: bold;
+    text-transform: uppercase;
 }
 
-.summary-items-label {
-    padding-left: 4px;
-}
-
-.transaction-buttons {
-    grid-area: buttons;
+.summary-actions {
+    grid-area: actions;
     justify-self: right;
+    grid-row: 2;
+    margin-top: 16px;
 }
 
 .transaction-button {
     @extend %text-sm;
-    margin: 0px 4px;
+
+    padding: 0 8px;
+    margin: 0 64px 0 0;
+
+    &:last-child {
+        margin-right: 0;
+    }
 
     .transaction-button-text {
         margin-right: 8px;
+    }
+
+    &.mobile-landscape,
+    &.mobile-portrait,
+    &.desktop-portrait {
+        margin-right: 16px;
+
+        &:last-child {
+            margin-right: 0;
+        }
     }
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/transaction-summary/transaction-summary.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/transaction-summary/transaction-summary.component.scss
@@ -108,7 +108,12 @@
     grid-area: value;
 }
 
-.summary-important {
+.summary-customer{
+    font-weight: bold;
+    margin-left: 4px;
+}
+
+.summary-very-important {
     font-weight: bold;
     text-transform: uppercase;
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/transaction-summary/transaction-summary.component.spec.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/transaction-summary/transaction-summary.component.spec.ts
@@ -41,6 +41,7 @@ describe('TransactionSummaryComponent', () => {
 })
 class MockIconComponent {
   @Input() iconName: string;
+  @Input() iconClass: string;
 }
 
 @Component({

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/transaction-summary/transaction-summary.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/transaction-summary/transaction-summary.component.ts
@@ -1,22 +1,26 @@
-import { Component, OnInit, Input } from '@angular/core';
+import {Component, OnInit, Input, OnChanges, SimpleChanges} from '@angular/core';
 import { ITransactionSummary } from './transaction-summary.interface';
 import { IActionItem } from '../../../core/actions/action-item.interface';
 import { ActionService } from '../../../core/actions/action.service';
+import {TransactionService} from '../../../core/services/transaction.service';
 
 @Component({
   selector: 'app-transaction-summary',
   templateUrl: './transaction-summary.component.html',
   styleUrls: ['./transaction-summary.component.scss']
 })
-export class TransactionSummaryComponent {
-
+export class TransactionSummaryComponent implements OnChanges {
   @Input()
   transactionSummary: ITransactionSummary;
+  statusClass: string;
 
-  constructor(private actionService: ActionService) { }
+  constructor(private actionService: ActionService, private transactionService: TransactionService) { }
 
   onClick(actionItem: IActionItem): void {
     this.actionService.doAction(actionItem, this.transactionSummary);
   }
 
+  ngOnChanges(changes: SimpleChanges) {
+    this.statusClass = this.transactionService.mapStatusToCssClass(this.transactionSummary.status);
+  }
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/transaction-summary/transaction-summary.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/transaction-summary/transaction-summary.interface.ts
@@ -1,21 +1,26 @@
 import { IActionItem } from '../../../core/actions/action-item.interface';
+import {TransactionStatusEnum} from '../../transaction-status.enum';
 
 export interface ITransactionSummary {
     sequenceNumber: string;
+    sequenceNumberFormatted: string;
     customerName: string;
     items: number;
+    itemsFormatted: string;
     transactionDate: string;
     deviceId: string;
     storeId: string;
     tillId: string;
     barcode: string;
     total: string;
-    icon: string;
     businessDate: string;
-    status: string;
+    status: TransactionStatusEnum;
+    statusText: string;
+    statusIcon: string;
     username: string;
     actions: IActionItem[];
     labels: any;
     transactionType: string;
+    transactionTypeIcon: string;
     tenderTypeIcons: string[];
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/transaction-history-part/transaction-history-part.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/transaction-history-part/transaction-history-part.component.html
@@ -6,7 +6,7 @@
         </div>
         <div class="detail-field">
             <span *ngIf="screenData.labels" class="detail-label">{{screenData.labels.status}}</span>
-            <span class="detail-value">{{screenData.status}}</span>
+            <span class="detail-value">{{screenData.statusText}}</span>
         </div>
     </div>
     <div class="transaction-history-details">

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/transaction-status.enum.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/transaction-status.enum.ts
@@ -1,0 +1,12 @@
+export enum TransactionStatusEnum {
+    InProgress = 'IN_PROGRESS',
+    Completed = 'COMPLETED',
+    Cancelled = 'CANCELLED',
+    Suspended = 'SUSPENDED',
+    Failed = 'FAILED',
+    SuspendRetrieved = 'SUSPEND_RETRIEVED',
+    SuspendCancelled = 'SUSPEND_CANCELLED',
+    Voided = 'VOIDED',
+    Aborted = 'ABORTED',
+    Orphaned = 'ORPHANED'
+}

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/_app-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/_app-theme.scss
@@ -99,6 +99,10 @@
         color: $app-warn;
     }
 
+    .warn-light {
+        color: mat-color(mat-palette($mat-orange, 800));
+    }
+
     .accent {
         color: $app-accent;
     }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/public-api.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/public-api.ts
@@ -118,6 +118,7 @@ export * from './lib/core/services/training-overlay.service';
 export * from './lib/core/services/validators.service';
 export * from './lib/core/services/location.service';
 export * from './lib/core/services/fetch-message.service';
+export * from './lib/core/services/transaction.service';
 export * from './lib/core/personalization/client-url.service';
 export * from './lib/core/focus/focus.service';
 export * from './lib/core/ui-data-message/ui-data-message.service';
@@ -188,6 +189,7 @@ export * from './lib/customer-display/customer-display-home/customer-display-hom
 export * from './lib/customer-display/customer-display-sale/customer-display-sale.component';
 
 export * from './lib/shared/shared.module';
+export * from './lib/shared/transaction-status.enum';
 export * from './lib/shared/components/catalog-browser-item/catalog-browser-item.component';
 export * from './lib/shared/components/counter/counter.component';
 export * from './lib/shared/components/currency-text/currency-text.component';

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/IconType.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/IconType.java
@@ -9,6 +9,7 @@ public interface IconType {
     public static final String Back = "Back"; //keyboard_arrow_left
     public static final String BankIn = "BankIn"; //bank_transfer_in
     public static final String Barcode = "Barcode"; //barcode.svg
+    public static final String Broken = "Broken"; //broken_image.svg
     public static final String BusinessCustomer = "BusinessCustomer"; //business
     public static final String BypassAction = "BypassAction"; //low_priority
     public static final String Calendar = "Calendar"; //today
@@ -54,6 +55,7 @@ public interface IconType {
     public static final String Help = "Help"; //help
     public static final String Home = "Home"; //home
     public static final String Increment = "Increment"; //add
+    public static final String InProgress = "AutoRenew"; //autorenew
     public static final String ItemList = "ItemList"; //list
     public static final String Journal = "Journal"; //book
     public static final String KebabMenu = "KebabMenu"; //more_vert
@@ -93,6 +95,7 @@ public interface IconType {
     public static final String Trash = "Trash"; //delete
     public static final String User = "User";
     public static final String ViewAction = "ViewAction"; //pageview
+    public static final String Block = "Block"; //block
     public static final String WebOrder = "WebOrder"; //computer
     public static final String AddNote = "AddNote"; //note_add
     public static final String CheckRoutingSymbol = "CheckRoutingSymbol";

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/data/TransactionSummary.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/data/TransactionSummary.java
@@ -16,19 +16,23 @@ import java.util.Map;
 public class TransactionSummary implements Serializable {
 
     private Long sequenceNumber;
+    private String sequenceNumberFormatted;
     private String customerName;
     private Integer items;
+    private String itemsFormatted;
     private String transactionDate;
     private String deviceId;
     private String storeId;
     private String tillId;
     private String barcode;
     private String total;
-    private String icon;
     private String businessDate;
     private String status;
+    private String statusText;
+    private String statusIcon;
     private String username;
     private String transactionType;
+    private String transactionTypeIcon;
     private List<String> tenderTypeIcons;
     private List<ActionItem> actions;
 


### PR DESCRIPTION
### Issues Fixed
UI part of issue: https://github.com/JumpMind/commerce/issues/2243

### Summary
Updates the UI to support showing all transaction types.

Currently the UI will still only show **Sales** and **Returns**. I changed the database data to get the different types shown in the screenshots.

The backend change for this will come next.

### Screenshots
**Desktop**
![trans-search--desktop](https://user-images.githubusercontent.com/3991426/96953230-991ba680-14be-11eb-9b86-3253237dad9b.gif)

**ELO POS - Landscape**
![trans-search--elopos-landscape](https://user-images.githubusercontent.com/3991426/96953262-a59fff00-14be-11eb-9055-d3f7874d9550.gif)

**ELO POS - Portrait**
![trans-search--elopos-portrait](https://user-images.githubusercontent.com/3991426/96953283-b5b7de80-14be-11eb-9117-863a58003bb3.gif)

**IPad Pro - Landscape**
![trans-search--ipadpro-landscape](https://user-images.githubusercontent.com/3991426/96953308-c10b0a00-14be-11eb-8e46-70c22dc41159.gif)

**IPad Pro - Portrait**
![trans-search--ipadpro-portrait](https://user-images.githubusercontent.com/3991426/96953324-c8caae80-14be-11eb-99a9-e72f04ec3e07.gif)

**IPad - Landscape**
![trans-search--ipad-landscape](https://user-images.githubusercontent.com/3991426/96953345-d54f0700-14be-11eb-94e9-e542978e540c.gif)

**IPad - Portrait**
![trans-search--ipad-portrait](https://user-images.githubusercontent.com/3991426/96953362-e13ac900-14be-11eb-94a1-d0237a11fe7d.gif)
