### PR TITLE
Add module loader config

### DIFF
--- a/openpos-service/src/main/java/org/jumpmind/pos/service/ModuleLoaderConfig.java
+++ b/openpos-service/src/main/java/org/jumpmind/pos/service/ModuleLoaderConfig.java
@@ -1,0 +1,32 @@
+package org.jumpmind.pos.service;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.commons.collections4.CollectionUtils;
+
+import java.util.Set;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ModuleLoaderConfig {
+    private Set<String> includes;
+    private Set<String> excludes;
+
+    public boolean hasIncludes() {
+        return CollectionUtils.isNotEmpty(includes);
+    }
+
+    public boolean hasExcludes() {
+        return CollectionUtils.isNotEmpty(excludes);
+    }
+
+    public boolean includes(String name) {
+        return hasIncludes() && includes.contains(name);
+    }
+
+    public boolean excludes(String name) {
+        return hasExcludes() && excludes.contains(name);
+    }
+}

--- a/openpos-service/src/test/java/org/jumpmind/pos/service/AbstractRDBMSModuleTest.java
+++ b/openpos-service/src/test/java/org/jumpmind/pos/service/AbstractRDBMSModuleTest.java
@@ -1,0 +1,85 @@
+package org.jumpmind.pos.service;
+
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class AbstractRDBMSModuleTest {
+
+    AbstractRDBMSModule abstractRDBMSModule;
+
+    ModuleLoaderConfig config;
+
+    @Before
+    public void setup() {
+        abstractRDBMSModule = new AbstractRDBMSModule() {
+            @Override
+            protected String getArtifactName() {
+                return null;
+            }
+
+            @Override
+            public String getName() {
+                return "test";
+            }
+
+            @Override
+            public String getTablePrefix() {
+                return null;
+            }
+        };
+
+        config = new ModuleLoaderConfig();
+        abstractRDBMSModule.setLoaderConfig(config);
+    }
+
+    @Test
+    public void testIsDatabaseUpgradeableWhenMissingConfig() {
+        abstractRDBMSModule.setLoaderConfig(null);
+        assertTrue(abstractRDBMSModule.isDatabaseUpgradeable());
+    }
+
+    @Test
+    public void testIsDatabaseUpgradeableWhenConfigIsInIncludes() {
+        config.setIncludes(new LinkedHashSet<>(Arrays.asList("test")));
+        assertTrue(abstractRDBMSModule.isDatabaseUpgradeable());
+    }
+
+    @Test
+    public void testIsDatabaseUpgradeableWhenConfigIsNotInIncludes() {
+        config.setIncludes(new LinkedHashSet<>(Arrays.asList("nottest")));
+        assertFalse(abstractRDBMSModule.isDatabaseUpgradeable());
+    }
+
+    @Test
+    public void testIsDatabaseUpgradeableWhenConfigIsInExcludes() {
+        config.setExcludes(new LinkedHashSet<>(Arrays.asList("test")));
+        assertFalse(abstractRDBMSModule.isDatabaseUpgradeable());
+    }
+
+    @Test
+    public void testIsDatabaseUpgradeableWhenConfigIsNotInExcludes() {
+        config.setExcludes(new LinkedHashSet<>(Arrays.asList("nottest")));
+        assertTrue(abstractRDBMSModule.isDatabaseUpgradeable());
+    }
+
+    @Test
+    public void testIsDatabaseUpgradeableWhenConfigWhenInBoth() {
+        config.setExcludes(new LinkedHashSet<>(Arrays.asList("test")));
+        config.setIncludes(new LinkedHashSet<>(Arrays.asList("test")));
+        assertTrue(abstractRDBMSModule.isDatabaseUpgradeable());
+    }
+
+    @Test
+    public void testIsDatabaseUpgradeableWhenConfigWhenNotInBoth() {
+        config.setExcludes(new LinkedHashSet<>(Arrays.asList("nottest")));
+        config.setIncludes(new LinkedHashSet<>(Arrays.asList("nottest")));
+        assertFalse(abstractRDBMSModule.isDatabaseUpgradeable());
+    }
+}


### PR DESCRIPTION
### Summary
Adding new parameters to control whether to update the a module's database when starting an openpos application. If no configuration is provided will update all included modules, like the current behavior.

### Parameter Changes
`openpos.module.loaderConfig.includes` the list of modules to include for database updating. If is not empty all non-included modules will be excluded and only the included modules will be updated.
`openpos.module.loaderConfig.excludes` the list of modules to exclude for database updating. 