### PR TITLE
Bugfix/updates to item detail component master

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.html
@@ -18,6 +18,8 @@
         <h3 responsive-class>
             {{screen.promotions.length > 0 ? screen.itemPromotionsTitle : screen.itemNoPromotionsTitle}}
         </h3>
+        <app-instructions *ngIf="screen.promotions && screen.promotions.length > 1"  [instructions]="screen.promotionStackingDisclaimer"
+            [instructionsSize]="'text-md'"></app-instructions>
         <div class="promotion-items">
             <ng-container *ngFor="let promo of screen.promotions">
                 <div class="promotion-item-icon">

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.html
@@ -26,7 +26,11 @@
                 <div class="promotion-item-name">
                     {{promo.promotionName}}
                 </div>
-                <div class="promotion-item-price"><app-currency-text [amountText]="promo.promotionPrice"></app-currency-text></div>
+                <ul responsive-class class="promotion-item-rewards">
+                    <li *ngFor="let reward of promo.rewards">
+                        {{reward}}
+                    </li>
+                </ul>
             </ng-container>
         </div>
     </section>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.scss
@@ -77,12 +77,14 @@ app-options-list {
 
 .promotion-items {
     display: grid;
-    grid-template-columns: auto 65% 1fr;
+    grid-template-columns: auto 60% 1fr;
 }
 
-.promotion-item-price {
-    justify-self: end;
-    align-self: center;
+.promotion-item-rewards {
+    align-self: end;
+    list-style-type: none;
+    padding-inline-start: 0;
+    @extend %text-md;
 }
 
 .promotion-item-name {
@@ -91,6 +93,10 @@ app-options-list {
 
 .promotion-icon {
     margin-right: 1rem;
+}
+
+.promotion-item-icon {
+    align-self: center;
 }
 
 .properties {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.interface.ts
@@ -13,4 +13,5 @@ export interface ItemDetailInterface extends IAbstractScreen {
     itemPromotionsTitle: string;
     itemNoPromotionsTitle: string;
     promotions: IPromotionInterface[];
+    promotionStackingDisclaimer: string;
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/promotion.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/promotion.interface.ts
@@ -9,7 +9,6 @@ export interface IPromotionInterface extends IAbstractScreen {
     autoApply: boolean;
     maxUses: number;
     vendorFunded: boolean;
-    rewardApplicationTypeCode: string;
     forLoyaltyReward: boolean;
-    promotionPrice: string;
+    rewards: string[];
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/promotion.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/promotion.interface.ts
@@ -9,6 +9,7 @@ export interface IPromotionInterface extends IAbstractScreen {
     autoApply: boolean;
     maxUses: number;
     vendorFunded: boolean;
+    rewardApplicationTypeCode: string;
     forLoyaltyReward: boolean;
     rewards: string[];
 }

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/data/Promotion.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/data/Promotion.java
@@ -22,6 +22,7 @@ public class Promotion implements Serializable {
     boolean autoApply = true;
     BigDecimal maxUses;
     boolean vendorFunded;
+    String rewardApplicationTypeCode;
     boolean forLoyaltyReward;
     List<String> rewards;
 }

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/data/Promotion.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/data/Promotion.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.util.List;
 
 @Builder
 @Data
@@ -21,7 +22,6 @@ public class Promotion implements Serializable {
     boolean autoApply = true;
     BigDecimal maxUses;
     boolean vendorFunded;
-    String rewardApplicationTypeCode;
     boolean forLoyaltyReward;
-    String promotionPrice;
+    List<String> rewards;
 }

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/ItemDetailUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/ItemDetailUIMessage.java
@@ -27,6 +27,7 @@ public class ItemDetailUIMessage extends UIMessage {
     private String itemPromotionsTitle;
     private String itemNoPromotionsTitle;
     private List<Promotion> promotions;
+    private String promotionStackingDisclaimer;
 
 
     public void addItemProperty(DisplayProperty property) {


### PR DESCRIPTION
### Summary
Update item detail component to show reward(s) for the promotion rather than the promoted price since the promoted price can't be accurately calculated. With change to list more complex promos, the promoted price of the item may depend on what else is in the transaction such as is the case of a transaction percent off promotion or whether another promotion also gets applied to the item.

### Screenshots
Image shows example of complex promotion that has two reward models as well as another item level promo with a general disclaimer about stacking rules.
<img width="1679" alt="Screen Shot 2020-12-02 at 1 13 53 PM" src="https://user-images.githubusercontent.com/6811136/100915014-d736bd80-34a1-11eb-8a55-b57e3a7c82fe.png">

