### PR TITLE
Bugfix/keypress sources capturing both keyup and keydown master

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/lock-screen/lock-screen.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/lock-screen/lock-screen.component.html
@@ -4,7 +4,7 @@
             <app-icon [iconName]="data?.iconName" iconClass="xl"></app-icon>
             <h1>{{override ? data?.overrideText : data?.userText}}</h1>
             <app-rounded-input *ngIf="override" [placeholder]="data.usernameHint" [(value)]="username" ></app-rounded-input>
-            <app-rounded-input [placeholder]="data.passwordHint" [(value)]="password" (keydown.enter)="submit()" inputType="password"></app-rounded-input>
+            <app-rounded-input appKeypressSource [placeholder]="data.passwordHint" [(value)]="password" inputType="password"></app-rounded-input>
             <p *ngIf="!!data?.errorMessage" class="error">{{data?.errorMessage}}</p>
         </div>
         <div class="override">

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/lock-screen/lock-screen.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/lock-screen/lock-screen.component.html
@@ -4,7 +4,7 @@
             <app-icon [iconName]="data?.iconName" iconClass="xl"></app-icon>
             <h1>{{override ? data?.overrideText : data?.userText}}</h1>
             <app-rounded-input *ngIf="override" [placeholder]="data.usernameHint" [(value)]="username" ></app-rounded-input>
