### PR TITLE
Set display of toast component host (#1033)

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/toast/toast.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/toast/toast.component.ts
@@ -5,6 +5,7 @@ import {animate, state, style, transition, trigger} from "@angular/animations";
 @Component({
   selector: 'app-toast',
   templateUrl: './toast.component.html',
+  styles: [':host { display: block; }'],
   animations: [
     trigger('flyInOut', [
       state('inactive', style({ opacity: 0 })),


### PR DESCRIPTION
### Summary
Host component for `app-toast` was inconsistently getting `display: inherit` applied. Set to `block` manually so it will render correctly.

Before:
![image](https://user-images.githubusercontent.com/74971030/102937129-79c9d700-4477-11eb-9c07-3ba529870939.png)


After:
![image](https://user-images.githubusercontent.com/74971030/102937160-864e2f80-4477-11eb-9db6-920c0255ab75.png)

