### PR TITLE
Refactor IMessageInterceptor logic to allow for ordered interception

### DIFF
--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/IMessageInterceptor.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/IMessageInterceptor.java
@@ -3,6 +3,8 @@ package org.jumpmind.pos.core.flow;
 import org.jumpmind.pos.util.model.Message;
 
 public interface IMessageInterceptor<T extends Message> {
+    public static final int DEFAULT_ORDER = 0;
 
+    default int order() {return DEFAULT_ORDER;}
     void intercept(String appId, String nodeId, T message);
 }

--- a/openpos-peripheral/src/main/java/org/jumpmind/pos/print/EscpPOSPrinter.java
+++ b/openpos-peripheral/src/main/java/org/jumpmind/pos/print/EscpPOSPrinter.java
@@ -8,7 +8,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.text.StrSubstitutor;
 import org.jumpmind.pos.util.ClassUtils;
 import org.jumpmind.pos.util.status.Status;
-import org.jumpmind.pos.util.status.StatusReport;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
@@ -104,7 +103,7 @@ public class EscpPOSPrinter implements IOpenposPrinter {
                     throw new PrintException("The output stream for the printer driver cannot be null " +
                             "at this point. It probably was not initialized properly. (Hint: you may need to call open()");
                 }
-                if (StringUtils.containsIgnoreCase(data, printerCommands.get(PrinterCommands.CASH_DRAWER_OPEN))) {
+                if (data.contains(printerCommands.get(PrinterCommands.CASH_DRAWER_OPEN))) {
                     log.info("Sending printer command to OPEN cash drawer '{}'", station);
                     log.trace("Command sent: {}", data);
                 }

--- a/openpos-peripheral/src/main/java/org/jumpmind/pos/print/EscpPOSPrinter.java
+++ b/openpos-peripheral/src/main/java/org/jumpmind/pos/print/EscpPOSPrinter.java
@@ -3,6 +3,7 @@ package org.jumpmind.pos.print;
 import jpos.JposException;
 import jpos.POSPrinterConst;
 import jpos.services.EventCallbacks;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.text.StrSubstitutor;
 import org.jumpmind.pos.util.ClassUtils;
@@ -18,6 +19,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
+@Slf4j
 public class EscpPOSPrinter implements IOpenposPrinter {
 
     PrinterCommands printerCommands = new PrinterCommandPlaceholders();
@@ -101,6 +103,10 @@ public class EscpPOSPrinter implements IOpenposPrinter {
                 if (writer == null) {
                     throw new PrintException("The output stream for the printer driver cannot be null " +
                             "at this point. It probably was not initialized properly. (Hint: you may need to call open()");
+                }
+                if (StringUtils.containsIgnoreCase(data, printerCommands.get(PrinterCommands.CASH_DRAWER_OPEN))) {
+                    log.info("Sending printer command to OPEN cash drawer '{}'", station);
+                    log.trace("Command sent: {}", data);
                 }
                 writer.print(data);
                 writer.flush();


### PR DESCRIPTION

### Issues Fixed
- Adds support needed for PDPOS-3950

### Summary
- There was no way to add IMessageInterceptors from client code and control the order in which the interceptor was executed.  This change allows for IMessageInterceptors to be executed in the order defined by their `order` method, which enables client code to supplant behavior in the core commerce code if needed.
- Also adding some logging in the lowest level API for opening the cash drawer, so that we ensure we get a log message output whenever commerce code triggers a cash drawer to open.
