### PR TITLE
Rounding isn't precise enough to avoid penny errors

### DIFF
--- a/openpos-util/src/main/groovy/org/jumpmind/pos/util/ProrationCalculator.groovy
+++ b/openpos-util/src/main/groovy/org/jumpmind/pos/util/ProrationCalculator.groovy
@@ -26,7 +26,7 @@ class ProrationCalculator {
         
         BigDecimal proratedTotal = 0.00;
         for (BigDecimal amount : existingAmounts) {
-            BigDecimal itemPct = amount.divide(amountsTotal,4, RoundingMode.HALF_UP);
+            BigDecimal itemPct = amount.divide(amountsTotal,10, RoundingMode.HALF_UP);
             BigDecimal proratedAmount = amountToBeProrated * itemPct;
             proratedAmount = moneyCalculator.amount(proratedAmount);
             proratedAmounts.add(proratedAmount);

--- a/openpos-util/src/main/groovy/org/jumpmind/pos/util/ProrationCalculator.groovy
+++ b/openpos-util/src/main/groovy/org/jumpmind/pos/util/ProrationCalculator.groovy
@@ -26,7 +26,7 @@ class ProrationCalculator {
         
         BigDecimal proratedTotal = 0.00;
         for (BigDecimal amount : existingAmounts) {
-            BigDecimal itemPct = amount.divide(amountsTotal,10, RoundingMode.HALF_UP);
+            BigDecimal itemPct = amount.divide(amountsTotal,5, RoundingMode.HALF_UP);
             BigDecimal proratedAmount = amountToBeProrated * itemPct;
             proratedAmount = moneyCalculator.amount(proratedAmount);
             proratedAmounts.add(proratedAmount);

--- a/openpos-util/src/test/groovy/org/jumpmind/pos/util/ProrationCalculatorTest.groovy
+++ b/openpos-util/src/test/groovy/org/jumpmind/pos/util/ProrationCalculatorTest.groovy
@@ -21,6 +21,17 @@ public class ProrationCalculatorTest {
         assertEquals(moneyCalculator.amount(new BigDecimal(41.14)),proratedAmounts.get(1));        		
         assertEquals(moneyCalculator.amount(new BigDecimal(12.77)),proratedAmounts.get(2));        		
     }
+
+    @Test
+    public void testProratePrecision() {
+        BigDecimal amountToBeProrated = new BigDecimal(259.90);
+        List<BigDecimal>existingAmounts = new ArrayList<BigDecimal>();
+        existingAmounts.add(new BigDecimal(59.95));
+        existingAmounts.add(new BigDecimal(199.95));
+        List<BigDecimal> proratedAmounts = prorationCalculator.prorate(amountToBeProrated, existingAmounts);
+        assertEquals(moneyCalculator.amount(new BigDecimal(59.95)),proratedAmounts.get(0));
+        assertEquals(moneyCalculator.amount(new BigDecimal(199.95)),proratedAmounts.get(1));
+    }
     
     @Test
     public void testProrateWithRemainder() {


### PR DESCRIPTION
### Summary
The rounding for the proration needs to be more precise to avoid penny rounding errors.  See unit test for the use case that this fixes.