-            <app-rounded-input appKeypressSource [placeholder]="data.passwordHint" [(value)]="password" inputType="password"></app-rounded-input>
+            <app-rounded-input [placeholder]="data.passwordHint" [(value)]="password" inputType="password"></app-rounded-input>
             <p *ngIf="!!data?.errorMessage" class="error">{{data?.errorMessage}}</p>
         </div>
         <div class="override">

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/directives/keypress-source.directive.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/directives/keypress-source.directive.ts
@@ -1,6 +1,6 @@
-import {Directive, ElementRef, OnDestroy, OnInit, Renderer2} from '@angular/core';
-import {KeyPressProvider} from '../providers/keypress.provider';
-import {fromEvent, Subject} from 'rxjs';
+import { Directive, ElementRef, OnDestroy, OnInit, Renderer2 } from '@angular/core';
+import { KeyPressProvider } from '../providers/keypress.provider';
+import { fromEvent, Subject } from 'rxjs';
 
 @Directive({
     selector: '[appKeypressSource]',
@@ -18,22 +18,8 @@ export class KeyPressSourceDirective implements OnInit, OnDestroy {
         this.keyPressProvider.registerKeyPressSource(fromEvent<KeyboardEvent>(this.el.nativeElement, 'keyup'));
         this.keyPressProvider.registerKeyPressSource(fromEvent<KeyboardEvent>(this.el.nativeElement, 'keydown'));
 
-        this.el.nativeElement.addEventListener('keyup', (event) => {
-            if (this.keyPressProvider.keyHasSubscribers(event)) {
-                const key = this.keyPressProvider.getNormalizedKey(event);
-                console.log(`[appKeypressSource]: Handling "${event.type}" event for "${key}" for element`, this.el.nativeElement);
-            }
-        });
-
-        this.el.nativeElement.addEventListener('keydown', (event) => {
-            if (this.keyPressProvider.keyHasSubscribers(event)) {
-                const key = this.keyPressProvider.getNormalizedKey(event);
-                console.log(`[appKeypressSource]: Handling "${event.type}" event for "${key}" for element`, this.el.nativeElement);
-            }
-        });
         // Need to do this so that this element can grab key events
         this.renderer.setAttribute(this.el.nativeElement, 'tabindex', '0');
-
     }
 
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/directives/keypress-source.directive.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/directives/keypress-source.directive.ts
@@ -1,7 +1,6 @@
 import {Directive, ElementRef, OnDestroy, OnInit, Renderer2} from '@angular/core';
 import {KeyPressProvider} from '../providers/keypress.provider';
-import {fromEvent, merge, Subject} from 'rxjs';
-import {filter, takeUntil, tap} from 'rxjs/operators';
+import {fromEvent, Subject} from 'rxjs';
 
 @Directive({
     selector: '[appKeypressSource]',
@@ -16,35 +15,27 @@ export class KeyPressSourceDirective implements OnInit, OnDestroy {
     }
 
     ngOnInit(): void {
-        this.keyPressProvider.registerKeyPressSource(this.keyup$);
-        this.keyPressProvider.registerKeyPressSource(this.keydown$);
+        this.keyPressProvider.registerKeyPressSource(fromEvent<KeyboardEvent>(this.el.nativeElement, 'keyup'));
+        this.keyPressProvider.registerKeyPressSource(fromEvent<KeyboardEvent>(this.el.nativeElement, 'keydown'));
+
+        this.el.nativeElement.addEventListener('keyup', (event) => {
+            if (this.keyPressProvider.keyHasSubscribers(event)) {
+                const key = this.keyPressProvider.getNormalizedKey(event);
+                console.log(`[appKeypressSource]: Handling "${event.type}" event for "${key}" for element`, this.el.nativeElement);
+            }
+        });
+
+        this.el.nativeElement.addEventListener('keydown', (event) => {
+            if (this.keyPressProvider.keyHasSubscribers(event)) {
+                const key = this.keyPressProvider.getNormalizedKey(event);
+                console.log(`[appKeypressSource]: Handling "${event.type}" event for "${key}" for element`, this.el.nativeElement);
+            }
+        });
         // Need to do this so that this element can grab key events
         this.renderer.setAttribute(this.el.nativeElement, 'tabindex', '0');
 
-        const keydownEvent$ = fromEvent<KeyboardEvent>(this.el.nativeElement, 'keydown');
-        const keyupEvent$ = fromEvent<KeyboardEvent>(this.el.nativeElement, 'keyup');
-
-        merge(keydownEvent$, keyupEvent$).pipe(
-            filter(event => this.el.nativeElement.contains(event.target)),
-            tap(event => this.handleKeyboardEvent(event)),
-            takeUntil(this.destroyed$)
-        ).subscribe();
     }
 
-    handleKeyboardEvent(event: KeyboardEvent): void {
-        if(event.type === 'keydown') {
-            this.keydown$.next(event)
-        } else {
-            this.keyup$.next(event)
-        }
-
-        if(this.keyPressProvider.keyHasSubscribers(event)) {
-            event.stopPropagation();
-            event.preventDefault();
-            const key = this.keyPressProvider.getNormalizedKey(event);
-            console.log(`[appKeypressSource]: Handling "${event.type}" event for "${key}" for element`, this.el.nativeElement);
-        }
-    }
 
     ngOnDestroy(): void {
         this.keyPressProvider.unregisterKeyPressSource(this.keyup$);

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/providers/keypress.provider.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/providers/keypress.provider.ts
@@ -63,6 +63,7 @@ export class KeyPressProvider implements OnDestroy {
     }
 
     shouldRunGlobalAction(action: IActionItem): boolean {
+        // do we need to check if lock screen is enabled now that we stop propagation?
         const isLockScreenEnabled = this.lockScreenService.enabled.getValue();
 
         if (isLockScreenEnabled) {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/providers/keypress.provider.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/providers/keypress.provider.ts
@@ -65,7 +65,7 @@ export class KeyPressProvider implements OnDestroy {
     shouldRunGlobalAction(action: IActionItem): boolean {
         const isLockScreenEnabled = this.lockScreenService.enabled.getValue();
 
-        if(isLockScreenEnabled) {
+        if (isLockScreenEnabled) {
             const key = this.getNormalizedKey(action.keybind);
             console.warn(`[KeyPressProvider]: Blocking global action "${key}: ${action.action}" because the lock screen is active`);
         }
@@ -113,13 +113,15 @@ export class KeyPressProvider implements OnDestroy {
         this.keypressSourceUnregistered$.next();
     }
 
-    subscribe(keyOrActionList: string | string[] | IActionItem | IActionItem[], priority: number, next: (KeyboardEvent, IActionItem?) => void, stop$?: Observable<any>): Subscription {
+    subscribe(keyOrActionList: string | string[] | IActionItem | IActionItem[],
+              priority: number, next: (keyEvent: KeyboardEvent, actionItem?: IActionItem?) => void,
+              stop$?: Observable<any>, eventType$?: string): Subscription {
         if (!keyOrActionList) {
             console.warn('[KeyPressProvider]: Cannot subscribe to null or undefined or empty string keybinding');
             return null;
         }
 
-        if( !Configuration.enableKeybinds ){
+        if ( !Configuration.enableKeybinds ) {
             console.info('KeyBinds not enabled skipping subscription');
             return new Subscription();
         }
@@ -127,14 +129,18 @@ export class KeyPressProvider implements OnDestroy {
         let subscriptions;
 
         // Arrays - Recursively call this function with each item
-        if(Array.isArray(keyOrActionList)) {
-            subscriptions = (keyOrActionList as any[]).map(keyOrAction => this.subscribe(keyOrAction, priority, next, stop$));
+        if (Array.isArray(keyOrActionList)) {
+            subscriptions = (keyOrActionList as any[]).map(keyOrAction => this.subscribe(keyOrAction, priority, next, stop$, eventType$));
         } else {
             // Single item - Register the binding
             const key = typeof keyOrActionList === 'string' ? keyOrActionList : keyOrActionList.keybind;
             const action = typeof keyOrActionList === 'string' ? null : keyOrActionList;
             const keyBindings = this.parse(key);
-            subscriptions = this.registerKeyBindings(keyBindings, action, priority, next);
+            if (eventType$) {
+                subscriptions = this.registerKeyBindings(keyBindings, action, priority, next, eventType$);
+            } else {
+                subscriptions = this.registerKeyBindings(keyBindings, action, priority, next, 'keydown');
+            }
         }
 
         const mainSubscription = new Subscription(() => subscriptions.forEach(s => s.unsubscribe()));
@@ -148,8 +154,10 @@ export class KeyPressProvider implements OnDestroy {
         return mainSubscription;
     }
 
-    registerKeyBindings(keyBindings: Keybinding[], action: IActionItem, priority: number, next: (KeyboardEvent, IActionItem?) => void): Subscription[] {
-        if(!keyBindings) {
+    registerKeyBindings(keyBindings: Keybinding[], action: IActionItem, priority: number,
+                        next: (keyEvent: KeyboardEvent, actionItem?: IActionItem?) => void, eventType: string): Subscription[] {
+
+        if (!keyBindings) {
             return [];
         }
 
@@ -174,12 +182,12 @@ export class KeyPressProvider implements OnDestroy {
 
             if (this.subscribers.get(key).has(priority)) {
                 console.warn(`[KeyPressProvider]: Another subscriber already exists with key "${key}" and priority "${priority}"`);
-            } else if(action) {
+            } else if (action) {
                 console.log(`[KeyPressProvider]: Subscribed to "${key}: ${action.action}" with priority "${priority}"`);
             } else {
                 console.log(`[KeyPressProvider]: Subscribed to key "${key}" with priority "${priority}"`);
             }
-            this.subscribers.get(key).set(priority, {key, action, subscription, priority, next});
+            this.subscribers.get(key).set(priority, {key, action, subscription, priority, next, eventType});
 
             subscriptions.push(subscription);
         });
@@ -214,23 +222,23 @@ export class KeyPressProvider implements OnDestroy {
     }
 
     getNormalizedKey(obj: KeyboardEvent | Keybinding | string): string {
-        let keyBinding = typeof obj === 'string' ? this.parse(obj as string)[0] : obj as Keybinding;
+        const keyBinding = typeof obj === 'string' ? this.parse(obj as string)[0] : obj as Keybinding;
         let normalizedKey = '';
 
-        if(!keyBinding) {
+        if (!keyBinding) {
             return normalizedKey;
         }
 
-        if(keyBinding.key !== 'Control') {
+        if (keyBinding.key !== 'Control') {
             normalizedKey += (keyBinding.ctrlKey ? 'ctrl+' : '');
         }
-        if(keyBinding.key !== 'Alt') {
+        if (keyBinding.key !== 'Alt') {
             normalizedKey += (keyBinding.altKey ? 'alt+' : '');
         }
-        if(keyBinding.key !== 'Shift') {
+        if (keyBinding.key !== 'Shift') {
             normalizedKey += (keyBinding.shiftKey ? 'shift+' : '');
         }
-        if(keyBinding.key !== 'Meta') {
+        if (keyBinding.key !== 'Meta') {
             normalizedKey += (keyBinding.metaKey ? 'meta+' : '');
         }
         normalizedKey += this.escapeKey(keyBinding.key);
@@ -307,16 +315,16 @@ export class KeyPressProvider implements OnDestroy {
         const keyPressList = [];
         let keyBuffer = '';
 
-        for(let i = 0; i < keys.length; i++) {
+        for (let i = 0; i < keys.length; i++) {
             const char = keys[i];
             const nextChar = keys[i + 1];
 
             // If the delimiter is escaped, treat it as a key
-            if(char === this.keyEscape && (nextChar === this.keyDelimiter || nextChar == this.keyCombinationChar)) {
+            if (char === this.keyEscape && (nextChar === this.keyDelimiter || nextChar === this.keyCombinationChar)) {
                 keyBuffer += this.keyEscape + nextChar;
                 i++;
             // If we've reached the delimiter, and there's stuff in the buffer, add the buffer to the key list and flush buffer
-            } else if(char === this.keyDelimiter && keyBuffer) {
+            } else if (char === this.keyDelimiter && keyBuffer) {
                 keyPressList.push(keyBuffer);
                 keyBuffer = '';
             // Add the char to the key buffer
@@ -326,7 +334,7 @@ export class KeyPressProvider implements OnDestroy {
         }
 
         // Add what's left in the key buffer to the list
-        if(keyBuffer) {
+        if (keyBuffer) {
             keyPressList.push(keyBuffer);
         }
 
@@ -338,7 +346,7 @@ export class KeyPressProvider implements OnDestroy {
     }
 
     escapeKey(key: string): string {
-        if(!key.startsWith(this.keyEscape) && (key === this.keyCombinationChar || key === this.keyDelimiter)) {
+        if (!key.startsWith(this.keyEscape) && (key === this.keyCombinationChar || key === this.keyDelimiter)) {
             return this.keyEscape + key;
         }
 
@@ -351,7 +359,8 @@ export interface KeybindSubscription {
     action: IActionItem;
     subscription: Subscription;
     priority: number;
-    next: (KeyboardEvent, IActionItem?) => void;
+    eventType: string;
+    next: (keyEvent: KeyboardEvent, actionItem?: IActionItem?) => void;
 }
 
 export interface Keybinding {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/providers/keypress.provider.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/providers/keypress.provider.ts
@@ -70,7 +70,7 @@ export class KeyPressProvider implements OnDestroy {
             console.warn(`[KeyPressProvider]: Blocking global action "${key}: ${action.action}" because the lock screen is active`);
         }
 
-        return !isLockScreenEnabled;
+        return !isLockScreenEnabled && Configuration.enableKeybinds;
     }
 
     findMatchingAction(actions: IActionItem[], event: KeyboardEvent): IActionItem {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/providers/keypress.provider.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/providers/keypress.provider.ts
@@ -114,7 +114,7 @@ export class KeyPressProvider implements OnDestroy {
     }
 
     subscribe(keyOrActionList: string | string[] | IActionItem | IActionItem[],
-              priority: number, next: (keyEvent: KeyboardEvent, actionItem?: IActionItem?) => void,
+              priority: number, next: (keyEvent: KeyboardEvent, actionItem?: IActionItem) => void,
               stop$?: Observable<any>, eventType$?: string): Subscription {
         if (!keyOrActionList) {
             console.warn('[KeyPressProvider]: Cannot subscribe to null or undefined or empty string keybinding');
@@ -155,7 +155,7 @@ export class KeyPressProvider implements OnDestroy {
     }
 
     registerKeyBindings(keyBindings: Keybinding[], action: IActionItem, priority: number,
-                        next: (keyEvent: KeyboardEvent, actionItem?: IActionItem?) => void, eventType: string): Subscription[] {
+                        next: (keyEvent: KeyboardEvent, actionItem?: IActionItem) => void, eventType: string): Subscription[] {
 
         if (!keyBindings) {
             return [];
@@ -223,6 +223,7 @@ export class KeyPressProvider implements OnDestroy {
                     keybindSubscription.next(event, keybindSubscription.action);
                     event.stopPropagation();
                     event.preventDefault();
+                    console.log(`[KeyPressProvider]: Handling "${event.type}" event for "${key}" for element`, event.target);
                 }
             } else {
                 return;
@@ -266,7 +267,7 @@ export class KeyPressProvider implements OnDestroy {
         keys.forEach(theKey => {
             const keyParts = Array.from(theKey['matchAll'](this.keyRegex)).map((value: RegExpMatchArray) => value.groups.key);
 
-            if(keyParts.length === 0) {
+            if (keyParts.length === 0) {
                 return;
             }
 
@@ -369,7 +370,7 @@ export interface KeybindSubscription {
     subscription: Subscription;
     priority: number;
     eventType: string;
-    next: (keyEvent: KeyboardEvent, actionItem?: IActionItem?) => void;
+    next: (keyEvent: KeyboardEvent, actionItem?: IActionItem) => void;
 }
 
 export interface Keybinding {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.component.ts
@@ -4,8 +4,8 @@ import { Validators, FormControl, FormGroup, ValidatorFn } from '@angular/forms'
 import { ValidatorsService } from '../../../core/services/validators.service';
 import { IActionItem } from '../../../core/actions/action-item.interface';
 import { PromptFormPartInterface } from './prompt-form-part.interface';
-import {Configuration} from "../../../configuration/configuration";
-import {merge} from "rxjs";
+import {Configuration} from '../../../configuration/configuration';
+import {merge} from 'rxjs';
 
 @Component({
     selector: 'app-prompt-form-part',
@@ -72,8 +72,8 @@ export class PromptFormPartComponent extends ScreenPartComponent<PromptFormPartI
         }
         this.promptFormGroup = new FormGroup(group);
 
-        this.keyPressProvider.subscribe(this.screenData.actionButton, 100,() => this.onFormSubmit(), this.stop$);
-        this.keyPressProvider.subscribe(this.screenData.otherActions, 100,(event, action) => this.doAction(action), this.stop$);
+        this.keyPressProvider.subscribe(this.screenData.actionButton, 100, () => this.onFormSubmit(), this.stop$);
+        this.keyPressProvider.subscribe(this.screenData.otherActions, 100, (event, action) => this.doAction(action), this.stop$);
     }
 
     public keybindsEnabled() {


### PR DESCRIPTION
### Summary
Change fixes an issue where pressing 'Enter' to unlock the lock screen was also using the enter keypress to send the open store dialog action and continue opening the store. This issue resulted from the fact that both keyup and keydown events were being handled for the keypress sources which resulted in the lock screen being handled on keydown and the dialog underneath to capture and use keyup.

Changes made include:
- updating the lock-screen component to use the KeyPressProvider and keypress-source to handle the keypress rather than using a host listener
- updating keypress-source.directive.ts to make sure it's only registering the source to the provider and not also subscribing to keyup and keydown events in the source directive
- updating keypress.provider.ts to add additional optional parameter to subscribe to specify the eventType that the key should subscribe to. If this parameter is not passed in, it subscribes to 'keydown' by default.
- updating keypress.provider.ts rebuildKeyPressObserver function to filter on the event type of the subscriptions and then sort so that it is handling only subscriptions for that key and that eventType(keyup or keydown).
- updating keypress.provider.ts to check the Configuration.keybindsEnabled in the shouldRunGlobalAction function
- updating action-item-key-mapping.directive.ts so that it subscribes to both keyup and keydown to continue to handle the button styling
- cleaned up spacing and formatting
