### PR TITLE
bugfix/fix-tender-icon-on-transaction-details

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/item-card/item-card.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/item-card/item-card.component.html
@@ -1,6 +1,8 @@
 <mat-card class="item-card" [class]="item.lineItemType | lowercase" [ngClass]="{'mat-elevation-z5':hover, 'mat-elevation-z1':!hover}">
     <mat-card-content class="item-content">
-        <app-image responsive-class
+        <app-image
+                   responsive-class
+                   *ngIf="item.imageUrl && !item.svgImage"
                    class="item-card-image"
                    [imageUrl]="item.imageUrl | imageUrl"
                    [altText]="item.description"


### PR DESCRIPTION

### Summary
Fix missing icon on transaction detail tenders.

![image](https://user-images.githubusercontent.com/4398634/103106921-a1e84000-4607-11eb-9c6a-f47d766a14ef.png)
