### PR TITLE
Retain focus on poptart input

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/dynamic-form-field/dynamic-form-field.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/dynamic-form-field/dynamic-form-field.component.html
@@ -21,7 +21,7 @@
                  
             <input class="poptart" *ngSwitchCase="'PopTart'" matInput [formControlName]="formField.id" [formControl]="formGroup.controls[formField.id]" [placeholder]="getPlaceholderText(formField)"
                  [required]="formField.required" (click)="openPopTart()" 
-                 onfocus="this.blur()" readonly id="{{formField.id}}">
+                 readonly id="{{formField.id}}">
 
             <button *ngIf="formField.inputType==='PopTart'" type="button" mat-button matSuffix mat-icon-button (click)="openPopTart()">
                 <mat-icon>more_vert</mat-icon>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/dynamic-form-field/dynamic-form-field.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/dynamic-form-field/dynamic-form-field.component.ts
@@ -180,6 +180,7 @@ export class DynamicFormFieldComponent implements OnInit, OnDestroy, AfterViewIn
     dialogRef.afterClosed().subscribe(result => {
       console.info('pop tart closed with value of: ' + result);
       this.formGroup.get(this.formField.id).setValue(result);
+      this.field.focus();
       this.onFormElementChanged(this.formField);
     });
   }


### PR DESCRIPTION
### Issues Fixed
https://petcoalm.atlassian.net/browse/PDPOS-4496

### Summary
PopTart input types were losing focus when changed, causing the user to have to manually advance the form rather than just hitting the enter button. This change ensures the input retains focus when the dialog has been closed.
