### PR TITLE
Add Prompt Buttons Support to Options Screen

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/options/options-screen-dialog.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/options/options-screen-dialog.component.html
@@ -7,3 +7,4 @@
     </div>
 </div>
 <app-scan-part></app-scan-part>
+<app-prompt-button-row></app-prompt-button-row>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/options/options-screen-dialog.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/options/options-screen-dialog.component.scss
@@ -44,3 +44,7 @@
         }
     }
 }
+
+app-prompt-button-row {
+    margin-top: 24px;
+}


### PR DESCRIPTION
### Summary
Adds the ability to include prompt buttons to the options screen. This is useful when there are special actions that are supported on a view.

### Screenshots
![Screen Shot 2020-12-18 at 9 19 21 AM](https://user-images.githubusercontent.com/2295721/102636632-20c61000-4112-11eb-8300-538210f58f48.png)

