### PR TITLE
Updates to dml operations to use tagged fields when part of primary key

### DIFF
--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/DBSession.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/DBSession.java
@@ -570,7 +570,7 @@ public class DBSession {
     private boolean isTaggedWithPrimaryKey(AbstractModel model) {
         if (model != null && model instanceof ITaggedModel) {
             Tagged tagged = model.getClass().getAnnotation(Tagged.class);
-            return model instanceof ITaggedModel && tagged != null && tagged.includeTagsInPrimaryKey();
+            return tagged != null && tagged.includeTagsInPrimaryKey();
         }
         return false;
     }

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/DBSession.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/DBSession.java
@@ -523,7 +523,7 @@ public class DBSession {
 
     protected int excecuteDml(DmlType type, ModelWrapper model, Table table) {
         boolean[] nullKeyValues = model.getNullKeys();
-        List<Column> primaryKeyColumns = model.getPrimaryKeyColumns();
+        List<Column> primaryKeyColumns = getPrimaryKeyWithTags(model, table);
 
         DmlStatement statement = databasePlatform.createDmlStatement(type, table.getCatalog(), table.getSchema(), table.getName(),
                 primaryKeyColumns.toArray(new Column[primaryKeyColumns.size()]), model.getColumns(table), nullKeyValues, null);
@@ -547,13 +547,32 @@ public class DBSession {
             List<Table> tables = getValidatedTables(exampleModel);
             for (Table table : tables) {
                 boolean[] nullKeyValues = model.getNullKeys();
-                List<Column> primaryKeyColumns = model.getPrimaryKeyColumns();
+                List<Column> primaryKeyColumns = getPrimaryKeyWithTags(model, table);
+                
                 DmlStatement statement = databasePlatform.createDmlStatement(dmlType, table.getCatalog(), table.getSchema(), table.getName(),
                         primaryKeyColumns.toArray(new Column[primaryKeyColumns.size()]), model.getColumns(table), nullKeyValues, null);
                 String sql = statement.getSql();
                 jdbcTemplate.getJdbcOperations().batchUpdate(sql, getValueArray(statement, models), model.getColumnTypes(table));
             }
         }
+    }
+    
+    private List<Column> getPrimaryKeyWithTags(ModelWrapper model, Table table) {
+        List<Column> primaryKeyColumns = new ArrayList<>(model.getPrimaryKeyColumns());
+        if (isTaggedWithPrimaryKey(model.getModel())) {
+            primaryKeyColumns.addAll(Arrays.stream(model.getColumns(table))
+                    .filter(c -> StringUtils.startsWith(c.getName(), TagModel.TAG_PREFIX))
+                    .collect(Collectors.toList()));
+        }
+        return primaryKeyColumns;
+    }
+    
+    private boolean isTaggedWithPrimaryKey(AbstractModel model) {
+        if (model != null && model instanceof ITaggedModel) {
+            Tagged tagged = model.getClass().getAnnotation(Tagged.class);
+            return model instanceof ITaggedModel && tagged != null && tagged.includeTagsInPrimaryKey();
+        }
+        return false;
     }
 
     public void batchInsert(List<? extends AbstractModel> models) {

--- a/openpos-persist/src/test/java/org/jumpmind/pos/persist/cars/CarModel.java
+++ b/openpos-persist/src/test/java/org/jumpmind/pos/persist/cars/CarModel.java
@@ -1,13 +1,11 @@
 package org.jumpmind.pos.persist.cars;
 
-import org.jumpmind.pos.persist.ColumnDef;
+import org.jumpmind.pos.persist.*;
 import org.joda.money.Money;
-import org.jumpmind.pos.persist.IndexDef;
-import org.jumpmind.pos.persist.IndexDefs;
-import org.jumpmind.pos.persist.TableDef;
 import org.jumpmind.pos.persist.model.AbstractTaggedModel;
 import org.jumpmind.pos.persist.model.ITaggedModel;
 
+@Tagged
 @TableDef(name="car",
         description = "A basic concept of an automobile fit to drive down the road.",
         primaryKey = "vin")


### PR DESCRIPTION
### Summary
Fixing an issue where deletes and updates are not look at tagged columns as primary key values when the Tagged annotation was present and includeTagsInPrimaryKey=true. This would cause extra rows to be deleted/updated when tags had values in them.