### PR TITLE
Mask scan data to hide info like drivers licenses

### DIFF
--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/util/ActionSerializer.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/util/ActionSerializer.java
@@ -1,12 +1,10 @@
 package org.jumpmind.pos.core.util;
 
 import java.io.IOException;
+import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
-import org.jumpmind.pos.core.model.FieldInputType;
-import org.jumpmind.pos.core.model.Form;
-import org.jumpmind.pos.core.model.FormField;
-import org.jumpmind.pos.core.model.IFormElement;
+import org.jumpmind.pos.core.model.*;
 import org.jumpmind.pos.server.model.Action;
 import org.jumpmind.pos.util.ObjectUtils;
 
@@ -34,6 +32,9 @@ public class ActionSerializer extends JsonSerializer<Action> {
             if (StringUtils.containsAny(clone.getName().toLowerCase(), LogFormatter.SENSITIVE_FIELDS)) {
                 if (clone.getData() instanceof String) {
                     clone.setData(MASKED_STRING);
+                } else if (clone.getData() instanceof Map) {
+                    Map data = clone.getData();
+                    data.replaceAll((key, old) -> MASKED_STRING);
                 }
             }
         }
@@ -56,7 +57,7 @@ public class ActionSerializer extends JsonSerializer<Action> {
                 }
             }
         }
-        
+
         defaultSerializer.serialize(clone, gen, serializers);
     }
 

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/util/LogFormatter.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/util/LogFormatter.java
@@ -27,7 +27,7 @@ public class LogFormatter {
             "password", "account", "cid", "creditcard", 
             "cardNumber", "driverLicense", "pinblock", "routingnumber", "walletidentifier", 
             "emvdata", "track1", "track2", "track3", "approvalcode", "ksnblock", "cardexpirydate", "referralnum",
-            "ecomtoken", "issuernumber", "socialsec" };
+            "ecomtoken", "issuernumber", "socialsec", "scan" };
 
     
     private ObjectMapper mapper = new ObjectMapper().setSerializationInclusion(Include.NON_NULL);

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/util/LogFormatter.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/util/LogFormatter.java
@@ -27,7 +27,7 @@ public class LogFormatter {
             "password", "account", "cid", "creditcard", 
             "cardNumber", "driverLicense", "pinblock", "routingnumber", "walletidentifier", 
             "emvdata", "track1", "track2", "track3", "approvalcode", "ksnblock", "cardexpirydate", "referralnum",
-            "ecomtoken", "issuernumber", "socialsec", "scan" };
+            "ecomtoken", "issuernumber", "socialsec", "driverslicense" };
 
     
     private ObjectMapper mapper = new ObjectMapper().setSerializationInclusion(Include.NON_NULL);


### PR DESCRIPTION
### Summary
Mask scan data to hide sensitive info like drivers licenses when the server receives an Action

The resulting logging for the action would look like:
```
2020-12-03 16:41:52.818 INFO  [pos:11111-111] [clientInboundChannel-2] [ScreenService] Received action from 11111-111
{
  "name" : "ScanDriversLicense",
  "data" : {
    "data" : "********************",
    "rawData" : "********************"
  },
  "type" : "Screen",
  "doNotBlockForResponse" : false
} 
```