### PR TITLE
Update item detail screen to support promo prices (#1065)

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/_item-detail-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/_item-detail-theme.scss
@@ -1,8 +1,12 @@
 @mixin item-detail-theme($theme) {
     $app-primary: mat-color(map-get($theme, primary));
-
+    $background: map-get($mat-grey, 300);
     .promotion-icon {
         color: $app-primary;
+    }
+
+    .promotion-item-gray {
+        background-color: $background;
     }
 
     .rounded-edge {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.html
@@ -1,41 +1,54 @@
 <app-bacon-strip></app-bacon-strip>
-<section responsive-class class="item-card">
-    <h1 responsive-class>{{screen.itemName}}</h1>
-    <p responsive-class>{{screen.summary}}</p>
-    <app-carousel class="carousel" carouselSize="xl" [carouselItemClass]="'rounded-edge'">
-        <ng-template *ngFor="let image of screen.imageUrls" #carouselItem>
-            <app-image [imageUrl]="image | imageUrl" [altImageUrl]="screen.alternateImageUrl" [altText]="'Image NotFound'"></app-image>
-        </ng-template>
-    </app-carousel>
+<section class="scrollable">
+    <mat-card class="item-card page-gutter">
+        <h1 responsive-class>{{screen.itemName}}</h1>
+        <p responsive-class>{{screen.summary}}</p>
+        <app-carousel class="carousel" carouselSize="xl" [carouselItemClass]="'rounded-edge'">
+            <ng-template *ngFor="let image of screen.imageUrls" #carouselItem>
+                <app-image [imageUrl]="image | imageUrl" [altImageUrl]="screen.alternateImageUrl" [altText]="'Image NotFound'"></app-image>
+            </ng-template>
+        </app-carousel>
 
-    <ul responsive-class class="properties">
-        <li *ngFor="let prop of screen.itemProperties">
-            <app-display-property [property]="prop"></app-display-property>
-        </li>
-    </ul>
+        <ul responsive-class class="properties">
+            <li *ngFor="let prop of screen.itemProperties">
+                <app-display-property [property]="prop"></app-display-property>
+            </li>
+        </ul>
 
-    <section responsive-class class="promotions">
+        <app-options-list optionListSizeClass="md"></app-options-list>
+    </mat-card>
+    <mat-card class="promotions page-gutter">
         <h3 responsive-class>
             {{screen.promotions.length > 0 ? screen.itemPromotionsTitle : screen.itemNoPromotionsTitle}}
         </h3>
         <app-instructions *ngIf="screen.promotions && screen.promotions.length > 1"  [instructions]="screen.promotionStackingDisclaimer"
-            [instructionsSize]="'text-md'"></app-instructions>
-        <div class="promotion-items">
-            <ng-container *ngFor="let promo of screen.promotions">
+                          [instructionsSize]="'text-md'"></app-instructions>
+        <div>
+            <span class="promotion-items promotion-item-gray">
                 <div class="promotion-item-icon">
-                    <app-icon [iconName]="promo.icon" color="primary" class="promotion-icon" iconClass="md"></app-icon> 
+                    <app-icon iconClass="md"></app-icon>
                 </div>
                 <div class="promotion-item-name">
-                    {{promo.promotionName}}
+                    {{screen.itemValueDisplay.label}}
                 </div>
-                <ul responsive-class class="promotion-item-rewards">
-                    <li *ngFor="let reward of promo.rewards">
-                        {{reward}}
-                    </li>
-                </ul>
+                <div class="price">
+                    {{screen.itemValueDisplay.value}}
+                </div>
+            </span>
+            <ng-container *ngFor="let promo of screen.promotions; let i = index">
+                <span class="promotion-items" [ngClass]="{'promotion-item-gray': 0 === (i + 1) % 2}">
+                    <div class="promotion-item-icon">
+                        <app-icon [iconName]="promo.icon" color="primary" class="promotion-icon" iconClass="md"></app-icon>
+                    </div>
+                    <div class="promotion-item-name">
+                        {{promo.promotionName}}
+                    </div>
+                    <div class="price">
+                        {{promo.promotionPrice}}
+                    </div>
+                </span>
             </ng-container>
         </div>
-    </section>
-
-    <app-options-list optionListSizeClass="md"></app-options-list>
+    </mat-card>
 </section>
+

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.scss
@@ -21,13 +21,14 @@ p{
     margin: 0;
 }
 
+.page-gutter {
+    @extend %page-gutter
+}
+
 .item-card{
     display: grid;
     @extend %sub-element-container;
-    @extend %page-gutter;
     @extend %page-element;
-    width: 75%;
-    height: 100%;
     overflow-y: auto;
     align-self: center;
     justify-self: center;
@@ -61,8 +62,13 @@ app-options-list {
 .promotions {
     grid-area: promotions;
     align-self: start;
-
+    width: 50%;
+    float: right;
     @extend %text-md;
+    &.mobile,
+    &.tablet{
+        width: auto;
+    }
 }
 
 .promotion-list {
@@ -77,11 +83,19 @@ app-options-list {
 
 .promotion-items {
     display: grid;
-    grid-template-columns: auto 60% 1fr;
+    grid-template-columns: 65px 1fr 1fr;
+    padding-left: 5px;
+    padding-right: 5px;
+}
+
+.price {
+    justify-self: end;
+    align-self: center;
 }
 
 .promotion-item-rewards {
-    align-self: end;
+    justify-content: center;
+    align-self: center;
     list-style-type: none;
     padding-inline-start: 0;
     @extend %text-md;
@@ -89,6 +103,7 @@ app-options-list {
 
 .promotion-item-name {
     align-self: center;
+    font-weight: 525;
 }
 
 .promotion-icon {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.interface.ts
@@ -7,6 +7,7 @@ export interface ItemDetailInterface extends IAbstractScreen {
     imageUrls: string[];
     alternateImageUrl: string;
     itemName: string;
+    itemValueDisplay: DisplayProperty;
     summary: string;
     itemProperties: DisplayProperty[];
     itemActions: IActionItem[];

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/promotion.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/promotion.interface.ts
@@ -11,5 +11,5 @@ export interface IPromotionInterface extends IAbstractScreen {
     vendorFunded: boolean;
     rewardApplicationTypeCode: string;
     forLoyaltyReward: boolean;
-    rewards: string[];
+    promotionPrice: string;
 }

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/data/Promotion.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/data/Promotion.java
@@ -24,5 +24,5 @@ public class Promotion implements Serializable {
     boolean vendorFunded;
     String rewardApplicationTypeCode;
     boolean forLoyaltyReward;
-    List<String> rewards;
+    String promotionPrice;
 }

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/ItemDetailUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/ItemDetailUIMessage.java
@@ -21,6 +21,7 @@ public class ItemDetailUIMessage extends UIMessage {
 
     private String itemName;
     private String summary;
+    private DisplayProperty itemValueDisplay;
     private List<String> imageUrls;
     private String alternateImageUrl;
     private List<DisplayProperty> itemProperties;


### PR DESCRIPTION
### Issues Fixed
https://petcoalm.atlassian.net/browse/PDPOS-3991

### Summary
Update Item Detail screen to include price point as well as promo price for all promos for a specified item. Separated promos into separate card on detail screen:

### Screenshots
![image](https://user-images.githubusercontent.com/74971030/104482517-04908400-5595-11eb-867a-8cdbea8960cb.png)

![image](https://user-images.githubusercontent.com/74971030/104482629-2558d980-5595-11eb-89f1-a2b50f31939a.png)

No promotions:

![image](https://user-images.githubusercontent.com/74971030/104482671-343f8c00-5595-11eb-90c8-eae7eed6abc0.png)