### PR TITLE
Cancel all executors after the state manager has been reset

### DIFF
--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/ApplicationState.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/ApplicationState.java
@@ -58,6 +58,12 @@ public class ApplicationState {
         scope.getDeviceScope().keySet().forEach(s->
                 scheduledAnnotationBeanPostProcessor.
                         postProcessBeforeDestruction(scope.getDeviceScope().get(s).getValue(), s));
+
+        scope.getDeviceScope().values().stream().
+                filter(s->s.getValue() instanceof AsyncExecutor).
+                map(s-> (AsyncExecutor)s.getValue()).
+                forEach(a->a.cancel());
+
         scope = new Scope();
         stateStack = new LinkedList<>();
         currentContext = null;

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/AsyncExecutor.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/AsyncExecutor.java
@@ -46,7 +46,7 @@ public class AsyncExecutor {
     }
 
     synchronized public <T, R> void execute(T request, Function<T, R> doWork, Consumer<R> handleResult, Consumer<Throwable> handleError) {
-       execute(request, doWork, handleResult, handleError, r-> log.info("The executor returned but the results are being ignore because it was cancelled"), null);
+       execute(request, doWork, handleResult, handleError, r-> log.info("The executor returned but the results are being ignored because it was cancelled.  The ignored results were {}", r), null);
     }
 
     synchronized public <T, R> void execute(T request, Function<T, R> doWork, Consumer<R> handleResult, Consumer<Throwable> handleError, Consumer<R> handleCancel, Runnable beforeCancel) {

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/StateManager.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/StateManager.java
@@ -166,7 +166,7 @@ public class StateManager implements IStateManager {
 
     @Override
     public void reset() {
-        log.info("StateManager resetting");
+        log.info("StateManager reset queued");
         this.actionQueue.clear();
         this.actionQueue.offer(new ActionContext(new Action(STATE_MANAGER_RESET_ACTION)));
     }
@@ -239,13 +239,13 @@ public class StateManager implements IStateManager {
                 if (actionContext != null) {
                     busyFlag.set(true);
                     if (actionContext.getAction().getName().equals(STATE_MANAGER_RESET_ACTION)) {
+                        log.info("StateManager reset queued");
                         actionContext.getAction().markProcessed();
                         runningFlag.set(false);
                         busyFlag.set(false);
                         init(this.getAppId(), this.getDeviceId());
-                        this.messageService.sendMessage(getAppId(), getDeviceId(), new Message(MessageType.Connected));
                         log.info("StateManager reset");
-                        eventPublisher.publish(new DeviceResetEvent(getDeviceId(), getAppId()));
+                        this.eventPublisher.publish(new DeviceResetEvent(getDeviceId(), getAppId()));
                         break;
                     } else if (actionContext.getAction().getName().equals(STATE_MANAGER_STOP_ACTION)) {
                         actionContext.getAction().markProcessed();

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/StateManager.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/StateManager.java
@@ -166,7 +166,7 @@ public class StateManager implements IStateManager {
 
     @Override
     public void reset() {
-        log.info("StateManager resetting.");
+        log.info("StateManager resetting");
         this.actionQueue.clear();
         this.actionQueue.offer(new ActionContext(new Action(STATE_MANAGER_RESET_ACTION)));
     }
@@ -185,6 +185,7 @@ public class StateManager implements IStateManager {
         this.eventBroadcaster = new EventBroadcaster(this);
 
         applicationState.getScope().setDeviceScope("stateManager", this);
+
         initDefaultScopeObjects();
 
         if (initialFlowConfig != null) {

--- a/openpos-flow/src/test/java/org/jumpmind/pos/core/flow/AsyncExecutorTest.java
+++ b/openpos-flow/src/test/java/org/jumpmind/pos/core/flow/AsyncExecutorTest.java
@@ -61,4 +61,30 @@ public class AsyncExecutorTest {
         }
         assertEquals(2, hit.intValue());
     }
+
+    @Test
+    public void testExecuteCancelled() {
+        final Object arg = new Object();
+        final MutableInt result = new MutableInt();
+        final MutableInt hit = new MutableInt(0);
+        asyncExecutor.execute(arg, o -> {
+            assertEquals(o, arg);
+            AppUtils.sleep(200);
+            result.increment();
+            return result;
+        } , o -> {
+            hit.increment();
+        } , throwable -> {
+            hit.increment();
+        }, o -> {
+            assertEquals(result, o);
+        });
+        asyncExecutor.cancel();
+
+        while (result.intValue() == 0) {
+            AppUtils.sleep(100);
+        }
+
+        assertEquals(0, hit.intValue());
+    }
 }

--- a/openpos-flow/src/test/java/org/jumpmind/pos/core/flow/AsyncExecutorTest.java
+++ b/openpos-flow/src/test/java/org/jumpmind/pos/core/flow/AsyncExecutorTest.java
@@ -6,6 +6,8 @@ import org.jumpmind.util.AppUtils;
 import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+
 public class AsyncExecutorTest {
 
     AsyncExecutor asyncExecutor;
@@ -67,6 +69,8 @@ public class AsyncExecutorTest {
         final Object arg = new Object();
         final MutableInt result = new MutableInt();
         final MutableInt hit = new MutableInt(0);
+        final MutableInt beforeCancel = new MutableInt(0);
+
         asyncExecutor.execute(arg, o -> {
             assertEquals(o, arg);
             AppUtils.sleep(200);
@@ -78,13 +82,13 @@ public class AsyncExecutorTest {
             hit.increment();
         }, o -> {
             assertEquals(result, o);
-        });
+        }, ()->{ beforeCancel.increment();});
         asyncExecutor.cancel();
 
         while (result.intValue() == 0) {
             AppUtils.sleep(100);
         }
-
+        assertEquals(1, beforeCancel.intValue());
         assertEquals(0, hit.intValue());
     }
 }


### PR DESCRIPTION
### Summary
State's can start asynchronous threads via `AsyncExecutors`.  If someone logs out while an AsyncExecutor is running then it needs to be marked as cancelled so that the results are handled appropriately.
