### PR TITLE
update primary-button and secondary-buttons to add padding on the app…

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/primary-button/primary-button.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/primary-button/primary-button.component.scss
@@ -27,4 +27,5 @@ button{
 
 :host ::ng-deep app-icon {
   margin: -4px -4px -4px 0;
+  padding: 4px;
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/secondary-button/secondary-button.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/secondary-button/secondary-button.component.scss
@@ -27,4 +27,5 @@ button{
 
 :host ::ng-deep app-icon {
   margin: -4px -4px -4px 0;
+  padding: 4px;
 }


### PR DESCRIPTION
### Summary
update primary-button and secondary-buttons to add padding on the app-icon so that there is some space between icon and text

### Screenshots
Without padding:
<img width="217" alt="Screen Shot 2020-12-17 at 6 15 31 PM" src="https://user-images.githubusercontent.com/6811136/102555240-6217da80-4094-11eb-89ba-52ee8e0c59a2.png">
With padding:
<img width="228" alt="Screen Shot 2020-12-17 at 6 14 56 PM" src="https://user-images.githubusercontent.com/6811136/102555260-6d6b0600-4094-11eb-8d22-3a55856d747f.png">

