### PR TITLE
Upgraded Lombok to 1.18.16

### DIFF
--- a/openpos-gradle/src/main/resources/java.gradle
+++ b/openpos-gradle/src/main/resources/java.gradle
@@ -26,7 +26,7 @@ ext {
     springfoxSwaggerVersion='2.9.2'
     javaposVersion='1.14.2'
     jacksonVersion='2.8.10'
-    lombokVersion='1.18.6'
+    lombokVersion='1.18.16'
     snakeYamlVersion='1.23'
 }
 


### PR DESCRIPTION
### Summary
In order to compile the project using IntelliJ 2020.3 Lombok is required to be under version `1.18.16` or later. See mplushnikov/lombok-intellij-plugin#988.
