### PR TITLE
Add `ClientContext` default for `businessUnitId`

### DIFF
--- a/openpos-util/src/main/java/org/jumpmind/pos/util/clientcontext/ClientContext.java
+++ b/openpos-util/src/main/java/org/jumpmind/pos/util/clientcontext/ClientContext.java
@@ -20,6 +20,9 @@ public class ClientContext {
     @Value("${openpos.installationId:'not set'}")
     String installationId;
 
+    @Value("${openpos.businessunitId:'not set'}")
+    String businessUnitId;
+
     public void put(String name, String value) {
         if (propertiesMap.get() == null) {
             propertiesMap.set(new HashMap<>());
@@ -34,6 +37,8 @@ public class ClientContext {
         if (props == null || !props.containsKey(name)) {
             if ("deviceId".equals(name)) {
                 return installationId;
+            } else if ("businessUnitId".equals(name)) {
+                return businessUnitId;
             } else if ("appId".equals(name)) {
                 return "server";
             } else if ("timezoneOffset".equals(name)) {


### PR DESCRIPTION
### Summary
Adds a reasonable default implementation for `businessUnitId` lookups within the `ClientContext`. This mimics the behavior of `installationId` and is useful for inferring the `businessUnitId` during endpoint requests.