### PR TITLE
Allow empty labels in item details

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/interfaces/additional-label.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/interfaces/additional-label.interface.ts
@@ -1,0 +1,4 @@
+export interface IAdditionalLabel {
+    label: string;
+    value: string;
+}

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/interfaces/sell-item.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/interfaces/sell-item.interface.ts
@@ -1,5 +1,6 @@
 import { IActionItem } from '../actions/action-item.interface';
 import { IItem } from './item.interface';
+import { IAdditionalLabel } from './additional-label.interface';
 
 export interface ISellItem extends IItem {
     posItemId: string;
@@ -21,10 +22,10 @@ export interface ISellItem extends IItem {
     labels: string[];
     icon: string;
     showSellingPrice: boolean;
-    additionalLabels: {label: string, value: string} [];
-    returnItemLabels: {label: string, value: string} [];
-    orderItemLabels: {label: string, value: string} [];
-    collapsedAdditionalLabels : {label: string, value: string} [];
+    additionalLabels: IAdditionalLabel [];
+    returnItemLabels: IAdditionalLabel [];
+    orderItemLabels: IAdditionalLabel [];
+    collapsedAdditionalLabels : IAdditionalLabel [];
     optionsLabel: string;
     isOrderItem: boolean;
     isTender: boolean;

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/interfaces/sell-item.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/interfaces/sell-item.interface.ts
@@ -24,7 +24,7 @@ export interface ISellItem extends IItem {
     additionalLabels: {label: string, value: string} [];
     returnItemLabels: {label: string, value: string} [];
     orderItemLabels: {label: string, value: string} [];
-    collapsedAdditionalLabels : [];
+    collapsedAdditionalLabels : {label: string, value: string} [];
     optionsLabel: string;
     isOrderItem: boolean;
     isTender: boolean;

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/item-card/item-card.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/item-card/item-card.component.html
@@ -29,14 +29,14 @@
                     </li>
                 </ul>
             </section>
-            <ul responsive-class class="item-card-details" *ngIf="filteredAdditionalLabels && !expanded">
-                <li *ngFor="let additionalLabel of filteredAdditionalLabels" class="muted-color" style="margin-top: 4px">
-                    {{additionalLabel.label}}: {{additionalLabel.value}}
+            <ul responsive-class class="item-card-details" *ngIf="item.collapsedAdditionalLabels && !expanded">
+                <li *ngFor="let additionalLabel of item.collapsedAdditionalLabels" class="muted-color" style="margin-top: 4px">
+                    <span class="item-card-details-label">{{additionalLabel.label}}</span><span class="item-card-details-value">{{additionalLabel.value}}</span>
                 </li>
             </ul>
             <ul responsive-class class="item-card-details" *ngIf="item.additionalLabels && expanded">
                 <li *ngFor="let additionalLabel of item.additionalLabels" class="muted-color">
-                    {{additionalLabel.label}}: {{additionalLabel.value}}
+                    <span class="item-card-details-label">{{additionalLabel.label}}</span><span class="item-card-details-value">{{additionalLabel.value}}</span>
                 </li>
             </ul>
         </div>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/item-card/item-card.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/item-card/item-card.component.scss
@@ -118,6 +118,10 @@
                 >* {
                     margin-top: 4px;
                 }
+
+                .item-card-details-label:not(:empty)::after {
+                    content: ': ';
+                }
             }
         }
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/item-card/item-card.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/item-card/item-card.component.scss
@@ -117,6 +117,7 @@
 
                 >* {
                     margin-top: 4px;
+                    min-height: 1rem;
                 }
 
                 .item-card-details-label:not(:empty)::after {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/item-card/item-card.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/item-card/item-card.component.ts
@@ -18,11 +18,9 @@ import { KebabLabelButtonComponent } from '../kebab-label-button/kebab-label-but
 export class ItemCardComponent implements OnDestroy {
 
   private _item:ISellItem;
-  filteredAdditionalLabels:{label: string, value: string} [];
 
   @Input() set item(item: ISellItem) {
     this._item = item;
-    this.filterAdditionalLabels();
   }
 
   get item() {
@@ -90,24 +88,16 @@ export class ItemCardComponent implements OnDestroy {
     return enabled;
   }
 
-  public filterAdditionalLabels() {
-    this.filteredAdditionalLabels = this.item.additionalLabels.filter(additionalLabel =>
-        this.item.collapsedAdditionalLabels.find(
-            label => label == additionalLabel.label
-        )
-    )
+  @HostListener('mouseenter')
+  onMouseEnter() {
+    if (this.enableHover) {
+     this.hover = true;
+    }
   }
 
-  @HostListener('mouseenter')
-  onMouseEnter() {
-    if (this.enableHover) {
-      this.hover = true;
-    }
-  }
-
-  @HostListener('mouseleave')
-  onMouseLeave() {
-    this.hover = false;
-  }
+  @HostListener('mouseleave')
+  onMouseLeave() {
+    this.hover = false;
+  }
 
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/mobile-item/mobile-item.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/mobile-item/mobile-item.component.html
@@ -26,14 +26,14 @@
                     </li>
                 </ul>
             </section>
-            <ul responsive-class class="item-card-details" *ngIf="filteredAdditionalLabels && !expanded">
-                <li *ngFor="let additionalLabel of filteredAdditionalLabels" class="muted-color" style="margin-top: 4px">
-                    {{additionalLabel.label}}: {{additionalLabel.value}}
+            <ul responsive-class class="item-card-details" *ngIf="item.collapsedAdditionalLabels && !expanded">
+                <li *ngFor="let additionalLabel of item.collapsedAdditionalLabels" class="muted-color" style="margin-top: 4px">
+                    <span class="item-card-details-label">{{additionalLabel.label}}</span><span class="item-card-details-value">{{additionalLabel.value}}</span>
                 </li>
             </ul>
             <ul responsive-class class="item-card-details" *ngIf="item.additionalLabels && expanded">
                 <li *ngFor="let additionalLabel of item.additionalLabels" class="muted-color" style="margin-top: 4px">
-                    {{additionalLabel.label}}: {{additionalLabel.value}}
+                    <span class="item-card-details-label">{{additionalLabel.label}}</span><span class="item-card-details-value">{{additionalLabel.value}}</span>
                 </li>
             </ul>
         </div>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/mobile-item/mobile-item.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/mobile-item/mobile-item.component.scss
@@ -95,6 +95,7 @@
                 margin: unset;
                 >*{
                     margin-top: 4px;
+                    min-height: 1rem;
                 }
 
                 .item-card-details-label:not(:empty)::after {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/mobile-item/mobile-item.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/mobile-item/mobile-item.component.scss
@@ -96,6 +96,10 @@
                 >*{
                     margin-top: 4px;
                 }
+
+                .item-card-details-label:not(:empty)::after {
+                    content: ': ';
+                }
             }
         }
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/mobile-item/mobile-item.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/mobile-item/mobile-item.component.ts
@@ -13,11 +13,9 @@ import { ActionService } from '../../../core/actions/action.service';
 export class MobileItemComponent {
 
     private _item: ISellItem;
-    filteredAdditionalLabels:{label: string, value: string} [];
 
     @Input() set item(item: ISellItem) {
         this._item = item;
-        this.filterAdditionalLabels();
     }
 
     get item() {
@@ -38,13 +36,5 @@ export class MobileItemComponent {
             enabled = false;
         }
         return enabled;
-    }
-
-    public filterAdditionalLabels() {
-        this.filteredAdditionalLabels = this.item.additionalLabels.filter(additionalLabel =>
-            this.item.collapsedAdditionalLabels.find(
-                label => label == additionalLabel.label
-            )
-        )
     }
 }

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/data/SellItem.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/data/SellItem.java
@@ -33,7 +33,7 @@ public class SellItem extends DefaultItem {
     private List<AdditionalLabel> additionalLabels = new ArrayList<>();
     private List<AdditionalLabel> returnItemLabels;
     private List<AdditionalLabel> orderItemLabels;
-    private List<String> collapsedAdditionalLabels = new ArrayList<>();
+    private List<AdditionalLabel> collapsedAdditionalLabels = new ArrayList<>();
     private String imageUrl;
     private String optionsLabel;
     private boolean isTender;
@@ -357,11 +357,11 @@ public class SellItem extends DefaultItem {
         return true;
     }
 
-    public List<String> getCollapsedAdditionalLabels() {
+    public List<AdditionalLabel> getCollapsedAdditionalLabels() {
         return collapsedAdditionalLabels;
     }
 
-    public void setCollapsedAdditionalLabels(List<String> collapsedAdditionalLabels) {
+    public void setCollapsedAdditionalLabels(List<AdditionalLabel> collapsedAdditionalLabels) {
         this.collapsedAdditionalLabels = collapsedAdditionalLabels;
     }
 


### PR DESCRIPTION
### Summary
Need to display empty labels on additional labels section on the item card. Previously the : was in the template moving to use css instead.
- Use CSS to display : only when the label is non-empty.
- Add IAdditionalLabel instead of using `{label: string, value: string} `.
- Change collapsedAdditionalLabels to use AdditionalLabel instead of a string.

Will have a PR for commerce later.
