### PR TITLE
Fixed Appriss not prompting to manually re enter

### DIFF
--- a/openpos-util/src/main/java/org/jumpmind/pos/util/DefaultObjectMapper.java
+++ b/openpos-util/src/main/java/org/jumpmind/pos/util/DefaultObjectMapper.java
@@ -4,6 +4,7 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.TimeZone;
 
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.joda.money.Money;
 import org.jumpmind.pos.util.web.MoneyDeserializer;
@@ -27,6 +28,7 @@ public class DefaultObjectMapper {
         mapper.setSerializationInclusion(Include.NON_NULL);
         mapper.registerModule(module);
         mapper.registerModule(new JavaTimeModule());
+        mapper.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true);
         return mapper;
     }
 

--- a/openpos-util/src/main/java/org/jumpmind/pos/util/DriversLicense.java
+++ b/openpos-util/src/main/java/org/jumpmind/pos/util/DriversLicense.java
@@ -4,10 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.FastDateFormat;
 
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 @Slf4j
 public class DriversLicense {
@@ -15,6 +12,8 @@ public class DriversLicense {
     private static final FastDateFormat DATE_FORMAT = FastDateFormat.getInstance("MMddyyyy");
 
     private Map<String, String> elements;
+
+    private String rawData;
 
     private String firstLine;
 
@@ -29,7 +28,7 @@ public class DriversLicense {
     private String jurisdictionBarCodeVersion;
 
     private String numberOfSubFiles;
-    
+
     private String subfileDesignators;
 
     private String jurisdictionVehicleClass;
@@ -139,12 +138,18 @@ public class DriversLicense {
     public DriversLicense(String data) {
         elements = new HashMap<>();
         parse(data);
-        setAttributes();
     }
 
     public void parse(String data)  {
+        rawData = data;
+
         elements.clear();
-        String[] lines = data.split("\r\n|\n|\r");
+        String[] lines = Arrays.stream(data.split("\r\n|\n|\r")).filter(StringUtils::isNotEmpty).toArray(String[]::new);
+
+        if (lines.length < 2) {
+            return;
+        }
+
         complianceIndicator = lines[0];
         fileType = lines[1].substring(0, 5);
         issuerIDNumber = lines[1].substring(5, 11);
@@ -260,6 +265,8 @@ public class DriversLicense {
         }
         return parsedDate;
     }
+
+    public String getRawData() { return rawData; }
 
     public String getFileType() { return fileType; }
 


### PR DESCRIPTION
### Issues Fixed
[PDPOS-4694](https://petcoalm.atlassian.net/browse/PDPOS-4694)

### Summary
This fixes an issue where the Appriss response JSON was not correctly parsed because this response uses different casing than for the properties than all other cases.

### Screenshots
![appriss-re-enter-id](https://user-images.githubusercontent.com/3991426/104368811-97c0af80-54ea-11eb-9895-67ab4e517af5.gif)
