### PR TITLE
lock screen enter button click should still work even when keybinds not enabled

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/lock-screen/lock-screen.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/lock-screen/lock-screen.component.html
@@ -4,7 +4,7 @@
             <app-icon [iconName]="data?.iconName" iconClass="xl"></app-icon>
             <h1>{{override ? data?.overrideText : data?.userText}}</h1>
             <app-rounded-input *ngIf="override" [placeholder]="data.usernameHint" [(value)]="username" ></app-rounded-input>
-            <app-rounded-input [placeholder]="data.passwordHint" [(value)]="password" inputType="password"></app-rounded-input>
+            <app-rounded-input [placeholder]="data.passwordHint" [(value)]="password" (keydown.enter)="submit($event)" inputType="password"></app-rounded-input>
             <p *ngIf="!!data?.errorMessage" class="error">{{data?.errorMessage}}</p>
         </div>
         <div class="override">

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/lock-screen/lock-screen.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/lock-screen/lock-screen.component.ts
@@ -18,25 +18,19 @@ export class LockScreenComponent implements OnDestroy {
   password = '';
   username = '';
   override = false;
-  keyPressProvider: KeyPressProvider;
-  keyPressSubscription: Subscription;
   destroy = new Subject();
 
   constructor(
       @Inject(LOCK_SCREEN_DATA) data: Observable<LockScreenMessage>,
-      private actionService: ActionService,
-      @Optional() injector: Injector) {
+      private actionService: ActionService) {
       data.pipe(
           tap( message => this.data = message),
           takeUntil(this.destroy)
       ).subscribe();
-      if ( !!injector ) {
-        this.keyPressProvider = injector.get(KeyPressProvider);
-      }
-      this.keyPressSubscription = this.keyPressProvider.subscribe('Enter', 10, () => this.submit());
   }
 
-  submit() {
+  submit($event: any) {
+    $event.stopPropagation();
     if (this.override) {
       this.doOverride();
     } else {
@@ -57,7 +51,6 @@ export class LockScreenComponent implements OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.keyPressSubscription.unsubscribe();
     this.destroy.next();
   }
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/lock-screen/lock-screen.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/lock-screen/lock-screen.component.ts
@@ -1,7 +1,6 @@
-import {Component, Inject, Injector, OnDestroy, Optional} from '@angular/core';
-import {Observable, Subject, Subscription} from 'rxjs';
+import {Component, Inject, OnDestroy} from '@angular/core';
+import {Observable, Subject} from 'rxjs';
 import {takeUntil, tap} from 'rxjs/operators';
-import { KeyPressProvider } from '../../shared/providers/keypress.provider';
 import {ActionService} from '../actions/action.service';
 import {LockScreenMessage} from '../messages/lock-screen-message';
 import {LOCK_SCREEN_DATA} from './lock-screen.service';


### PR DESCRIPTION
### Summary
change lock-screen back to handling the enter click as it was before and stop propagation on the enter. Using keypress provider caused the enter button to not work on the lock screen in the case where keybinds were not enabled & for this screen the enter button should always work.