### PR TITLE
Fixed forms submitting when they're invalid

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/form/form.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/form/form.component.ts
@@ -27,7 +27,9 @@ export class FormComponent {
     submitFormEvent = new EventEmitter();
 
     submitForm() {
-        if (this.form.valid) {
+        const shouldSubmit = this.form.valid && !this.form.pending;
+
+        if (shouldSubmit) {
             this.submitFormEvent.emit();
         } else {
             // Set focus on the first invalid field found
@@ -54,5 +56,7 @@ export class FormComponent {
                 }
             }
         }
+
+        return shouldSubmit;
     }
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/dynamic-form-part/dynamic-form-part.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/dynamic-form-part/dynamic-form-part.component.html
@@ -16,7 +16,7 @@
                 <span>{{button.label}}</span>
                 <app-icon *ngIf="button.icon" [iconName]="button.icon"></app-icon>
             </app-secondary-button>
-            <app-primary-button *ngIf="submitButton" (click)="submitForm()">
+            <app-primary-button *ngIf="submitButton" type="submit" [disabled]="!form.valid || form.pending">
                 <span>{{submitButton.title}}</span>
                 <app-icon *ngIf="submitButton.icon" [iconName]="submitButton.icon"></app-icon>
             </app-primary-button>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/dynamic-form-part/dynamic-form-part.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/dynamic-form-part/dynamic-form-part.component.ts
@@ -121,8 +121,10 @@ export class DynamicFormPartComponent extends ScreenPartComponent<IForm> impleme
     }
 
     submitForm() {
-        this.formBuilder.buildFormPayload(this.form, this.screenData);
-        this.doAction(this.submitButton, this.screenData);
+        if (this.form.valid && !this.form.pending) {
+            this.formBuilder.buildFormPayload(this.form, this.screenData);
+            this.doAction(this.submitButton, this.screenData);
+        }
     }
 
     onFieldChanged(formElement: IFormElement) {


### PR DESCRIPTION
### Issues Fixed
[PDPOS-4633](https://petcoalm.atlassian.net/browse/PDPOS-4633)

### Summary
This fixes a bug where forms could be submitted, by pressing `enter` or clicking a `submit` button, when they're invalid. 

### Screenshots
**Edit User Form**
*Key presses are logged in the top-right corner so you can see enter key submissions*
![form-block-submit-when-invalid--user](https://user-images.githubusercontent.com/3991426/103920468-58a3f000-50df-11eb-91d0-c3b9a3f85b7b.gif)

**Returns - Manual Id Entry Form**
*Key presses are logged in the top-right corner so you can see enter key submissions*
![form-block-submit-when-invalid--return](https://user-images.githubusercontent.com/3991426/103920599-80935380-50df-11eb-8e09-34b7b9d3526c.gif)
