### PR TITLE
Fixed sales total panel hiding loyalty button after capturing id

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.html
@@ -39,7 +39,7 @@
             {{screenData.taxExemptCertificateDetail.label}}: {{screenData.taxExemptCertificateDetail.value}}
         </div>
         <app-secondary-button responsive-class
-                              *ngIf="!screenData.readOnly && !screenData.customer && screenData.loyaltyButton"
+                              *ngIf="!screenData.readOnly && !screenData.linkedCustomerButton && screenData.loyaltyButton"
                               [actionItem]="screenData.loyaltyButton"
                               (actionClick)="doMenuItemAction(screenData.loyaltyButton)"
                               (click)="doMenuItemAction(screenData.loyaltyButton)" class="sale-total-loyalty-button">


### PR DESCRIPTION
### Summary
This fixes a bug where the loyalty button would hide after capturing a user's id during a return.

### Screenshots
![returns-capture-id-should-not-hide-loyalty-button](https://user-images.githubusercontent.com/3991426/102826061-f55f5180-43ad-11eb-9c1f-944706948935.gif)

