### PR TITLE
add :host to ::ng-deep

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/dynamic-form-dialog/dynamic-form-dialog.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/dynamic-form-dialog/dynamic-form-dialog.component.scss
@@ -5,6 +5,6 @@
     @extend %page-spaced-content; 
 }
 
-::ng-deep .content {
+:host ::ng-deep .content {
     max-height: 50vh;
 }


### PR DESCRIPTION
### Summary
This fixes an issue where double scroll bar could appear on screens using the selection-list-screen-dialog component. The style max-height: 50vh defined in dynamic-form-dialog could be applied to other components that had class with the name content. This would only occur when navigating to a dialog that used the dynamic-form-dialog (such as add customer) then navigating back to a selection-list-screen-dialog (such as resume transaction or lookup transaction list). Adding :host will restrict the style to applying to the children of dynamic-form-dialog.
