### PR TITLE
update item-detail to show the list of promotions across the entire s…

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.html
@@ -19,7 +19,7 @@
             {{screen.promotions.length > 0 ? screen.itemPromotionsTitle : screen.itemNoPromotionsTitle}}
         </h3>
         <app-instructions *ngIf="screen.promotions && screen.promotions.length > 1"  [instructions]="screen.promotionStackingDisclaimer"
-            [instructionsSize]="'text-md'"></app-instructions>
+            [instructionsSize]="'text-sm'"></app-instructions>
         <div class="promotion-items">
             <ng-container *ngFor="let promo of screen.promotions">
                 <div class="promotion-item-icon">

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.scss
@@ -31,7 +31,7 @@ p{
     @extend %sub-element-container;
     @extend %page-gutter;
     @extend %page-element;
-    width: 75%;
+    width: 100%;
     height: 100%;
     overflow-y: auto;
     align-self: center;

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.scss
@@ -14,6 +14,11 @@ h1{
     margin: 0;
 }
 
+h3{
+    font-weight: normal;
+    margin: 0;
+}
+
 p{
     grid-area: summary;
     @extend %text-md;
@@ -33,8 +38,8 @@ p{
     justify-self: center;
     grid-template: "image title" auto
                     "image summary" auto
-                    "image properties" 1fr
-                    "image promotions" 1fr
+                    "image properties" auto
+                    "promotions promotions" 1fr
                     "actions actions" auto/ auto 1fr;
     &.mobile,
     &.tablet-portrait{


### PR DESCRIPTION
### Summary
update item-detail to show the list of promotions across the entire section under the image and item properties

### Screenshots
Before:
<img width="769" alt="Screen Shot 2020-12-22 at 4 57 24 PM" src="https://user-images.githubusercontent.com/6811136/102937533-6834ff00-4478-11eb-9496-fb1b0a613ae2.png">
<img width="959" alt="Screen Shot 2020-12-22 at 4 57 40 PM" src="https://user-images.githubusercontent.com/6811136/102937544-6cf9b300-4478-11eb-8402-1f5af5a4d1b2.png">
<img width="1394" alt="Screen Shot 2020-12-22 at 4 58 06 PM" src="https://user-images.githubusercontent.com/6811136/102937560-73882a80-4478-11eb-82c7-a389ba37d53a.png">

After:
<img width="770" alt="Screen Shot 2020-12-22 at 5 03 45 PM" src="https://user-images.githubusercontent.com/6811136/102937579-81d64680-4478-11eb-981e-f480f1dd23f1.png">
<img width="959" alt="Screen Shot 2020-12-22 at 5 04 20 PM" src="https://user-images.githubusercontent.com/6811136/102937619-94e91680-4478-11eb-9b1b-0e8a44231114.png">
<img width="1220" alt="Screen Shot 2020-12-22 at 5 03 20 PM" src="https://user-images.githubusercontent.com/6811136/102937651-a3cfc900-4478-11eb-8ed8-3be40ac98fd6.png">


