### PR TITLE
pushScopeValue for when @Out is not an option for propoga…

### DIFF
--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/Outjector.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/Outjector.java
@@ -59,19 +59,15 @@ public class Outjector {
 
             switch (scopeType) {
                 case Device:
-                    scope.setDeviceScope(name, value);
-                    break;
                 case Session:
-                    scope.setSessionScope(name, value);
-                    break;
                 case Conversation:
-                    scope.setConversationScope(name, value);
+                    scope.setScope(name, scopeType, value);
                     break;
                 case Flow:
                     currentContext.setFlowScope(name, value);
                     break;
                 default:
-                    throw new FlowException("Invalid scope " + scopeType + " for out field " + field);
+                    throw new FlowException("Invalid scope " + scopeType + " for out field " + field + " name " + name);
             }
         } catch (Exception ex) {
             if (ex instanceof FlowException) {

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/Scope.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/Scope.java
@@ -66,6 +66,22 @@ public class Scope {
         return null;
     }
 
+    public void setScope(String name, ScopeType scopeType, Object value) {
+        switch (scopeType) {
+            case Device:
+                setDeviceScope(name, value);
+                break;
+            case Session:
+                setSessionScope(name, value);
+                break;
+            case Conversation:
+                setConversationScope(name, value);
+                break;
+            default:
+                throw new FlowException("Invalid scope " + scopeType + " for name '" + name + "'");
+        }
+    }
+
     public void setDeviceScope(String name, Object value) {
         setScope(deviceScope, name, value);
     }

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/StateManager.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/StateManager.java
@@ -497,6 +497,11 @@ public class StateManager implements IStateManager {
         }
     }
 
+    public void pushScopeValue(String name, ScopeType scopeType, Object value) {
+        applicationState.getScope().setScope(name, scopeType, value);
+        refreshDeviceScope();
+    }
+
     public void performOutjections(Object stateOrStep) {
         outjector.performOutjections(stateOrStep, applicationState.getScope(), applicationState.getCurrentContext());
     }


### PR DESCRIPTION

### Summary
Add an alternative way to push a scope value for when @Out is not an option.  (This was the original way that scope values were "outjected" before @Out was created.)   The use case I needed this for was logging a user in for training more and making sure "currentUser" was visisble to all the device scoped beans beans before proceeded.
