### PR TITLE
Optimize item detail screen for responsive layout (#1068)

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.html
@@ -17,7 +17,7 @@
 
         <app-options-list optionListSizeClass="md"></app-options-list>
     </mat-card>
-    <mat-card class="promotions page-gutter">
+    <mat-card responsive-class class="promotions page-gutter">
         <h3 responsive-class>
             {{screen.promotions.length > 0 ? screen.itemPromotionsTitle : screen.itemNoPromotionsTitle}}
         </h3>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.scss
@@ -62,12 +62,12 @@ app-options-list {
 .promotions {
     grid-area: promotions;
     align-self: start;
-    width: 50%;
+    width: auto;
     float: right;
     @extend %text-md;
     &.mobile,
-    &.tablet{
-        width: auto;
+    &.tablet {
+        float: none;
     }
 }
 


### PR DESCRIPTION
### Summary
Changes to item detail screen needs optimized for tablet and mobile layouts (promo card grid was scrunched in tablet/mobile). Changed promo card to auto fit the screen.

### Screenshots
![image](https://user-images.githubusercontent.com/74971030/104605251-3f092800-564c-11eb-93a8-4d3e75207997.png)

![image](https://user-images.githubusercontent.com/74971030/104605318-53e5bb80-564c-11eb-8884-310e2ff71082.png)
