### PR TITLE
Fixed keybinding not working after lock screen closed

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/lock-screen/lock-screen.service.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/lock-screen/lock-screen.service.ts
@@ -20,7 +20,7 @@ export const LOCK_SCREEN_DATA = new InjectionToken<Observable<LockScreenMessage>
 export class LockScreenService {
     private lockScreenOverlayRef: OverlayRef;
     private lockScreenData = new ReplaySubject<LockScreenMessage>();
-    public enabled = new BehaviorSubject(false);
+    public enabled$ = new BehaviorSubject(false);
 
     constructor(sessionService: SessionService,
         private overlay: Overlay,
@@ -28,12 +28,12 @@ export class LockScreenService {
         private focusService: FocusService
     ) {
         sessionService.getMessages(MessageTypes.LOCK_SCREEN).pipe(
-            tap(() => this.enabled.next(true)),
+            tap(() => this.enabled$.next(true)),
             tap(() => this.showLockScreen()),
             tap(message => this.lockScreenData.next(message))
         ).subscribe();
         sessionService.getMessages(MessageTypes.UNLOCK_SCREEN).pipe(
-            tap(() => this.enabled.next(false)),
+            tap(() => this.enabled$.next(false)),
             tap(message => this.removeLockScreen(message))
         ).subscribe();
     }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/providers/keypress.provider.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/providers/keypress.provider.ts
@@ -64,7 +64,7 @@ export class KeyPressProvider implements OnDestroy {
 
     shouldRunGlobalAction(action: IActionItem): boolean {
         // do we need to check if lock screen is enabled now that we stop propagation?
-        const isLockScreenEnabled = this.lockScreenService.enabled.getValue();
+        const isLockScreenEnabled = this.lockScreenService.enabled$.getValue();
 
         if (isLockScreenEnabled) {
             const key = this.getNormalizedKey(action.keybind);


### PR DESCRIPTION
### Issues Fixed
[#PDPOS-3836](https://petcoalm.atlassian.net/browse/PDPOS-3836)

### Summary
This fixes a bug where the keybindings stop working after the lock screen is closed. There is already a directive in place, called `[appStayFocused]`, that fixes a previous bug with the keybindings not working, and this directive was modified to include this fix. 

The fix works by listening for an `enabled` event, raised by the `LockScreenService`, and when the lock screen is not enabled focus is returned to the main application.

### Screenshots
In the screenshot, the `activeTransactionTimeout` was set to 5 seconds to shorten the wait time for the lock screen to show.

![lockscreen-keybinds-fix](https://user-images.githubusercontent.com/3991426/98713142-39921780-2355-11eb-96e0-aa6faf839406.gif)
