### PR TITLE
Close connection after script execution

### DIFF
--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/DBSession.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/DBSession.java
@@ -199,8 +199,8 @@ public class DBSession {
     }
 
     public void executeScript(Reader reader) {
-        try {
-            RunScript.execute(getConnection(), reader);
+        try (Connection connection = getConnection()) {
+            RunScript.execute(connection, reader);
         } catch (Exception ex) {
             throw new PersistException("Failed to execute script " + reader, ex);
         }


### PR DESCRIPTION
### Summary
Closing the connection after executing the script. Was causing an issue where tests are running multiple scripts and running out of connections.