### PR TITLE
Do not allow duplicate persistent toast messages (#1038)

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/services/toast.service.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/services/toast.service.ts
@@ -26,6 +26,19 @@ export class ToastService {
 
     private showMessage(message: any) {
         const toastMessage = message as IToastScreen;
+        if(toastMessage.persistent) {
+            if(!this.persistedToasts.get(toastMessage.persistedId)) {
+                const toast = this.getToast(toastMessage);
+                this.persistedToasts.set(toastMessage.persistedId, toast);
+            }
+        }
+        else {
+            this.getToast(toastMessage);
+        }
+        this.sessionService.cancelLoading();
+    }
+
+    private getToast(toastMessage: IToastScreen): ActiveToast<any> {
         const toast = this.toastrService.show(toastMessage.message, null, {
             timeOut: toastMessage.duration,
             extendedTimeOut: toastMessage.duration,
@@ -36,10 +49,7 @@ export class ToastService {
             toastComponent: ToastComponent
         });
         toast.toastRef.componentInstance.iconName = toastMessage.icon;
-        if(toastMessage.persistent) {
-            this.persistedToasts.set(toastMessage.persistedId, toast);
-        }
-        this.sessionService.cancelLoading();
+        return toast;
     }
 
     private isStickyToast(toastMessage: IToastScreen): boolean {

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/StateManager.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/StateManager.java
@@ -1048,9 +1048,11 @@ public class StateManager implements IStateManager {
             throw new FlowException(
                     "There is no applicationState.getCurrentContext() on this StateManager.  HINT: States should use @In(scope=ScopeType.Node) to get the StateManager, not @Autowired.");
         }
+
         if(toast.isPersistent() && toast.getPersistedId() == null) {
-            toast.setPersistedId(UUID.randomUUID());
+            throw new FlowException("Persistent toast message requires ID");
         }
+
         screenService.showToast(applicationState.getAppId(), applicationState.getDeviceId(), toast);
 
         lastShowTimeInMs.set(System.currentTimeMillis());

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/CloseToast.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/CloseToast.java
@@ -6,19 +6,19 @@ import org.jumpmind.pos.util.model.Message;
 import java.util.UUID;
 
 public class CloseToast extends Message {
-    private UUID persistedId;
+    private String persistedId;
 
-    public CloseToast(UUID persistedId) {
+    public CloseToast(String persistedId) {
         this.persistedId = persistedId;
         setType(MessageType.CloseToast);
         setWillUnblock(true);
     }
 
-    public UUID getPersistedId() {
+    public String getPersistedId() {
         return persistedId;
     }
 
-    public void setPersistedId(UUID persistedId) {
+    public void setPersistedId(String persistedId) {
         this.persistedId = persistedId;
     }
 }

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/Toast.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/Toast.java
@@ -15,7 +15,7 @@ public class Toast extends Message {
     private String verticalPosition = "bottom";
     private String icon;
     private boolean persistent;
-    private UUID persistedId;
+    private String persistedId;
 
     public static Toast createSuccessToast(String message) {
         return createSuccessToast(message, true);
@@ -120,11 +120,11 @@ public class Toast extends Message {
         this.persistent = persistent;
     }
 
-    public UUID getPersistedId() {
+    public String getPersistedId() {
         return persistedId;
     }
 
-    public void setPersistedId(UUID persistedId) {
+    public void setPersistedId(String persistedId) {
         this.persistedId = persistedId;
     }
 }


### PR DESCRIPTION
### Summary
Was previously setting random UUID for persistent toast messages so they could be closed from the server, but we were finding issues with that approach due to the fact that toast references were being removed on logout, error, and device reset. Instead changed the UUID to a string constant and changed the client to not allow duplicate IDs.