### PR TITLE
bugfix/fix-reading-drawer-and-micr-status-jserialcomm

### DIFF
--- a/openpos-peripheral/src/main/java/org/jumpmind/pos/print/PeripheralConnection.java
+++ b/openpos-peripheral/src/main/java/org/jumpmind/pos/print/PeripheralConnection.java
@@ -3,6 +3,7 @@ package org.jumpmind.pos.print;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 
 import java.io.InputStream;
@@ -11,11 +12,28 @@ import java.io.OutputStream;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@Slf4j
 public class PeripheralConnection {
+
+    private long RESET_TIMEOUT = 10000;
 
     OutputStream out;  // write to printer.
     InputStream in;  // read status, etc. from printer.
     Object rawConnection;
+
+    public void resetInput() {
+        if (in != null) {
+            try {
+                long start = System.currentTimeMillis();
+                while (in.available() > 0 && (System.currentTimeMillis()-start) <= RESET_TIMEOUT) {
+                    int readByte = in.read();
+                    log.debug("Flushing read byte {}", readByte);
+                }
+            } catch (Exception ex) {
+                throw new PrintException("Failed to resetInput", ex);
+            }
+        }
+    }
 
     public void close() {
         IOUtils.closeQuietly(in, out);


### PR DESCRIPTION

### Summary
jSerialComm appears to buffer some bytes that RXTX did not, so essentially this change resets the input stream before sending the new command and reading status.

![image](https://user-images.githubusercontent.com/4398634/97229343-9961bd80-17ae-11eb-8956-ca7aa8a7e5a2.png)
