### PR TITLE
Lookup and resave fails on postgres with tagged models

### DIFF
--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AbstractTaggedModel.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AbstractTaggedModel.java
@@ -20,6 +20,9 @@ abstract public class AbstractTaggedModel extends AbstractModel implements ITagg
 
     @Override
     public void setTags(Map<String, String> tags) {
+        if (!(tags instanceof CaseInsensitiveMap)) {
+            tags = new CaseInsensitiveMap<>(tags);
+        }
         this.tags = tags;
     }
 

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/TagHelper.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/TagHelper.java
@@ -6,9 +6,11 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -114,7 +116,7 @@ public class TagHelper {
      }
      
      protected Map<String, String> additionalFieldsToTags(Map<String, Object> additionalFields) {
-         Map<String, String> tags = new HashMap<>();
+         Map<String, String> tags = new CaseInsensitiveMap<>();
          for (String columnName : additionalFields.keySet()) {
              String columnUpper = columnName.toUpperCase();
              if (columnUpper.startsWith(TagModel.TAG_PREFIX)) {


### PR DESCRIPTION
### Summary
Lookup and resave fails on postgres with tagged models because the lookup overrides the case insensitive map with a case sensitive one.