### PR TITLE
Reset to initialState on StateManager endSession()

### DIFF
--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/StateManager.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/StateManager.java
@@ -1009,6 +1009,7 @@ public class StateManager implements IStateManager {
         clearScopeOnDeviceScopeBeans(ScopeType.Session);
         refreshDeviceScope();
 
+        applicationState.setStateStack(new LinkedList<>());
         applicationState.setAppId(this.getAppId());
         applicationState.setDeviceId(this.getNodeId());
         applicationState.getScope().setDeviceScope("stateManager", this);

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/StateManager.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/StateManager.java
@@ -1009,7 +1009,6 @@ public class StateManager implements IStateManager {
         clearScopeOnDeviceScopeBeans(ScopeType.Session);
         refreshDeviceScope();
 
-        applicationState.reset();
         applicationState.setAppId(this.getAppId());
         applicationState.setDeviceId(this.getNodeId());
         applicationState.getScope().setDeviceScope("stateManager", this);

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/StateManager.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/StateManager.java
@@ -51,7 +51,6 @@ import org.jumpmind.pos.core.ui.data.UIDataMessageProvider;
 import org.jumpmind.pos.server.model.Action;
 import org.jumpmind.pos.server.service.IMessageService;
 import org.jumpmind.pos.util.ClassUtils;
-import org.jumpmind.pos.util.ObjectUtils;
 import org.jumpmind.pos.util.Versions;
 import org.jumpmind.pos.util.event.Event;
 import org.jumpmind.pos.util.model.Message;
@@ -1004,12 +1003,20 @@ public class StateManager implements IStateManager {
 
     @Override
     public void endSession() {
+        endConversation();
         applicationState.getScope().clearSessionScope();
         clearScopeOnStates(ScopeType.Session);
         clearScopeOnDeviceScopeBeans(ScopeType.Session);
         refreshDeviceScope();
-    }
 
+        applicationState.reset();
+        applicationState.setAppId(this.getAppId());
+        applicationState.setDeviceId(this.getNodeId());
+        applicationState.getScope().setDeviceScope("stateManager", this);
+        applicationState.setCurrentContext(new StateContext(initialFlowConfig, null, null));
+
+        transitionTo(new Action(StateManagerActionConstants.STARTUP_ACTION), initialFlowConfig.getInitialState());
+    }
 
     public void setInitialFlowConfig(FlowConfig initialFlowConfig) {
         this.initialFlowConfig = initialFlowConfig;


### PR DESCRIPTION
### Issues Fixed
Petco PDPOS-3950

### Summary
In order to support returning to the initial state (i.e., Home screen) from any point in the app, I've modified the StateManager endSession method to end the current conversation, clean up the application state, and then directly transition to the initial state.