### PR TITLE
Mobile Dialog Style Fixes

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/prompt/prompt-screen-dialog.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/prompt/prompt-screen-dialog.component.scss
@@ -16,11 +16,15 @@
     
         .prompt-image {
             max-width: 100%;
+            justify-self: left;
+
+            &.tablet {
+                max-height: 6rem;
+            }
 
             &.mobile {
                 display: none;
             }
-            justify-self: center;
         }
     }
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/content-card/_content-card-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/content-card/_content-card-theme.scss
@@ -7,7 +7,6 @@
             background-color: $card;
             border-color: $border;
             border-style: solid;
-            border-width: 2px;
         }
     }
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/content-card/content-card.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/content-card/content-card.component.scss
@@ -8,4 +8,10 @@
     @extend %sub-element;
     display: block;
     overflow-y: auto;
+    border-width: 2px;
+
+    &.mobile,
+    &.tablet-portrait {
+        border-width: 1px;
+    }
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/primary-button/primary-button.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/primary-button/primary-button.component.scss
@@ -8,13 +8,20 @@ button{
 
   &.tablet {
     min-width: 100px;
-    padding: $text-md-mobile/4 $text-md-mobile*1.25;
+    padding: $text-md-mobile/4 $text-md-mobile;
+  }
+
+  &.tablet-portrait {
+    border-width: 1px;
+    min-width: 75px;
+    font-size: $text-xs-mobile*1.75;
   }
 
   &.mobile {
-    @extend %text-sm;
+    border-width: 1px;
+    font-size: $text-xs-mobile*1.25;
     min-width: 75px;
-    padding: $text-sm-mobile/4 $text-sm-mobile*1.25;
+    padding: $text-sm-mobile/8 $text-sm-mobile*.75;
   }
 }
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/prompt-input/prompt-input.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/prompt-input/prompt-input.component.scss
@@ -4,6 +4,10 @@
 .prompt-password,
 .prompt-input {
   @extend %text-lg;
+
+  &.mobile {
+    font-size: $text-md-mobile;
+  }
 }
 
 .prompt-textarea,

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/secondary-button/secondary-button.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/secondary-button/secondary-button.component.scss
@@ -8,13 +8,20 @@ button{
 
   &.tablet {
     min-width: 100px;
-    padding: $text-md-mobile/4 $text-md-mobile*1.25;
+    padding: $text-md-mobile/4 $text-md-mobile;
+  }
+
+  &.tablet-portrait {
+    border-width: 1px;
+    min-width: 75px;
+    font-size: $text-xs-mobile*1.75;
   }
 
   &.mobile {
-    @extend %text-sm;
+    border-width: 1px;
+    font-size: $text-xs-mobile*1.25;
     min-width: 75px;
-    padding: $text-sm-mobile/4 $text-sm-mobile*1.25;
+    padding: $text-sm-mobile/8 $text-sm-mobile*.75;
   }
 }
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/dialog-header/dialog-header.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/dialog-header/dialog-header.component.scss
@@ -1,6 +1,8 @@
+@import '../../../styles/mixins/typography';
+
 .header {
   &.mobile {
-    font-size: 1rem;
+    font-size: $text-md-mobile*.8;
   }
 }
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/variables/_spacing.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/variables/_spacing.scss
@@ -24,6 +24,9 @@ $xx-large-space: 2rem;
   &.mobile{
     padding: $large-space/$mobile-factor;
   }
+  &.mobile-landscape{
+    padding: $large-space/($mobile-factor*2);
+  }
 }
 
 %clickable-sub-element{


### PR DESCRIPTION
### Summary
This is a continuation of some style updates for mobile, and these fixes are specifically for dialogs.

### Screenshots
<img width="379" alt="zebra-tc52-retina--portrait" src="https://user-images.githubusercontent.com/3991426/100027305-8f85a700-2dba-11eb-9889-fb28a36eafad.png">
<img width="679" alt="zebra-tc52-retina--landscape" src="https://user-images.githubusercontent.com/3991426/100027312-90b6d400-2dba-11eb-95bb-20db822444e1.png">
<img width="327" alt="zebra-tc52--portrait" src="https://user-images.githubusercontent.com/3991426/100027318-91e80100-2dba-11eb-8cf6-06daa2830e31.png">
<img width="1000" alt="zebra-tc52--landscape" src="https://user-images.githubusercontent.com/3991426/100027321-92809780-2dba-11eb-9b7a-d3677ce17b13.png">
<img width="364" alt="elopos--portrait" src="https://user-images.githubusercontent.com/3991426/100027327-92809780-2dba-11eb-83b4-89e825f48610.png">
<img width="1030" alt="elopos--landscape" src="https://user-images.githubusercontent.com/3991426/100027328-93192e00-2dba-11eb-8db8-0783888c1fb4.png">
<img width="792" alt="ipad--landscape" src="https://user-images.githubusercontent.com/3991426/100027331-93b1c480-2dba-11eb-8ee4-e326db88db56.png">
<img width="431" alt="ipad--portrait" src="https://user-images.githubusercontent.com/3991426/100027332-93b1c480-2dba-11eb-9780-1dccbfb9d5b7.png">
<img width="464" alt="ipadpro--portrait" src="https://user-images.githubusercontent.com/3991426/100027333-93b1c480-2dba-11eb-9043-8c8de2092578.png">
<img width="720" alt="ipadpro--landscape" src="https://user-images.githubusercontent.com/3991426/100027335-944a5b00-2dba-11eb-9861-eb29fbc7a6b7.png">

