### PR TITLE
Added dark-blue theme

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/interfaces/sell-item.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/interfaces/sell-item.interface.ts
@@ -13,6 +13,7 @@ export interface ISellItem extends IItem {
     size: string;
     longDescription: string;
     type: string;
+    lineItemType: string;
     prop65Item: boolean;
     prop65WarningText: string;
     styleNumber: string;

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/currency-text/currency-text.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/currency-text/currency-text.component.html
@@ -1,1 +1,1 @@
-<span class="currency-text-before-symbol">{{textBeforeSymbol}}</span><span class="currency-symbol-text">{{symbolText}}</span><span class="currency-text-after-symbol">{{textAfterSymbol}}</span>
+<span [ngClass]="{'negative': isNegative}" class="currency-text-before-symbol">{{textBeforeSymbol}}</span><span [ngClass]="{'negative': isNegative}" class="currency-symbol-text">{{symbolText}}</span><span [ngClass]="{'negative': isNegative}" class="currency-text-after-symbol">{{textAfterSymbol}}</span>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/currency-text/currency-text.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/currency-text/currency-text.component.ts
@@ -27,6 +27,7 @@ export class CurrencyTextComponent implements OnChanges {
     textBeforeSymbol: string;
     textAfterSymbol: string;
     symbolText: string;
+    isNegative: boolean;
 
     constructor(private localeService: LocaleService) {}
 
@@ -36,7 +37,7 @@ export class CurrencyTextComponent implements OnChanges {
 
         let localAmtText = this.amountText || (typeof(this.amountText) === 'number') ? this.amountText.toString().trim() : null;
         if (localAmtText) {
-            const hasNegSign = localAmtText.indexOf('-') >= 0;
+            this.isNegative = localAmtText.indexOf('-') >= 0;
             const hasParens = localAmtText.indexOf('(') >= 0;
             // CurrencyPipe does not like text starting with open paren
             localAmtText = this.normalizeNegativeAmount(localAmtText);

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/item-card/item-card.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/item-card/item-card.component.html
@@ -1,4 +1,4 @@
-<mat-card class="item-card" [ngClass]="{'mat-elevation-z5':hover, 'mat-elevation-z1':!hover}">
+<mat-card class="item-card" [class]="item.lineItemType | lowercase" [ngClass]="{'mat-elevation-z5':hover, 'mat-elevation-z1':!hover}">
     <mat-card-content class="item-content">
         <app-image responsive-class
                    class="item-card-image"

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/data/DefaultItem.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/data/DefaultItem.java
@@ -4,13 +4,18 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import org.jumpmind.pos.core.model.FormDisplayField;
 import org.jumpmind.pos.core.ui.IItem;
 
+@Data
 public class DefaultItem implements IItem, Serializable {
     private static final long serialVersionUID = 1L;
     
-    private String id;
+    private String iD;
     private Integer index;
     private String description;
     protected String subtitle;
@@ -19,6 +24,7 @@ public class DefaultItem implements IItem, Serializable {
     private List<FormDisplayField> fields = new ArrayList<>();;
     private boolean selected = false;
     private String type;
+    private String lineItemType;
     private boolean enabled = true;
 
     public DefaultItem() {}
@@ -29,106 +35,12 @@ public class DefaultItem implements IItem, Serializable {
         this.amount = amount;
     }
     
-    @Override
-    public Integer getIndex() {
-        return this.index;
-    }
-
-    @Override
-    public void setIndex(Integer index) {
-        this.index = index;
-    }
-
-    @Override
-    public String getID() {
-        return this.id;
-    }
-
-    @Override
-    public void setID(String id) {
-        this.id = id;
-    }
-
-    @Override
-    public String getDescription() {
-        return description;
-    }
-
-    @Override
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    @Override
-    public String getSubtitle() {
-        return subtitle;
-    }
-    @Override
-    public void setSubtitle(String subtitle) {
-        this.subtitle = subtitle;
-    }
-    @Override
-    public String getAmount() {
-        return amount;
-    }
-    @Override
-    public void setAmount(String amount) {
-        this.amount = amount;
-    }
-
-    @Override
-    public List<FormDisplayField> getFields() {
-        return fields;
-    }
-
-    @Override
-    public void setFields(List<FormDisplayField> fields) {
-        this.fields = fields;
-    }
-    
     public void addField(FormDisplayField field) {
         this.fields.add(field);
     }
     
-    @Override
-    public boolean isSelected() {
-        return this.selected;
-    }
-    
-    @Override
-    public void setSelected(boolean selected) {
-        this.selected = selected;
-    }
-
-    public List<String> getLabels() {
-        return labels;
-    }
-
-    public void setLabels(List<String> labels) {
-        this.labels = labels;
-    } 
-    
     public void addLabel( String label ) {
         this.labels.add( label );
     }
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
-    }
-
-    @Override
-    public void setEnabled(boolean enabled) {
-        this.enabled = enabled;        
-    }
-
-    @Override
-    public boolean isEnabled() {
-        return enabled;
-    }
-    
 }
 


### PR DESCRIPTION
### Issues Fixed
[PDPOS-4222](https://petcoalm.atlassian.net/browse/PDPOS-4222)

### Summary
This adds a new **Dark Blue** theme that's used by **Petco**.

### Screenshots

#### Home
<img width="1792" alt="Screen Shot 2020-12-02 at 2 30 25 PM" src="https://user-images.githubusercontent.com/3991426/100932963-a1ea9980-34ba-11eb-9ce2-9fd37482153d.png">

#### Crispy Bacon Menu
<img width="1792" alt="Screen Shot 2020-12-02 at 2 38 18 PM" src="https://user-images.githubusercontent.com/3991426/100932914-97300480-34ba-11eb-8718-19d6772f2810.png">

#### Dialogs/Popups
<img width="1792" alt="Screen Shot 2020-12-02 at 2 34 19 PM" src="https://user-images.githubusercontent.com/3991426/100932924-97c89b00-34ba-11eb-8c74-2212f4279676.png">
<img width="1792" alt="Screen Shot 2020-12-02 at 2 30 44 PM" src="https://user-images.githubusercontent.com/3991426/100932936-9b5c2200-34ba-11eb-9761-bee4e3ad2266.png">
<img width="1792" alt="Screen Shot 2020-12-02 at 2 31 02 PM" src="https://user-images.githubusercontent.com/3991426/100932934-9ac38b80-34ba-11eb-969a-51f5c8993ae4.png">

#### Forms
<img width="1792" alt="Screen Shot 2020-12-02 at 2 31 45 PM" src="https://user-images.githubusercontent.com/3991426/100932931-99925e80-34ba-11eb-8337-ac327924a921.png">

#### Negative Values
<img width="1792" alt="Screen Shot 2020-12-02 at 2 33 58 PM" src="https://user-images.githubusercontent.com/3991426/100932925-98613180-34ba-11eb-85d1-88494bbae562.png">

#### Line Item Type Styling (coupons have a specific background color)
<img width="1792" alt="Screen Shot 2020-12-02 at 2 33 08 PM" src="https://user-images.githubusercontent.com/3991426/100932927-98f9c800-34ba-11eb-8cc3-67f7276754f5.png">

#### Item Search Results
<img width="1792" alt="Screen Shot 2020-12-02 at 2 32 20 PM" src="https://user-images.githubusercontent.com/3991426/100932929-98f9c800-34ba-11eb-9e21-8cd5cf166b2c.png">

#### Reports
<img width="1792" alt="Screen Shot 2020-12-02 at 2 39 40 PM" src="https://user-images.githubusercontent.com/3991426/100932910-95fed780-34ba-11eb-9b3f-682ec00add83.png">

#### Manage Users
<img width="1792" alt="Screen Shot 2020-12-02 at 2 41 36 PM" src="https://user-images.githubusercontent.com/3991426/100932908-94351400-34ba-11eb-9bf6-febd5d2c674c.png">
