### PR TITLE
Toast container (#1009) - Cherry pick into master

### DIFF
--- a/openpos-client-libs/package-lock.json
+++ b/openpos-client-libs/package-lock.json
@@ -7756,6 +7756,14 @@
         "tslib": "^1.9.0"
       }
     },
+    "ngx-toastr": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ngx-toastr/-/ngx-toastr-10.1.0.tgz",
+      "integrity": "sha512-LXGL8jKIm0SGklkXytNKbR6VrF94all35SaUfgd1gOUzgllTW2ldqORDZlgIaiMB3Dcybaald8p3boEHvfjEIQ==",
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",

--- a/openpos-client-libs/package.json
+++ b/openpos-client-libs/package.json
@@ -41,6 +41,7 @@
     "js-logger": "^1.4.1",
     "ngx-electron": "^2.1.1",
     "ngx-markdown": "^7.1.3",
+    "ngx-toastr": "^10.1.0",
     "rxjs": "6.3.3",
     "showdown": "^1.9.1",
     "signature_pad": "2.3.0",

--- a/openpos-client-libs/projects/openpos-client-core-lib/package.json
+++ b/openpos-client-libs/projects/openpos-client-core-lib/package.json
@@ -25,6 +25,7 @@
     "angular2-text-mask": "^9.0.0",
     "core-js": "^2.5.7",
     "ngx-electron": "^2.1.1",
+    "ngx-toastr": "^10.1.0",
     "hammer-timejs": "^1.1.0",
     "hammerjs": "^2.0.8",
     "js-logger": "^1.4.1",

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/core.module.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/core.module.ts
@@ -6,7 +6,7 @@ import {ScanditScannerCordovaPlugin} from './platform-plugins/scanners/scandit-s
 import { SessionService } from './services/session.service';
 import { PersonalizationStartupTask } from './startup/personalization-startup-task';
 import { STARTUP_TASKS, STARTUP_FAILED_COMPONENT } from './services/startup.service';
-
+import { ToastrModule } from 'ngx-toastr';
 // Angular Includes
 import { NgModule, Injector, Optional, SkipSelf, ErrorHandler } from '@angular/core';
 import { Location, LocationStrategy, PathLocationStrategy, DatePipe } from '@angular/common';
@@ -100,11 +100,13 @@ registerLocaleData(locale_frCA, 'fr-CA');
         SharedModule,
         BrowserModule,
         BrowserAnimationsModule,
