### PR TITLE
Mobile style updates - Round 1

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/audio/audio-interaction.service.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/audio/audio-interaction.service.ts
@@ -16,6 +16,7 @@ export class AudioInteractionService implements OnDestroy {
     private destroyed$ = new Subject();
     private stop$ = new Subject();
     private config = AudioUtil.getDefaultConfig();
+    private isBeingTouched: boolean;
 
     constructor(private audioRepositoryService: AudioRepositoryService,
                 private dialogService: DialogService,
@@ -66,9 +67,13 @@ export class AudioInteractionService implements OnDestroy {
         // Use "capture" so this service hears the event even if propagation is stopped
         const mouseDown$ = fromEvent<MouseEvent>(document.body, 'mousedown', {capture: true});
         const mouseUp$ = fromEvent<MouseEvent>(document.body, 'mouseup', {capture: true});
+        const click$ = fromEvent<MouseEvent>(document.body, 'click', {capture: true});
         const mouseEvents$ = merge(mouseDown$, mouseUp$);
 
         mouseEvents$.pipe(
+            // Touch events fire first, before mouse events, so check the flag to make sure sounds for the mouse
+            // don't play for a touch-enabled deice
+            filter(() => !this.isBeingTouched),
             filter(() => this.isEnabled('mouse')),
             takeUntil(merge(this.stop$, this.destroyed$))
         ).subscribe(event => {
@@ -76,10 +81,15 @@ export class AudioInteractionService implements OnDestroy {
                 console.log('[AudioInteractionService]: Playing button mouse-down sound');
                 this.play(this.config.interactions.mouse.mouseDown);
             } else if (event.type === 'mouseup') {
-                console.log('[AudioInteractionService]: Playing button mouse-up sound')
+                console.log('[AudioInteractionService]: Playing button mouse-up sound');
                 this.play(this.config.interactions.mouse.mouseUp);
             }
         });
+
+        // Click is the last event in the touch/click sequence, so reset the flag to track if the device is being touched
+        click$.pipe(
+            takeUntil(merge(this.stop$, this.destroyed$))
+        ).subscribe(() => this.isBeingTouched = false);
     }
 
     listenForTouchInteractions(): void {
@@ -92,6 +102,9 @@ export class AudioInteractionService implements OnDestroy {
             filter(() => this.isEnabled('touch')),
             takeUntil(merge(this.stop$, this.destroyed$))
         ).subscribe(event => {
+            // Set the flag used to prevent sounds for the mouse from playing when a device is being touched
+            this.isBeingTouched = true;
+
             if (event.type === 'touchstart') {
                 console.log('[AudioInteractionService]: Playing button touch-start sound');
                 this.play(this.config.interactions.touch.touchStart);

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/dialog/generic-dialog.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/dialog/generic-dialog.component.html
@@ -10,10 +10,10 @@
                     <p [class]="l.cssClass">{{l.message}}</p>
                 </div>
             </ng-container>
-            <app-scan-part></app-scan-part>
         </mat-dialog-content>
         <mat-dialog-actions class="buttons">
             <app-prompt-button-row></app-prompt-button-row>
         </mat-dialog-actions>
     </div>
 </div>
+<app-scan-part></app-scan-part>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/home/home.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/home/home.component.scss
@@ -28,7 +28,9 @@
   &.mobile {
     min-width: 96px;
     min-height: 96px;
-    line-height: 24px;
+    line-height: 16px;
+    font-weight: normal;
+    font-size: .75rem;
   }
 }
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/options/options-screen-dialog.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/options/options-screen-dialog.component.html
@@ -1,10 +1,9 @@
-<div class="options-outer">
-    <app-dialog-header></app-dialog-header>
+<div class="options-outer" responsive-class >
+    <app-dialog-header class="options-header"></app-dialog-header>
     <div class="options-body">
         <img *ngIf="screen.imageUrl" [src]="screen.imageUrl | imageUrl" class="options-image">
         <app-instructions *ngIf="screen.prompt" [instructions]="screen.prompt" [instructionsSize]="'text-sm'"></app-instructions>
         <app-options-list class="options-list" [optionListSizeClass]="'md'" (optionClick)="doAction($event)"></app-options-list>
-        <app-scan-part></app-scan-part>
     </div>
 </div>
-
+<app-scan-part></app-scan-part>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/prompt-with-info/prompt-with-info-screen-dialog.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/prompt-with-info/prompt-with-info-screen-dialog.component.html
@@ -1,9 +1,8 @@
-
 <div class="prompt-outer">
     <app-dialog-header></app-dialog-header>
     <div class="prompt-body">
         <img *ngIf="screen.imageUrl" [src]="screen.imageUrl | imageUrl" class="prompt-image">
         <app-prompt-form-part></app-prompt-form-part>
-        <app-scan-part></app-scan-part>
     </div>
 </div>
+<app-scan-part></app-scan-part>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/prompt/prompt-screen-dialog.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/prompt/prompt-screen-dialog.component.html
@@ -3,6 +3,6 @@
     <div class="prompt-body">
         <img *ngIf="screen.imageUrl" [src]="screen.imageUrl | imageUrl" class="prompt-image" responsive-class>
         <app-prompt-form-part></app-prompt-form-part>
-        <app-scan-part></app-scan-part>
     </div>
 </div>
+<app-scan-part></app-scan-part>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/prompt/prompt-screen-dialog.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/prompt/prompt-screen-dialog.component.html
@@ -1,7 +1,7 @@
 <div class="prompt-outer">
     <app-dialog-header></app-dialog-header>
     <div class="prompt-body">
-        <img *ngIf="screen.imageUrl" [src]="screen.imageUrl | imageUrl" class="prompt-image">
+        <img *ngIf="screen.imageUrl" [src]="screen.imageUrl | imageUrl" class="prompt-image" responsive-class>
         <app-prompt-form-part></app-prompt-form-part>
         <app-scan-part></app-scan-part>
     </div>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/prompt/prompt-screen-dialog.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/prompt/prompt-screen-dialog.component.scss
@@ -15,8 +15,10 @@
         @extend %page-spaced-content; 
     
         .prompt-image {
+            max-width: 100%;
+
             &.mobile {
-                max-height: 4em;
+                display: none;
             }
             justify-self: center;
         }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/option-button/option-button.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/option-button/option-button.component.scss
@@ -12,7 +12,7 @@
     }
 
     &.mobile {
-        padding: 12px;
+        padding: 8px;
         margin: 4px 0px;
         text-align: start;
         justify-self: start;

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/primary-button/_primary-button-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/primary-button/_primary-button-theme.scss
@@ -4,10 +4,8 @@
 
     app-primary-button {
         button {
-            padding: 8px 16px;
             border-color: $primary;
             border-style: solid;
-            border-width: 2px;
             &[disabled] {
                 border-color: $disabled-border;
             }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/primary-button/primary-button.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/primary-button/primary-button.component.scss
@@ -2,20 +2,22 @@
 
 button{
   @extend %text-md;
-  padding: 8px;
+  border-width: 2px;
+  padding: $text-md/2 $text-md*1.25;
   min-width: 150px;
 
-  &.desktop-portrait {
-    padding: 12px 24px;
+  &.tablet {
     min-width: 100px;
+    padding: $text-md-mobile/4 $text-md-mobile*1.25;
   }
 
-  &.tablet{
-    min-width: 100px;
-  }
-
-  &.mobile{
+  &.mobile {
     @extend %text-sm;
     min-width: 75px;
+    padding: $text-sm-mobile/4 $text-sm-mobile*1.25;
   }
+}
+
+:host ::ng-deep app-icon {
+  margin: -4px -4px -4px 0;
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/prompt-input/prompt-input.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/prompt-input/prompt-input.component.html
@@ -1,63 +1,63 @@
 <div [formGroup]="promptFormGroup">
-        <ng-container  *ngIf="!isDateField(); else dateField" [ngSwitch]="true">   
-            <mat-form-field fxFlexFill *ngSwitchDefault ngClass="text-lg">
-                <!-- Was using this:
-                    <mat-icon matPrefix class="material-icons" color="primary">{{promptIcon}}</mat-icon>
-                    but want to be able to use local icons.  TODO: problem with styling however, sizing not working
-                    for SVG icon
-                -->
-                <button *ngIf="isScanAllowed(); else iconBlock" type="button" mat-button matPrefix mat-icon-button (click)="onScan()">
-                    <mat-icon svgIcon="barcode"></mat-icon>
-                </button> 
-                <ng-template #iconBlock>
-                    <app-icon matPrefix iconClass="material-icons md primary" [iconName]="promptIcon"></app-icon>
-                </ng-template>
-                <input matInput [errorStateMatcher]="errorMatcher" [formControlName]="'promptInputControl'" [formatterName]="responseType" cdkFocusInitial
-                       [attr.minlength]="minLength" [attr.maxlength]="maxLength" [readonly]="readOnly" [attr.type]="isNumericField() ? 'tel' : 'text'"
-                       [keyboardLayout]="keyboardLayout" autoSelectOnFocus>
-                <mat-placeholder>{{placeholderText}}</mat-placeholder>
-                <mat-hint class="text-sm" align="start">{{hintText}}</mat-hint>
-                <mat-error class="text-sm">
-                    <app-show-errors [control]="promptFormGroup.controls['promptInputControl']" [additionalValidationMessages]="validationMessages"></app-show-errors>
-                </mat-error>
-            </mat-form-field>
+    <ng-container  *ngIf="!isDateField(); else dateField" [ngSwitch]="true">
+        <mat-form-field fxFlexFill *ngSwitchDefault ngClass="prompt-text" responsive-class>
+            <!-- Was using this:
+                <mat-icon matPrefix class="material-icons" color="primary">{{promptIcon}}</mat-icon>
+                but want to be able to use local icons.  TODO: problem with styling however, sizing not working
+                for SVG icon
+            -->
+            <button *ngIf="isScanAllowed(); else iconBlock" type="button" mat-button matPrefix mat-icon-button (click)="onScan()">
+                <mat-icon svgIcon="barcode"></mat-icon>
+            </button>
+            <ng-template #iconBlock>
+                <app-icon matPrefix iconClass="material-icons md primary" [iconName]="promptIcon" responsive-class></app-icon>
+            </ng-template>
+            <input matInput [errorStateMatcher]="errorMatcher" [formControlName]="'promptInputControl'" [formatterName]="responseType" cdkFocusInitial
+                   [attr.minlength]="minLength" [attr.maxlength]="maxLength" [readonly]="readOnly" [attr.type]="isNumericField() ? 'tel' : 'text'"
+                   [keyboardLayout]="keyboardLayout" class="prompt-input" autoSelectOnFocus responsive-class>
+            <mat-placeholder>{{placeholderText}}</mat-placeholder>
+            <mat-hint class="prompt-hint" align="start" responsive-class>{{hintText}}</mat-hint>
+            <mat-error class="prompt-error">
+                <app-show-errors [control]="promptFormGroup.controls['promptInputControl']" [additionalValidationMessages]="validationMessages"></app-show-errors>
+            </mat-error>
+        </mat-form-field>
 
-            <mat-form-field fxFlexFill *ngSwitchCase="responseType==='TextArea'" ngClass="text-sm">
-                <textarea matInput [rows]="5" [cols]="40" [formControlName]="'promptInputControl'" cdkFocusInitial style="font-size:18px"
-                    [attr.minlength]="minLength" [attr.maxlength]="maxLength" [readonly]="readOnly" [attr.type]="isNumericField() ? 'tel' : 'text'" autoSelectOnFocus>
-                    </textarea>
-                    <mat-placeholder *ngIf="placeholderText" >{{placeholderText}}</mat-placeholder>
-                    <mat-placeholder *ngIf="!placeholderText">Comments</mat-placeholder>
-                    <mat-hint class="text-sm" align="start">{{hintText}}</mat-hint>
-                    <mat-error class="text-sm">
-                        <app-show-errors [control]="promptFormGroup.controls['promptInputControl']" [additionalValidationMessages]="validationMessages"></app-show-errors>
-                    </mat-error>
-            </mat-form-field>
-        
-            <mat-slide-toggle *ngSwitchCase="responseType==='ONOFF'" [formControlName]="'promptInputControl'"  (click)="onCheck()" color="primary" ngClass="text-lg">
-                {{placeholderText}} {{responseText}} 
-            </mat-slide-toggle>
-        
-            <mat-form-field fxFlexFill *ngSwitchCase="isPassword()" ngClass="text-lg">
-                <app-icon matPrefix iconClass="material-icons md primary" [iconName]="promptIcon"></app-icon>
-                <input matInput [formControlName]="'promptInputControl'" cdkFocusInitial autoSelectOnFocus
-                    type="password" [formatterName]="responseType"  [attr.minlength]="minLength" [attr.maxlength]="maxLength">
-                <mat-placeholder>{{placeholderText}}</mat-placeholder>
-                <mat-hint class="text-sm" align="start">{{hintText}}</mat-hint>
-                <mat-error class="text-sm">
+        <mat-form-field fxFlexFill *ngSwitchCase="responseType==='TextArea'" ngClass="prompt-textarea" responsive-class>
+            <textarea matInput [rows]="5" [cols]="40" [formControlName]="'promptInputControl'" cdkFocusInitial style="font-size:18px"
+                [attr.minlength]="minLength" [attr.maxlength]="maxLength" [readonly]="readOnly" [attr.type]="isNumericField() ? 'tel' : 'text'"
+                autoSelectOnFocus responsive-class>
+                </textarea>
+                <mat-placeholder *ngIf="placeholderText" >{{placeholderText}}</mat-placeholder>
+                <mat-placeholder *ngIf="!placeholderText">Comments</mat-placeholder>
+                <mat-hint class="prompt-hint" align="start" responsive-class>{{hintText}}</mat-hint>
+                <mat-error class="prompt-error">
                     <app-show-errors [control]="promptFormGroup.controls['promptInputControl']" [additionalValidationMessages]="validationMessages"></app-show-errors>
                 </mat-error>
-            </mat-form-field>
-           
+        </mat-form-field>
+
+        <mat-slide-toggle *ngSwitchCase="responseType==='ONOFF'" [formControlName]="'promptInputControl'"  (click)="onCheck()" color="primary" ngClass="text-lg">
+            {{placeholderText}} {{responseText}}
+        </mat-slide-toggle>
+
+        <mat-form-field fxFlexFill *ngSwitchCase="isPassword()" ngClass="prompt-password" responsive-class>
+            <app-icon matPrefix iconClass="material-icons md primary" [iconName]="promptIcon" responsive-class></app-icon>
+            <input matInput [formControlName]="'promptInputControl'" cdkFocusInitial autoSelectOnFocus class="prompt-input"
+                type="password" [formatterName]="responseType"  [attr.minlength]="minLength" [attr.maxlength]="maxLength" responsive-class>
+            <mat-placeholder>{{placeholderText}}</mat-placeholder>
+            <mat-hint class="prompt-hint" align="start" responsive-class>{{hintText}}</mat-hint>
+            <mat-error class="prompt-error">
+                <app-show-errors [control]="promptFormGroup.controls['promptInputControl']" [additionalValidationMessages]="validationMessages"></app-show-errors>
+            </mat-error>
+        </mat-form-field>
+    </ng-container>
+
+    <ng-template #dateField>
+        <ng-container>
+            <app-dynamic-date-form-field [controlName]="'promptInputControl'" [hiddenControl]="'promptInputHiddenDateControl'" [form]="promptFormGroup"
+            [type]="responseType" [(value)]="responseText" [placeholder]="placeholderText" [isPrompt]=true [hintText]="hintText"></app-dynamic-date-form-field>
+            <mat-error class="text-sm">
+                <app-show-errors [control]="promptFormGroup.controls['promptInputControl']" [additionalValidationMessages]="validationMessages"></app-show-errors>
+            </mat-error>
         </ng-container>
-    
-        <ng-template #dateField>
-            <ng-container>
-                <app-dynamic-date-form-field [controlName]="'promptInputControl'" [hiddenControl]="'promptInputHiddenDateControl'" [form]="promptFormGroup"
-                [type]="responseType" [(value)]="responseText" [placeholder]="placeholderText" [isPrompt]=true [hintText]="hintText"></app-dynamic-date-form-field>
-                <mat-error class="text-sm">
-                    <app-show-errors [control]="promptFormGroup.controls['promptInputControl']" [additionalValidationMessages]="validationMessages"></app-show-errors>
-                </mat-error>
-            </ng-container>
-        </ng-template>
-    </div> 
+    </ng-template>
+</div>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/prompt-input/prompt-input.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/prompt-input/prompt-input.component.scss
@@ -1,0 +1,40 @@
+@import '../../../styles/mixins/typography';
+
+.prompt-text,
+.prompt-password,
+.prompt-input {
+  @extend %text-lg;
+}
+
+.prompt-textarea,
+.prompt-hint,
+.prompt-error {
+  @extend %text-sm;
+}
+
+app-icon {
+  position: relative;
+  bottom: -5px;
+  padding: 0 $text-lg/4;
+
+  &.mobile {
+    bottom: -3px;
+    padding: 0 $text-lg-mobile/4;
+  }
+
+  &.tablet {
+    padding: 0 $text-lg-mobile/4;
+  }
+}
+
+.mat-form-field-label {
+  @extend %text-lg;
+
+  @at-root app-prompt-input .mobile .mat-form-field-label {
+    font-size: $text-lg-mobile;
+  }
+
+  @at-root app-prompt-input .tablet .mat-form-field-label {
+    font-size: $text-lg-mobile;
+  }
+}

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/prompt-input/prompt-input.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/prompt-input/prompt-input.component.ts
@@ -8,6 +8,7 @@ import { Scan } from '../../../core/oldplugins/scan';
 
 @Component({
     selector: 'app-prompt-input',
+    styleUrls: ['./prompt-input.component.scss'],
     templateUrl: './prompt-input.component.html'
 })
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/secondary-button/_secondary-button-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/secondary-button/_secondary-button-theme.scss
@@ -4,10 +4,8 @@
 
     app-secondary-button {
         button {
-            padding: 8px 16px;
             border-color: $border;
             border-style: solid;
-            border-width: 2px;
             &[disabled] {
                 border-color: $disabled-border;
             }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/secondary-button/secondary-button.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/secondary-button/secondary-button.component.scss
@@ -2,20 +2,22 @@
 
 button{
   @extend %text-md;
-  padding: 8px;
+  border-width: 2px;
+  padding: $text-md/2 $text-md*1.25;
   min-width: 150px;
 
-  &.desktop-portrait {
-    padding: 12px 24px;
+  &.tablet {
     min-width: 100px;
+    padding: $text-md-mobile/4 $text-md-mobile*1.25;
   }
 
-  &.tablet{
-    min-width: 100px;
-  }
-
-  &.mobile{
+  &.mobile {
     @extend %text-sm;
     min-width: 75px;
+    padding: $text-sm-mobile/4 $text-sm-mobile*1.25;
   }
+}
+
+:host ::ng-deep app-icon {
+  margin: -4px -4px -4px 0;
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/bacon-strip/bacon-strip.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/bacon-strip/bacon-strip.component.scss
@@ -34,17 +34,21 @@
         grid-template:  "name icon" auto
                         "id icon" auto / auto auto;
 
-        .operator-name{
+        .operator-name {
             @extend %text-sm;
             grid-area: name;
+
+            @at-root .container.mobile .rightside .operator-name {
+                font-size: .75rem;
+            }
         }
 
-        .operator-id{
+        .operator-id {
             @extend %text-xs;
             grid-area: id;
         }
 
-        .icon{
+        .icon {
             grid-area: icon;
         }
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/dialog-header/dialog-header.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/dialog-header/dialog-header.component.html
@@ -1,5 +1,5 @@
 <mat-card-title gdAreas="header backbutton" gdColumns="1fr auto" gdAlignColumns="center center">
-    <div class="header" gdArea="header" gdColumns="auto 1fr">
+    <div class="header" gdArea="header" gdColumns="auto 1fr" responsive-class>
         <app-icon   *ngIf="screenData.headerIcon" 
                     class="screen-icon" 
                     [iconName]="screenData.headerIcon"></app-icon>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/dialog-header/dialog-header.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/dialog-header/dialog-header.component.html
@@ -1,5 +1,5 @@
 <mat-card-title gdAreas="header backbutton" gdColumns="1fr auto" gdAlignColumns="center center">
-    <div gdArea="header" gdColumns="auto 1fr">
+    <div class="header" gdArea="header" gdColumns="auto 1fr">
         <app-icon   *ngIf="screenData.headerIcon" 
                     class="screen-icon" 
                     [iconName]="screenData.headerIcon"></app-icon>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/dialog-header/dialog-header.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/dialog-header/dialog-header.component.scss
@@ -1,10 +1,12 @@
 .header {
+  &.mobile {
     font-size: 1rem;
+  }
 }
 
 @supports not(display: grid) {
-    .back-button{
-        position: absolute;
-        left: 95%;
-    }
+  .back-button {
+    position: absolute;
+    left: 95%;
+  }
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/dialog-header/dialog-header.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/dialog-header/dialog-header.component.scss
@@ -1,3 +1,7 @@
+.header {
+    font-size: 1rem;
+}
+
 @supports not(display: grid) {
     .back-button{
         position: absolute;

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.component.html
@@ -28,7 +28,7 @@
                 </div>
             </app-content-card>
 
-            <div *ngIf="screenData.otherActions || screenData.actionButton" class="prompt-buttons">
+            <div *ngIf="screenData.otherActions || screenData.actionButton" class="prompt-buttons" responsive-class>
                 <app-secondary-button inputType="button" *ngFor="let menuItem of screenData.otherActions" (click)="onAction(menuItem)">
                     <span responsive-class>{{menuItem.title}}</span>
                     <app-icon *ngIf="menuItem.icon" [iconClass]="'md'" [iconName]="menuItem.icon"></app-icon>
@@ -71,7 +71,7 @@
                 </div>
             </app-content-card>
 
-            <mat-dialog-actions *ngIf="screenData.otherActions && screenData.otherActions.length > 0" class="prompt-buttons">
+            <mat-dialog-actions *ngIf="screenData.otherActions && screenData.otherActions.length > 0" class="prompt-buttons" responsive-class>
                 <app-secondary-button inputType="button" *ngFor="let menuItem of screenData.otherActions" (click)="onAction(menuItem)">
                     <span>{{menuItem.title}}</span>
                     <app-icon *ngIf="menuItem.icon" [iconClass]="'md'" [iconName]="menuItem.icon"></app-icon>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.component.html
@@ -52,7 +52,7 @@
                 </div>
             </app-content-card>
             <app-content-card>
-                <mat-dialog-content class="content">
+                <mat-dialog-content class="content" responsive-class>
                     <app-prompt-input #promptInput [placeholderText]="screenData.placeholderText" [responseType]="screenData.responseType ? screenData.responseType.toString() : null"
                                       [promptIcon]="screenData.promptIcon" [responseText]="screenData.responseText" [hintText]="screenData.hintText"
                                       [minLength]="screenData.minLength" [maxLength]="screenData.maxLength" [promptFormGroup]="promptFormGroup"

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.component.scss
@@ -24,7 +24,9 @@
         justify-content: end;
         grid-column-gap: 8px;
         &.mobile {
-            grid-column-gap: 4px;
+            grid-auto-flow: row;
+            justify-content: center;
+            grid-row-gap: 8px;
         }
     }
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel-theme.scss
@@ -14,9 +14,8 @@
         min-height: 70px;
 
         .sale-total-loyalty-button-icon {
-            padding: 0 8px;
             max-width: 100%;
-            max-height: 3em;
+            max-height: 2.75em;
         }
     }
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/scan-or-search/scan-or-search.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/scan-or-search/scan-or-search.component.html
@@ -8,6 +8,7 @@
     (buttonClick)="scannerService.triggerScan()"
     ></app-icon-square-button>
 <input #input matInput
+       responsive-class
        class="scan-input"
        ngClass.xs="scan-input-xs"
        [keyboardLayout]="keyboardLayout"

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/scan-or-search/scan-or-search.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/scan-or-search/scan-or-search.component.scss
@@ -1,9 +1,10 @@
 :host {
     border-radius: 4px;
     display:grid;
-    grid-template-columns: 0px auto 1fr;
+    grid-template-columns: 0 auto 1fr;
     grid-template-rows: auto;
-    &.focusInitial{
+
+    &.focusInitial {
         grid-template-columns: auto 1fr;
     }
 }
@@ -15,7 +16,7 @@
 
 .scan-button {
     width: 100px;
-    height: 55px;
+    height: 50px;
 }
 
 .scan-button-xs {
@@ -25,16 +26,23 @@
 
 .scan-input {
     font-size: 24px;
-    margin: 0px;
-    padding: 4px;
-    padding-left: 8px;
-    border-width: 0px;
+    margin: 0;
+    padding: 4px 4px 4px 8px;
+    border-width: 0;
     width:auto;
+
+    &.mobile-landscape {
+        font-size: 1rem;
+    }
+
+    &.mobile-portrait {
+        font-size: .75rem;
+    }
 }
 
 .scan-input-xs {
     font-size: 16px;
-    margin: 0px;
+    margin: 0;
     padding: 4px;
 }
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/_app-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/_app-theme.scss
@@ -260,10 +260,6 @@
         color: $app-primary;
     }
 
-    app-prompt-input app-icon {
-        padding: 5px;
-    }
-
     .cdk-overlay-dark-backdrop {
         background: rgba(0, 0, 0, 0.72);
     }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/_core.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/_core.scss
@@ -99,4 +99,9 @@ $mat-card-default-margin: 24px !default;
     }
   }
 
+  @media only screen and (max-width: 640px) {
+    .mat-dialog-container {
+      padding: 16px !important;
+    }
+  }
 }


### PR DESCRIPTION
### Summary
This is round 1 of some style updates for mobile.

Updates are included for:
1. Item Search Results
2. Dialogs and Buttons

*NOTE*: There's still a few bugs I'll work out, in the round of mobile updates, for the Zebra TC52 (portrait) and Zebra and TC52 Retina (landscape).

### Screenshots
#### Item Search Results
<img width="1792" alt="desktop" src="https://user-images.githubusercontent.com/3991426/99837969-6359f400-2b36-11eb-8077-278882dcfc74.png">
<img width="1134" alt="elopos--landscape" src="https://user-images.githubusercontent.com/3991426/99837614-e3cc2500-2b35-11eb-8ec9-eacf623d9e88.png">
<img width="486" alt="elopos--portrait" src="https://user-images.githubusercontent.com/3991426/99837622-e62e7f00-2b35-11eb-9e74-c32a5d236925.png">
<img width="1074" alt="ipad--landscape" src="https://user-images.githubusercontent.com/3991426/99837625-e6c71580-2b35-11eb-8c8e-f75570ba7d1f.png">
<img width="626" alt="ipad--portrait" src="https://user-images.githubusercontent.com/3991426/99837629-e75fac00-2b35-11eb-9aa8-1848c238e1e2.png">
<img width="1147" alt="ipad-pro--landscape" src="https://user-images.githubusercontent.com/3991426/99837631-e75fac00-2b35-11eb-9aae-74ba8898b7e3.png">
<img width="539" alt="ipad-pro--portrait" src="https://user-images.githubusercontent.com/3991426/99837633-e7f84280-2b35-11eb-9479-d6eedbf7769a.png">
<img width="686" alt="zebra-tc52-retina--landscape" src="https://user-images.githubusercontent.com/3991426/99837635-e7f84280-2b35-11eb-87fc-2104a201fa74.png">
<img width="445" alt="zebra-tc52-retina--portrait" src="https://user-images.githubusercontent.com/3991426/99837637-e890d900-2b35-11eb-9cc5-b430f0bb657b.png">

#### Dialogs and Buttons
<img width="1792" alt="desktop" src="https://user-images.githubusercontent.com/3991426/99837832-31e12880-2b36-11eb-8358-f88a28876203.png">
<img width="722" alt="elopos-landscape" src="https://user-images.githubusercontent.com/3991426/99837838-34438280-2b36-11eb-8e86-d8ccb5e12bf0.png">
<img width="342" alt="elopos-portrait" src="https://user-images.githubusercontent.com/3991426/99837840-34dc1900-2b36-11eb-899d-3dc73e052bd8.png">
<img width="548" alt="ipad-landscape" src="https://user-images.githubusercontent.com/3991426/99837841-34dc1900-2b36-11eb-94e5-c9758cf6f46b.png">
<img width="414" alt="ipad-portrait" src="https://user-images.githubusercontent.com/3991426/99837842-34dc1900-2b36-11eb-8fa4-355ee49c8598.png">
<img width="720" alt="ipadpro-landscape" src="https://user-images.githubusercontent.com/3991426/99837844-3574af80-2b36-11eb-9ff8-6b3bb3bab708.png">
<img width="447" alt="ipadpro-portrait" src="https://user-images.githubusercontent.com/3991426/99837846-3574af80-2b36-11eb-9199-519952f4be88.png">
<img width="925" alt="zebratc52-landscape" src="https://user-images.githubusercontent.com/3991426/99837847-3574af80-2b36-11eb-981c-5b4255670ba4.png">
<img width="327" alt="zebratc52-portrait" src="https://user-images.githubusercontent.com/3991426/99837848-360d4600-2b36-11eb-9425-33c103cba12b.png">
<img width="688" alt="zebratc52retina-landscape" src="https://user-images.githubusercontent.com/3991426/99837849-360d4600-2b36-11eb-8a84-fde837b52808.png">
<img width="379" alt="zebratc52retina-portrait" src="https://user-images.githubusercontent.com/3991426/99837851-36a5dc80-2b36-11eb-8de6-ee2af86dafef.png">

