### PR TITLE
Disable Printer Status on Mobile Printing

### DIFF
--- a/openpos-peripheral/src/main/java/org/jumpmind/pos/peripheral/poledisplay/PoleDisplay.java
+++ b/openpos-peripheral/src/main/java/org/jumpmind/pos/peripheral/poledisplay/PoleDisplay.java
@@ -11,12 +11,14 @@ import org.jumpmind.pos.util.status.IStatusManager;
 import org.jumpmind.pos.util.status.IStatusReporter;
 import org.jumpmind.pos.util.status.Status;
 import org.jumpmind.pos.util.status.StatusReport;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
 
 @Slf4j
 @Component
+@ConditionalOnProperty(name = "openpos.devices.poleDisplay.enabled", havingValue = "true")
 public class PoleDisplay implements IStatusReporter {
 
     public final static String STATUS_NAME = "DEVICE.POLE_DISPLAY";

--- a/openpos-peripheral/src/main/java/org/jumpmind/pos/print/EscpPOSPrinter.java
+++ b/openpos-peripheral/src/main/java/org/jumpmind/pos/print/EscpPOSPrinter.java
@@ -4,7 +4,6 @@ import jpos.JposException;
 import jpos.POSPrinterConst;
 import jpos.services.EventCallbacks;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.text.StrSubstitutor;
 import org.jumpmind.pos.util.AppUtils;
@@ -49,7 +48,7 @@ public class EscpPOSPrinter implements IOpenposPrinter {
     static final int THERMAL_HEAD_OR_VOLTAGE_OUT_OF_RANGE = 0b10000000;
 
     int currentPrintStation = POSPrinterConst.PTR_S_RECEIPT;
-    private PrinterStatusReporter printerStatusReporter;
+    private IPrinterStatusReporter printerStatusReporter;
 
     public EscpPOSPrinter() {
         this.settings = new HashMap<>();
@@ -303,7 +302,7 @@ public class EscpPOSPrinter implements IOpenposPrinter {
         return printerCommands.get(commandName);
     }
 
-    public void init(Map<String, Object> settings, PrinterStatusReporter printerStatusReporter) {
+    public void init(Map<String, Object> settings, IPrinterStatusReporter printerStatusReporter) {
         this.printerStatusReporter = printerStatusReporter;
         this.settings = settings;
         this.refreshConnectionFactoryFromSettings();

--- a/openpos-peripheral/src/main/java/org/jumpmind/pos/print/IOpenposPrinter.java
+++ b/openpos-peripheral/src/main/java/org/jumpmind/pos/print/IOpenposPrinter.java
@@ -18,7 +18,7 @@ public interface IOpenposPrinter extends POSPrinterService19 {
 
     public int getPrintWidth();
 
-    public void init(Map<String,Object> settings, PrinterStatusReporter printerStatusReporter);
+    public void init(Map<String,Object> settings, IPrinterStatusReporter printerStatusReporter);
 
     public String getPrinterName();
 

--- a/openpos-peripheral/src/main/java/org/jumpmind/pos/print/IPrinterStatusReporter.java
+++ b/openpos-peripheral/src/main/java/org/jumpmind/pos/print/IPrinterStatusReporter.java
@@ -1,0 +1,7 @@
+package org.jumpmind.pos.print;
+
+import org.jumpmind.pos.util.status.Status;
+
+public interface IPrinterStatusReporter {
+    void reportStatus(Status status, String message);
+}

--- a/openpos-peripheral/src/main/java/org/jumpmind/pos/print/LogPOSPrinter.java
+++ b/openpos-peripheral/src/main/java/org/jumpmind/pos/print/LogPOSPrinter.java
@@ -20,7 +20,7 @@ public class LogPOSPrinter implements IOpenposPrinter {
 
     private StringBuilder buff = new StringBuilder(128);
 
-    private PrinterStatusReporter printerStatusReporter;
+    private StatusManagerPrinterStatusReporter printerStatusReporter;
 
     private static int cashDrawerOpened;
 
@@ -49,7 +49,7 @@ public class LogPOSPrinter implements IOpenposPrinter {
     }
 
     @Override
-    public void init(Map<String, Object> settings, PrinterStatusReporter printerStatusReporter) {
+    public void init(Map<String, Object> settings, IPrinterStatusReporter printerStatusReporter) {
         printerStatusReporter.reportStatus(Status.Online, "LogPOSPrinter Ok.");
     }
 

--- a/openpos-peripheral/src/main/java/org/jumpmind/pos/print/LogPOSPrinter.java
+++ b/openpos-peripheral/src/main/java/org/jumpmind/pos/print/LogPOSPrinter.java
@@ -20,8 +20,6 @@ public class LogPOSPrinter implements IOpenposPrinter {
 
     private StringBuilder buff = new StringBuilder(128);
 
-    private StatusManagerPrinterStatusReporter printerStatusReporter;
-
     private static int cashDrawerOpened;
 
     @Override
@@ -65,10 +63,6 @@ public class LogPOSPrinter implements IOpenposPrinter {
 
     @Override
     public int readPrinterStatus() {
-        if (printerStatusReporter != null) {
-            printerStatusReporter.reportStatus(Status.Online, "LogPOSPrinter Ok.");
-        }
-
         return 0;
     }
 

--- a/openpos-peripheral/src/main/java/org/jumpmind/pos/print/NoopPrinterStatusReporter.java
+++ b/openpos-peripheral/src/main/java/org/jumpmind/pos/print/NoopPrinterStatusReporter.java
@@ -1,0 +1,12 @@
+package org.jumpmind.pos.print;
+
+import org.jumpmind.pos.util.status.Status;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(name = "openpos.devices.enableMobilePrint", havingValue = "true")
+public class NoopPrinterStatusReporter implements IPrinterStatusReporter {
+    @Override
+    public void reportStatus(Status status, String message) {}
+}

--- a/openpos-peripheral/src/main/java/org/jumpmind/pos/print/StatusManagerPrinterStatusReporter.java
+++ b/openpos-peripheral/src/main/java/org/jumpmind/pos/print/StatusManagerPrinterStatusReporter.java
@@ -5,11 +5,12 @@ import org.jumpmind.pos.util.status.IStatusReporter;
 import org.jumpmind.pos.util.status.Status;
 import org.jumpmind.pos.util.status.StatusReport;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 @Component
-public class PrinterStatusReporter implements IStatusReporter {
-
+@ConditionalOnProperty(name = "openpos.devices.enableMobilePrint", havingValue = "false")
+public class StatusManagerPrinterStatusReporter implements IStatusReporter, IPrinterStatusReporter {
     private IStatusManager statusManager;
 
     private StatusReport lastStatus;

--- a/openpos-peripheral/src/main/java/org/jumpmind/pos/print/StatusManagerPrinterStatusReporter.java
+++ b/openpos-peripheral/src/main/java/org/jumpmind/pos/print/StatusManagerPrinterStatusReporter.java
@@ -9,7 +9,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 @Component
-@ConditionalOnProperty(name = "openpos.devices.enableMobilePrint", havingValue = "false")
+@ConditionalOnProperty(name = "openpos.devices.enableMobilePrint", havingValue = "false", matchIfMissing = true)
 public class StatusManagerPrinterStatusReporter implements IStatusReporter, IPrinterStatusReporter {
     private IStatusManager statusManager;
 


### PR DESCRIPTION
### Summary
When mobile printing is enabled, the printer status isn't exactly functional, nor does it have a great way for it to become functional. This PR removes printer status when the mobile printing option is enabled. It was achieved by abstracting out the `PrinterStatusReporter` into an interface that a new Noop version implements and provides when `@Autowire`d.  When the Noop version does not implement that `IStatusReporter` interface which the `StatusManager` picks up on for display thus hiding the status away while not breaking any existing reporting functionality.

### Screenshots
![image](https://user-images.githubusercontent.com/2295721/104051078-c9f9a680-51a4-11eb-9fd8-e3c6c5623d7e.png)