-        NgxElectronModule
+        NgxElectronModule,
+        ToastrModule.forRoot()
     ],
     exports: [
         BrowserModule,
-        BrowserAnimationsModule
+        BrowserAnimationsModule,
+        ToastrModule
     ],
     providers: [
         HttpClient,

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/interfaces/toast-screen.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/interfaces/toast-screen.interface.ts
@@ -5,9 +5,17 @@ export interface IToastScreen extends IAbstractScreen {
     toastType: ToastType;
     duration: number;
     verticalPosition: string;
+    icon?: string;
+    persistent?: boolean;
+    persistedId?: string;
+}
+
+export interface CloseToastMessage {
+    persistedId?: string;
 }
 
 export enum ToastType {
     Success= 'Success',
-    Warn= 'Warn'
+    Warn= 'Warn',
+    Info= 'Info'
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/services/toast.service.spec.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/services/toast.service.spec.ts
@@ -1,17 +1,18 @@
 import { TestBed } from '@angular/core/testing';
 import { SessionService } from './session.service';
-import { MatSnackBar } from '@angular/material';
 import { ToastService } from './toast.service';
 import { of } from 'rxjs';
 import { Injector } from '@angular/core';
-import { IToastScreen, ToastType } from '../interfaces/toast-screen.interface';
+import {CloseToastMessage, IToastScreen, ToastType} from '../interfaces/toast-screen.interface';
 import { AppInjector } from '../app-injector';
+import {ToastrService} from 'ngx-toastr';
+import {ToastComponent} from "../../shared/components/toast/toast.component";
 
 
 describe('ToastService', () => {
 
     let sessionServiceSpy: jasmine.SpyObj<SessionService>;
-    let matSnackBarSpy: jasmine.SpyObj<MatSnackBar>;
+    let toastrServiceSpy: jasmine.SpyObj<ToastrService>;
 
     let toastService: ToastService;
     const testToast: IToastScreen = {
@@ -25,15 +26,28 @@ describe('ToastService', () => {
         toastType: ToastType.Success
     };
 
+    const persistedToast: IToastScreen = {
+        locale: 'en-us',
+        name: 'Toast',
+        type: 'Toast',
+        screenType: 'Toast',
+        message: 'Hi',
+        duration: 2500,
+        verticalPosition: 'top',
+        toastType: ToastType.Success,
+        persistent: true,
+        persistedId: 'persistedId'
+    };
+
     beforeEach(() => {
         const sessionSpy = jasmine.createSpyObj('SessionService', ['getMessages', 'cancelLoading']);
-        const matSnackSpy = jasmine.createSpyObj('MatSnackBar', ['open', 'dismiss']);
+        const toastrSpy = jasmine.createSpyObj('ToastrService', ['show', 'clear']);
 
         TestBed.configureTestingModule({
             providers: [
 
                 { provide: SessionService, useValue: sessionSpy },
-                { provide: MatSnackBar, useValue: matSnackSpy },
+                { provide: ToastrService, useValue: toastrSpy },
                 ToastService,
             ]
         });
@@ -42,25 +56,43 @@ describe('ToastService', () => {
         sessionServiceSpy = TestBed.get(SessionService);
         sessionServiceSpy.getMessages.and.returnValue(of(testToast));
 
-        matSnackBarSpy = TestBed.get(MatSnackBar);
+        toastrServiceSpy = TestBed.get(ToastrService);
+        toastrServiceSpy.show.and.returnValue({ toastRef: { componentInstance: {}}})
 
         toastService = TestBed.get(ToastService);
 
     });
 
     describe('constructor', () => {
-        it('should call MatSnackBar.open when called', () => {
-            expect(matSnackBarSpy.open.calls.count).toBeTruthy();
-            expect(matSnackBarSpy.open).toHaveBeenCalledWith(
+        it('should call ToastrService.show when called', () => {
+            expect(toastrServiceSpy.show.calls.count).toBeTruthy();
+            expect(toastrServiceSpy.show).toHaveBeenCalledWith(
                     testToast.message,
                     null,
                     {
-                        duration: 2500,
-                        panelClass: 'toast-success',
-                        verticalPosition: 'top'
+                        timeOut: 2500,
+                        extendedTimeOut: 2500,
+                        disableTimeOut: false,
+                        tapToDismiss: true,
+                        positionClass: 'toast-top-center',
+                        toastClass: 'ngx-toastr app-toast-success',
+                        toastComponent: ToastComponent
                     },
                 );
         });
-    });
 
+        it('should save persisted messages', () => {
+            sessionServiceSpy.getMessages.and.returnValue(of(persistedToast));
+            expect(toastService.persistedToasts.get('persistedId')).not.toBeNull();
+        });
+
+        it('should remove persisted message by ID', () => {
+            sessionServiceSpy.getMessages.and.returnValue(of(persistedToast));
+            const closeToast: CloseToastMessage = {
+                persistedId: 'persistedId'
+            };
+            sessionServiceSpy.getMessages.and.returnValue(of(closeToast));
+            expect(toastService.persistedToasts.get('persistedId')).toBeFalsy();
+        });
+    });
 });

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/services/toast.service.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/services/toast.service.ts
@@ -1,36 +1,70 @@
-import { Injectable } from '@angular/core';
-import { MatSnackBar, MatSnackBarVerticalPosition } from '@angular/material';
-import { SessionService } from './session.service';
-import { IToastScreen, ToastType } from '../interfaces/toast-screen.interface';
+import {Injectable} from '@angular/core';
+import {SessionService} from './session.service';
+import {CloseToastMessage, IToastScreen, ToastType} from '../interfaces/toast-screen.interface';
+import {ActiveToast, ToastrService} from 'ngx-toastr';
+import {ToastComponent} from "../../shared/components/toast/toast.component";
 
 @Injectable({
     providedIn: 'root',
   })
 export class ToastService {
-
-    constructor( private snackBar: MatSnackBar, private sessionService: SessionService ) {
-        sessionService.getMessages('Toast').subscribe(m => this.showToast(m));
-        sessionService.getMessages('Connected').subscribe(m => this.snackBar.dismiss());
+    persistedToasts = new Map<String,ActiveToast<any>>();
+    constructor( private sessionService: SessionService, private toastrService: ToastrService ) {
+        sessionService.getMessages('Toast').subscribe(m => this.showMessage(m));
+        sessionService.getMessages('CloseToast').subscribe(m => this.closeMessage(m));
+        sessionService.getMessages('Connected').subscribe(m => this.toastrService.clear());
+        window['toastService'] = this;
     }
 
-    private showToast( message: any) {
-        const toast = message as IToastScreen;
-        this.snackBar.open(toast.message, toast.duration === 0 ? 'X' : null, {
-            duration: toast.duration,
-            panelClass: this.getToastClass(toast.toastType),
-            verticalPosition: toast.verticalPosition === 'top' ? 'top' : 'bottom'
+    private closeMessage(message: any) {
+        const toastMessage = message as CloseToastMessage;
+        const messageToClose = this.persistedToasts.get(toastMessage.persistedId);
+        if(messageToClose) {
+            this.toastrService.remove(messageToClose.toastId);
+        }
+    }
+
+    private showMessage(message: any) {
+        const toastMessage = message as IToastScreen;
+        const toast = this.toastrService.show(toastMessage.message, null, {
+            timeOut: toastMessage.duration,
+            extendedTimeOut: toastMessage.duration,
+            disableTimeOut: this.isStickyToast(toastMessage),
+            tapToDismiss: !toastMessage.persistent,
+            positionClass: this.getPosition(toastMessage.verticalPosition),
+            toastClass: `ngx-toastr app-${this.getType(toastMessage.toastType)}`,
+            toastComponent: ToastComponent
         });
+        toast.toastRef.componentInstance.iconName = toastMessage.icon;
+        if(toastMessage.persistent) {
+            this.persistedToasts.set(toastMessage.persistedId, toast);
+        }
         this.sessionService.cancelLoading();
     }
 
-    private getToastClass(type: ToastType): string {
+    private isStickyToast(toastMessage: IToastScreen): boolean {
+        return toastMessage.duration === 0;
+    }
+
+    private getPosition(verticalPosition: String): string {
+        switch (verticalPosition) {
+            case 'top':
+                return 'toast-top-center';
+            case 'bottom':
+                return 'toast-bottom-center';
+        }
+        return null;
+    }
+
+    private getType(type: String): string {
         switch (type) {
             case ToastType.Success:
                 return 'toast-success';
             case ToastType.Warn:
-                return 'toast-warn';
+                return 'toast-warning';
+            case ToastType.Info:
+                return 'toast-info';
         }
-
         return null;
     }
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/dynamic-screen/dynamic-screen.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/dynamic-screen/dynamic-screen.component.html
@@ -1,5 +1,7 @@
 <app-loader></app-loader>
 <div class="container" inactivityMonitor appKeypressSource appStayFocused>
+    <div style="display: contents" toastContainer></div>
     <app-status-bar></app-status-bar>
-    <ng-template openposScreenOutlet></ng-template>
+    <ng-template openposScreenOutlet>
+    </ng-template>
 </div>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/dynamic-screen/dynamic-screen.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/dynamic-screen/dynamic-screen.component.ts
@@ -1,6 +1,7 @@
-import { Component } from '@angular/core';
+import {Component, OnInit, ViewChild} from '@angular/core';
 import {ActionService} from '../../../core/actions/action.service';
 import { MessageProvider } from '../../providers/message.provider';
+import {ToastContainerDirective, ToastrService} from "ngx-toastr";
 
 @Component({
     selector: 'app-dynamic-screen',
@@ -8,10 +9,16 @@ import { MessageProvider } from '../../providers/message.provider';
     styleUrls: ['./dynamic-screen.component.scss'],
     providers: [MessageProvider, ActionService]
 })
-export class DynamicScreenComponent {
-
+export class DynamicScreenComponent implements OnInit{
+    @ViewChild(ToastContainerDirective)
+    toastContainer: ToastContainerDirective;
     constructor(
-                messageProvider: MessageProvider) {
+                messageProvider: MessageProvider,
+                private toastrService: ToastrService) {
         messageProvider.setMessageType('Screen');
+    }
+
+    ngOnInit() {
+        this.toastrService.overlayContainer = this.toastContainer;
     }
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/toast/toast.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/toast/toast.component.html
@@ -1,0 +1,4 @@
+<div class="app-toast">
+  <app-icon class="app-toast-icon" *ngIf="iconName" [iconName]="iconName"></app-icon>
+  <div role="alertdialog" class="toast-message ng-star-inserted" aria-label="Message" [class]="options.messageClass">{{ message }}</div>
+</div>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/toast/toast.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/toast/toast.component.ts
@@ -1,0 +1,34 @@
+import {Component, Input, OnInit} from '@angular/core';
+import {Toast, ToastPackage, ToastrService} from "ngx-toastr";
+import {animate, state, style, transition, trigger} from "@angular/animations";
+
+@Component({
+  selector: 'app-toast',
+  templateUrl: './toast.component.html',
+  animations: [
+    trigger('flyInOut', [
+      state('inactive', style({ opacity: 0 })),
+      state('active', style({ opacity: 1 })),
+      state('removed', style({ opacity: 0 })),
+      transition(
+          'inactive => active',
+          animate('{{ easeTime }}ms {{ easing }}')
+      ),
+      transition(
+          'active => removed',
+          animate('{{ easeTime }}ms {{ easing }}')
+      )
+    ])
+  ],
+})
+export class ToastComponent extends Toast {
+  @Input()
+  iconName: string;
+
+  constructor(
+      protected toastrService: ToastrService,
+      public toastPackage: ToastPackage,
+  ) {
+    super(toastrService, toastPackage);
+  }
+}

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/shared.module.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/shared.module.ts
@@ -4,6 +4,7 @@ import {HttpModule} from '@angular/http';
 import {FlexLayoutModule} from '@angular/flex-layout';
 import {HttpClientModule} from '@angular/common/http';
 import {TextMaskModule} from 'angular2-text-mask';
+import {ToastrModule, ToastContainerModule} from 'ngx-toastr';
 import {MaterialModule} from '../material/material.module';
 import {MatKeyboardModule} from '../keyboard/keyboard.module';
 import {TaskCheckAllBoxComponent} from './components/task-check-all-box/task-check-all-box.component';
@@ -156,6 +157,7 @@ import { PromptButtonRowComponent } from './screen-parts/prompt-button-row/promp
 import { WarnButtonComponent } from './components/warn-button/warn-button.component';
 import {StayFocusedDirective} from './directives/stay-focused.directive';
 import { AudioLicenseComponent } from './components/audio-license/audio-license.component';
+import { ToastComponent } from './components/toast/toast.component';
 
 const screenParts = [
     TenderPartComponent,
@@ -265,7 +267,8 @@ const components = [
     OrderCardComponent,
     ButtonActionTimerComponent,
     TransactionSummaryComponent,
-    StampComponent
+    StampComponent,
+    ToastComponent
 ];
 
 const directives = [
@@ -330,7 +333,8 @@ const pipes = [
         NavListComponent,
         SystemStatusDialogComponent,
         BaconDrawerComponent,
-        HelpTextPageWrapperComponent
+        HelpTextPageWrapperComponent,
+        ToastComponent
     ],
     imports: [
         FormsModule,
@@ -343,7 +347,11 @@ const pipes = [
         MaterialModule,
         MatKeyboardModule,
         TextMaskModule,
-        BrowserAnimationsModule
+        BrowserAnimationsModule,
+        ToastrModule.forRoot({
+            toastComponent: ToastComponent
+        }),
+        ToastContainerModule
     ],
     exports: [
         FormsModule,

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/_app-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/_app-theme.scss
@@ -56,6 +56,7 @@
         background: map-merge($mat-light-theme-background, $openpos-background),
         selected: $selected,
         success: mat-palette($mat-green),
+        info: mat-palette($mat-amber),
         orders: mat-palette($mat-orange, 800),
         returns: mat-palette($mat-red, 900)
     );

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/mixins/_ngx-toastr.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/mixins/_ngx-toastr.scss
@@ -1,0 +1,180 @@
+/* based on angular-toastr css https://github.com/Foxandxss/angular-toastr/blob/cb508fe6801d6b288d3afc525bb40fee1b101650/dist/angular-toastr.css */
+
+@mixin openpos-ngx-toastr($theme) {
+  /* position */
+  .toast-center-center {
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+  .toast-top-center {
+    top: 0;
+    right: 0;
+    width: 100%;
+  }
+  .toast-bottom-center {
+    bottom: 0;
+    right: 0;
+    width: 100%;
+  }
+  .toast-top-full-width {
+    top: 0;
+    right: 0;
+    width: 100%;
+  }
+  .toast-bottom-full-width {
+    bottom: 0;
+    right: 0;
+    width: 100%;
+  }
+  .toast-top-left {
+    top: 12px;
+    left: 12px;
+  }
+  .toast-top-right {
+    top: 12px;
+    right: 12px;
+  }
+  .toast-bottom-right {
+    right: 12px;
+    bottom: 12px;
+  }
+  .toast-bottom-left {
+    bottom: 12px;
+    left: 12px;
+  }
+
+  /* toast styles */
+  .toast-title {
+    font-weight: bold;
+  }
+  .toast-message {
+    word-wrap: break-word;
+  }
+  .toast-message a,
+  .toast-message label {
+    color: #FFFFFF;
+  }
+  .toast-message a:hover {
+    color: #CCCCCC;
+    text-decoration: none;
+  }
+  .toast-close-button {
+    position: relative;
+    right: -0.3em;
+    top: -0.3em;
+    float: right;
+    font-size: 20px;
+    font-weight: bold;
+    color: #FFFFFF;
+    text-shadow: 0 1px 0 #ffffff;
+    /* opacity: 0.8; */
+  }
+  .toast-close-button:hover,
+  .toast-close-button:focus {
+    color: #000000;
+    text-decoration: none;
+    cursor: pointer;
+    opacity: 0.4;
+  }
+  /*Additional properties for button version
+   iOS requires the button element instead of an anchor tag.
+   If you want the anchor version, it requires `href="#"`.*/
+  button.toast-close-button {
+    padding: 0;
+    cursor: pointer;
+    background: transparent;
+    border: 0;
+  }
+  .toast-container {
+    pointer-events: none;
+    position: fixed;
+    z-index: 999999;
+  }
+  .toast-container * {
+    box-sizing: border-box;
+  }
+  .toast-container .ngx-toastr {
+    position: relative;
+    overflow: hidden;
+    margin: 0 0 6px;
+    padding: 15px 15px 15px 50px;
+    width: 300px;
+    border-radius: 3px 3px 3px 3px;
+    background-position: 15px center;
+    background-repeat: no-repeat;
+    background-size: 24px;
+    box-shadow: 0 0 12px #999999;
+    color: #FFFFFF;
+  }
+  .toast-container .ngx-toastr:hover {
+    box-shadow: 0 0 12px #000000;
+    opacity: 1;
+    cursor: pointer;
+  }
+
+  .toast-container.toast-top-center .ngx-toastr,
+  .toast-container.toast-bottom-center .ngx-toastr {
+    width: 300px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+  .toast-container.toast-top-full-width .ngx-toastr,
+  .toast-container.toast-bottom-full-width .ngx-toastr {
+    width: 96%;
+    margin-left: auto;
+    margin-right: auto;
+  }
+  .ngx-toastr {
+    background-color: #030303;
+    pointer-events: auto;
+  }
+  .toast-success {
+    background-color: #51A351;
+  }
+  .toast-error {
+    background-color: #BD362F;
+  }
+  .toast-info {
+    background-color: #2F96B4;
+  }
+  .toast-warning {
+    background-color: #F89406;
+  }
+  .toast-progress {
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    height: 4px;
+    background-color: #000000;
+    opacity: 0.4;
+  }
+  /* Responsive Design */
+  @media all and (max-width: 240px) {
+    .toast-container .ngx-toastr.div {
+      padding: 8px 8px 8px 50px;
+      width: 11em;
+    }
+    .toast-container .toast-close-button {
+      right: -0.2em;
+      top: -0.2em;
+    }
+  }
+  @media all and (min-width: 241px) and (max-width: 480px) {
+    .toast-container .ngx-toastr.div {
+      padding: 8px 8px 8px 50px;
+      width: 18em;
+    }
+    .toast-container .toast-close-button {
+      right: -0.2em;
+      top: -0.2em;
+    }
+  }
+  @media all and (min-width: 481px) and (max-width: 768px) {
+    .toast-container .ngx-toastr.div {
+      padding: 15px 15px 15px 50px;
+      width: 25em;
+    }
+  }
+}
+

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/theme-mixins/_snack-bar.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/theme-mixins/_snack-bar.scss
@@ -1,21 +1,51 @@
+@import '../mixins/ngx-toastr';
+
 @mixin openpos-snack-bar($theme){
-    .toast-success{
-        color: mat-color(map-get($theme, selected));
+    @include openpos-ngx-toastr($theme);
+    $foreground: map-get($theme, foreground);
+
+    %app-toast {
         border-style: solid;
-        border-width: 4px;
-        border-color: mat-color(map-get($theme, selected));
-        background-color: white;
+        border-width: 1px;
+        box-shadow: none !important;
+        padding: 10px 10px 10px 10px !important;
+        margin-top: 10px !important;
+        color: mat-color($foreground, text) !important;
+        width: fit-content !important;
     }
 
-    .toast-warn{
-        color: mat-color(map-get($theme, warn));
-        border-style: solid;
-        border-width: 4px;
+    .app-toast-success {
+        @extend %app-toast;
+        border-color: mat-color(map-get($theme, success));
+        background-color: lighten(mat-color(map-get($theme, success)), 40%);
+    }
+
+    .app-toast-warning {
+        @extend %app-toast;
         border-color: mat-color(map-get($theme, warn));
-        background-color: white;
+        background-color: lighten(mat-color(map-get($theme, warn)), 50%);
     }
 
-    .toast-warn .mat-simple-snackbar-action {
-        color: mat-color(map-get($theme, warn));  
+    .app-toast-info {
+        @extend %app-toast;
+        border-color: mat-color(map-get($theme, info));
+        background-color: lighten(mat-color(map-get($theme, info)), 40%);
     }
+
+    .app-toast-warning .mat-simple-snackbar-action {
+        color: mat-color(map-get($theme, warn));
+    }
+
+    .ngx-toastr .app-toast {
+        display: flex;
+    }
+
+    .app-toast-icon {
+        margin-right: 10px;
+    }
+
+    .toast-message {
+        margin: auto;
+    }
+
 }

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/IStateManager.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/IStateManager.java
@@ -23,6 +23,7 @@ package org.jumpmind.pos.core.flow;
 import java.util.Map;
 
 import org.jumpmind.pos.core.error.IErrorHandler;
+import org.jumpmind.pos.core.ui.CloseToast;
 import org.jumpmind.pos.core.ui.Toast;
 import org.jumpmind.pos.core.ui.UIMessage;
 import org.jumpmind.pos.core.ui.data.UIDataMessageProvider;
@@ -48,6 +49,7 @@ public interface IStateManager {
     public void showScreen(UIMessage screen, Map<String, UIDataMessageProvider<?>> dataMessageProviderMap);
     public void showScreen(UIMessage screen);
     public void showToast(Toast toast);
+    public void closeToast(Toast toast);
     public void refreshScreen();
     public void reset();
     public Object getCurrentState();

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/StateManager.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/StateManager.java
@@ -43,6 +43,7 @@ import org.jumpmind.pos.core.flow.config.*;
 import org.jumpmind.pos.core.model.MessageType;
 import org.jumpmind.pos.core.model.StartupMessage;
 import org.jumpmind.pos.core.service.UIDataMessageProviderService;
+import org.jumpmind.pos.core.ui.CloseToast;
 import org.jumpmind.pos.core.ui.Toast;
 import org.jumpmind.pos.core.ui.DialogProperties;
 import org.jumpmind.pos.core.service.IScreenService;
@@ -1047,10 +1048,28 @@ public class StateManager implements IStateManager {
             throw new FlowException(
                     "There is no applicationState.getCurrentContext() on this StateManager.  HINT: States should use @In(scope=ScopeType.Node) to get the StateManager, not @Autowired.");
         }
-
+        if(toast.isPersistent() && toast.getPersistedId() == null) {
+            toast.setPersistedId(UUID.randomUUID());
+        }
         screenService.showToast(applicationState.getAppId(), applicationState.getDeviceId(), toast);
 
         lastShowTimeInMs.set(System.currentTimeMillis());
+    }
+
+    @Override
+    public void closeToast(Toast toast) {
+        if (toast != null) {
+            keepAlive();
+
+            if (applicationState.getCurrentContext() == null) {
+                throw new FlowException(
+                        "There is no applicationState.getCurrentContext() on this StateManager.  HINT: States should use @In(scope=ScopeType.Node) to get the StateManager, not @Autowired.");
+            }
+            CloseToast closeToast = new CloseToast(toast.getPersistedId());
+            screenService.closeToast(applicationState.getAppId(), applicationState.getDeviceId(), closeToast);
+
+            lastShowTimeInMs.set(System.currentTimeMillis());
+        }
     }
 
 

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/model/MessageType.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/model/MessageType.java
@@ -8,6 +8,7 @@ public final class MessageType {
     public static final String Screen = "Screen";
     public static final String Dialog = "Dialog";
     public static final String Toast = "Toast";
+    public static final String CloseToast = "CloseToast";
     public static final String DevTools = "DevTools";
     public static final String Loading = "Loading";
     public static final String ConfigChanged = "ConfigChanged";

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/service/IScreenService.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/service/IScreenService.java
@@ -1,5 +1,6 @@
 package org.jumpmind.pos.core.service;
 
+import org.jumpmind.pos.core.ui.CloseToast;
 import org.jumpmind.pos.core.ui.Toast;
 import org.jumpmind.pos.core.ui.UIDataMessage;
 import org.jumpmind.pos.core.ui.UIMessage;
@@ -14,6 +15,8 @@ public interface IScreenService {
     public void showScreen(String appId, String nodeId, UIMessage screen);
 
     public void showToast(String appId, String nodeId, Toast toast);
+
+    public void closeToast(String appId, String nodeId, CloseToast toast);
 
     public UIMessage getLastScreen(String appId, String nodeId);
 

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/service/ScreenService.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/service/ScreenService.java
@@ -309,6 +309,12 @@ public class ScreenService implements IScreenService, IActionListener {
     }
 
     @Override
+    public void closeToast(String appId, String deviceId, CloseToast toast) {
+        interceptMessage(appId, deviceId, toast, CloseToast.class);
+        messageService.sendMessage(appId, deviceId, toast);
+    }
+
+    @Override
     public void showScreen(String appId, String deviceId, UIMessage screen) {
         showScreen(appId, deviceId, screen, null);
     }

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/service/ScreenService.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/service/ScreenService.java
@@ -310,7 +310,7 @@ public class ScreenService implements IScreenService, IActionListener {
 
     @Override
     public void closeToast(String appId, String deviceId, CloseToast toast) {
-        interceptMessage(appId, deviceId, toast, CloseToast.class);
+        interceptCloseToast(appId, deviceId, toast);
         messageService.sendMessage(appId, deviceId, toast);
     }
 
@@ -371,6 +371,16 @@ public class ScreenService implements IScreenService, IActionListener {
                 IMessageInterceptor<Toast> toastInterceptor =  (IMessageInterceptor<Toast>) applicationContext.getBean(beanName);
                 toastInterceptor.intercept(appId, deviceId, toast);
             }
+        }
+    }
+
+    protected void interceptCloseToast(String appId, String deviceId, CloseToast closeToast) {
+        String[] closeToastInterceptorBeanNames = applicationContext.getBeanNamesForType(ResolvableType.forClassWithGenerics(IMessageInterceptor.class, CloseToast.class));
+
+        for (String beanName: closeToastInterceptorBeanNames) {
+            @SuppressWarnings("unchecked")
+            IMessageInterceptor<CloseToast> toastInterceptor =  (IMessageInterceptor<CloseToast>) applicationContext.getBean(beanName);
+            toastInterceptor.intercept(appId, deviceId, closeToast);
         }
     }
     

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/CloseToast.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/CloseToast.java
@@ -1,0 +1,24 @@
+package org.jumpmind.pos.core.ui;
+
+import org.jumpmind.pos.core.model.MessageType;
+import org.jumpmind.pos.util.model.Message;
+
+import java.util.UUID;
+
+public class CloseToast extends Message {
+    private UUID persistedId;
+
+    public CloseToast(UUID persistedId) {
+        this.persistedId = persistedId;
+        setType(MessageType.CloseToast);
+        setWillUnblock(true);
+    }
+
+    public UUID getPersistedId() {
+        return persistedId;
+    }
+
+    public void setPersistedId(UUID persistedId) {
+        this.persistedId = persistedId;
+    }
+}

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/Toast.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/Toast.java
@@ -3,6 +3,8 @@ package org.jumpmind.pos.core.ui;
 import org.jumpmind.pos.core.model.MessageType;
 import org.jumpmind.pos.util.model.Message;
 
+import java.util.UUID;
+
 public class Toast extends Message {
 
     private static final long serialVersionUID = 1L;
@@ -11,6 +13,9 @@ public class Toast extends Message {
     private ToastType toastType;
     private int duration = 2500;
     private String verticalPosition = "bottom";
+    private String icon;
+    private boolean persistent;
+    private UUID persistedId;
 
     public static Toast createSuccessToast(String message) {
         return createSuccessToast(message, true);
@@ -52,6 +57,16 @@ public class Toast extends Message {
         this.verticalPosition = verticalPosition;
     }
 
+    public Toast(String message, ToastType toastType, int duration, String verticalPosition, String icon) {
+        this(message, toastType, duration, verticalPosition);
+        this.icon = icon;
+    }
+
+    public Toast(String message, ToastType toastType, int duration, String verticalPosition, String icon, boolean persistent) {
+        this(message, toastType, duration, verticalPosition, icon);
+        this.persistent = persistent;
+    }
+
     public Toast(String message, ToastType toastType, int duration, String verticalPosition, boolean willUnblock){
         this(message, toastType, duration, verticalPosition);
         this.setWillUnblock(willUnblock);
@@ -87,5 +102,29 @@ public class Toast extends Message {
     
     public String getVerticalPosition() {
         return verticalPosition;
+    }
+
+    public String getIcon() {
+        return icon;
+    }
+
+    public void setIcon(String icon) {
+        this.icon = icon;
+    }
+
+    public boolean isPersistent() {
+        return persistent;
+    }
+
+    public void setPersistent(boolean persistent) {
+        this.persistent = persistent;
+    }
+
+    public UUID getPersistedId() {
+        return persistedId;
+    }
+
+    public void setPersistedId(UUID persistedId) {
+        this.persistedId = persistedId;
     }
 }

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/ToastType.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/ToastType.java
@@ -2,5 +2,6 @@ package org.jumpmind.pos.core.ui;
 
 public enum ToastType {
 	Success,
-	Warn
+	Warn,
+	Info
 }


### PR DESCRIPTION
### Summary
Change implementation of toast messages to support business date mismatch message:
- Changed library for messages to support multiple messages
  - Required multiple changes, including style changes and implementation of custom toast component
- Updated Toast class to accept an icon
- Added `info` color scheme

### Screenshots
Samples of toast messages
![image](https://user-images.githubusercontent.com/74971030/101207106-1ef24c00-363e-11eb-981b-8807084d3f08.png)

Business Date Message
![image](https://user-images.githubusercontent.com/74971030/101207302-6d9fe600-363e-11eb-9bfa-202f162cdf96.png)

