### PR TITLE
Fixed keybinding not working after lock screen closed

### DIFF
--- a/openpos-client-libs/package-lock.json
+++ b/openpos-client-libs/package-lock.json
@@ -2070,7 +2070,8 @@
     "boolean": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.1.tgz",
-      "integrity": "sha512-HRZPIjPcbwAVQvOTxR4YE3o8Xs98NqbbL1iEZDCz7CL8ql0Lt5iOyJFxfnAB0oFs8Oh02F/lLlg30Mexv46LjA=="
+      "integrity": "sha512-HRZPIjPcbwAVQvOTxR4YE3o8Xs98NqbbL1iEZDCz7CL8ql0Lt5iOyJFxfnAB0oFs8Oh02F/lLlg30Mexv46LjA==",
+      "optional": true
     },
     "boxen": {
       "version": "1.3.0",
@@ -4432,7 +4433,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4453,12 +4455,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4473,17 +4477,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4600,7 +4607,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4612,6 +4620,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4626,6 +4635,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4633,12 +4643,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4657,6 +4669,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4737,7 +4750,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4749,6 +4763,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4834,7 +4849,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4870,6 +4886,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4889,6 +4906,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4932,12 +4950,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/lock-screen/lock-screen.service.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/lock-screen/lock-screen.service.ts
@@ -20,7 +20,7 @@ export const LOCK_SCREEN_DATA = new InjectionToken<Observable<LockScreenMessage>
 export class LockScreenService {
     private lockScreenOverlayRef: OverlayRef;
     private lockScreenData = new ReplaySubject<LockScreenMessage>();
-    public enabled = new BehaviorSubject(false);
+    public enabled$ = new BehaviorSubject(false);
 
     constructor(sessionService: SessionService,
         private overlay: Overlay,
@@ -28,12 +28,12 @@ export class LockScreenService {
         private focusService: FocusService
     ) {
         sessionService.getMessages(MessageTypes.LOCK_SCREEN).pipe(
-            tap(() => this.enabled.next(true)),
+            tap(() => this.enabled$.next(true)),
             tap(() => this.showLockScreen()),
             tap(message => this.lockScreenData.next(message))
         ).subscribe();
         sessionService.getMessages(MessageTypes.UNLOCK_SCREEN).pipe(
-            tap(() => this.enabled.next(false)),
+            tap(() => this.enabled$.next(false)),
             tap(message => this.removeLockScreen(message))
         ).subscribe();
     }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/providers/keypress.provider.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/providers/keypress.provider.ts
@@ -64,7 +64,7 @@ export class KeyPressProvider implements OnDestroy {
 
     shouldRunGlobalAction(action: IActionItem): boolean {
         // do we need to check if lock screen is enabled now that we stop propagation?
-        const isLockScreenEnabled = this.lockScreenService.enabled.getValue();
+        const isLockScreenEnabled = this.lockScreenService.enabled$.getValue();
 
         if (isLockScreenEnabled) {
             const key = this.getNormalizedKey(action.keybind);


### PR DESCRIPTION
### Issues Fixed
[#PDPOS-3836](https://petcoalm.atlassian.net/browse/PDPOS-3836)

### Summary
This fixes a bug where the keybindings stop working after the lock screen is closed. There is already a directive in place, called `[appStayFocused]`, that fixes a previous bug with the keybindings not working, and this directive was modified to include this fix. 

The fix works by listening for an `enabled` event, raised by the `LockScreenService`, and when the lock screen is not enabled focus is returned to the main application.

### Screenshots
In the screenshot, the `activeTransactionTimeout` was set to 5 seconds to shorten the wait time for the lock screen to show.

![lockscreen-keybinds-fix](https://user-images.githubusercontent.com/3991426/98713142-39921780-2355-11eb-96e0-aa6faf839406.gif)
