### PR TITLE
Personalization- if url has https and no port, set port to 443

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/personalization.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/personalization.component.ts
@@ -54,7 +54,7 @@ export class PersonalizationComponent implements IScreen, OnInit {
         this.navigateExternal = this.clientUrlService.navigateExternal;
         this.serverIsSSL = window.location.protocol.includes('https');
         this.appServerAddress = window.location.hostname;
-        this.appServerPort = window.location.port;
+        this.appServerPort = window.location.port? window.location.port : this.serverIsSSL? '443': '';
 
         if (this.navigateExternal && localStorage.getItem('clientUrl')) {
             this.clientUrlService.renavigate();


### PR DESCRIPTION
-During personalization step if the url is being served with https protocol
 and no port is specified then prefill port with 443
