### PR TITLE
Allow java.util.Date and other java objects to be queries from the persistence layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ openpos-client-libs/.DS_Store
 openpos-hazelcast/openpos-hazelcast.iml
 openpos-hazelcast/openpos-hazelcast.iml
 openpos-test/openpos-test.iml
+openpos-util/src/main/java/Test.java

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/DBSession.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/DBSession.java
@@ -1,21 +1,5 @@
 package org.jumpmind.pos.persist;
 
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
-
-import java.beans.PropertyDescriptor;
-import java.io.File;
-import java.io.FileReader;
-import java.io.Reader;
-import java.lang.reflect.Field;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.*;
-import java.util.stream.Collectors;
-
-import javax.sql.DataSource;
-
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.beanutils.PropertyUtils;
@@ -42,6 +26,21 @@ import org.springframework.jdbc.core.*;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.NamedParameterUtils;
 import org.springframework.jdbc.core.namedparam.ParsedSql;
+
+import javax.sql.DataSource;
+import java.beans.PropertyDescriptor;
+import java.io.File;
+import java.io.FileReader;
+import java.io.Reader;
+import java.lang.reflect.Field;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.apache.commons.lang3.StringUtils.*;
 
 @Slf4j
 public class DBSession {
@@ -662,6 +661,11 @@ public class DBSession {
                 if (resultClass != null) {
                     if (resultClass.equals(String.class)) {
                         object = (T) row.stringValue();
+                    } else if (resultClass.getPackage().getName().equals("java.lang") ||
+                            resultClass.getPackage().getName().equals("java.util") ||
+                            resultClass.getPackage().getName().equals("java.sql") ||
+                            resultClass.getPackage().getName().equals("java.math")) {
+                        object = (T) row.values().iterator().next();
                     } else if (isModel(resultClass)) {
                         object = mapModel(resultClass, row);
                     } else {

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/DBSession.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/DBSession.java
@@ -666,6 +666,9 @@ public class DBSession {
                             resultClass.getPackage().getName().equals("java.sql") ||
                             resultClass.getPackage().getName().equals("java.math")) {
                         object = (T) row.values().iterator().next();
+                        if (object != null && !resultClass.isAssignableFrom(object.getClass())) {
+                            throw new PersistException(object.getClass().getName() + " is not assignable to " + resultClass.getName());
+                        }
                     } else if (isModel(resultClass)) {
                         object = mapModel(resultClass, row);
                     } else {


### PR DESCRIPTION
### Summary
Allow java.util.Date and other java objects to be queries from the persistence layer
