### PR TITLE
Tweaks to responsive item detail screen (#1071)

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.html
@@ -1,52 +1,55 @@
 <app-bacon-strip></app-bacon-strip>
-<section class="scrollable">
-    <mat-card class="item-card page-gutter">
-        <h1 responsive-class>{{screen.itemName}}</h1>
-        <p responsive-class>{{screen.summary}}</p>
-        <app-carousel class="carousel" carouselSize="xl" [carouselItemClass]="'rounded-edge'">
-            <ng-template *ngFor="let image of screen.imageUrls" #carouselItem>
-                <app-image [imageUrl]="image | imageUrl" [altImageUrl]="screen.alternateImageUrl" [altText]="'Image NotFound'"></app-image>
-            </ng-template>
-        </app-carousel>
+<section class="item-details">
+    <mat-card responsive-class class="padding-none page-gutter">
+        <div responsive-class class="item-card padding-none page-gutter page-element margin-bottom">
+            <h1 responsive-class>{{screen.itemName}}</h1>
+            <p responsive-class>{{screen.summary}}</p>
+            <app-carousel class="carousel" [carouselSize]="carouselSize" [carouselItemClass]="'rounded-edge'">
+                <ng-template *ngFor="let image of screen.imageUrls" #carouselItem>
+                    <app-image [imageUrl]="image | imageUrl" [altImageUrl]="screen.alternateImageUrl" [altText]="'Image NotFound'"></app-image>
+                </ng-template>
+            </app-carousel>
 
-        <ul responsive-class class="properties">
-            <li *ngFor="let prop of screen.itemProperties">
-                <app-display-property [property]="prop"></app-display-property>
-            </li>
-        </ul>
+            <ul responsive-class class="properties">
+                <li *ngFor="let prop of screen.itemProperties">
+                    <app-display-property [property]="prop"></app-display-property>
+                </li>
+            </ul>
 
-        <app-options-list optionListSizeClass="md"></app-options-list>
+            <app-options-list optionListSizeClass="md"></app-options-list>
+        </div>
+
     </mat-card>
-    <mat-card responsive-class class="promotions page-gutter">
-        <h3 responsive-class>
-            {{screen.promotions.length > 0 ? screen.itemPromotionsTitle : screen.itemNoPromotionsTitle}}
-        </h3>
-        <app-instructions *ngIf="screen.promotions && screen.promotions.length > 1"  [instructions]="screen.promotionStackingDisclaimer"
-                          [instructionsSize]="'text-md'"></app-instructions>
-        <div>
+    <mat-card responsive-class class=" promotions page-gutter padding-none">
+        <div responsive-class class="page-gutter page-element margin-bottom">
+            <h3 responsive-class>
+                {{screen.promotions.length > 0 ? screen.itemPromotionsTitle : screen.itemNoPromotionsTitle}}
+            </h3>
+            <app-instructions *ngIf="screen.promotions && screen.promotions.length > 1"  [instructions]="screen.promotionStackingDisclaimer"
+                              [instructionsSize]="'text-md'"></app-instructions>
             <span class="promotion-items promotion-item-gray">
+            <div class="promotion-item-icon">
+                <app-icon iconClass="md"></app-icon>
+            </div>
+            <div class="promotion-item-name">
+                {{screen.itemValueDisplay.label}}
+            </div>
+            <div class="price">
+                {{screen.itemValueDisplay.value}}
+            </div>
+        </span>
+            <ng-container *ngFor="let promo of screen.promotions; let i = index">
+            <span class="promotion-items" [ngClass]="{'promotion-item-gray': 0 === (i + 1) % 2}">
                 <div class="promotion-item-icon">
-                    <app-icon iconClass="md"></app-icon>
+                    <app-icon [iconName]="promo.icon" color="primary" class="promotion-icon" iconClass="md"></app-icon>
                 </div>
                 <div class="promotion-item-name">
-                    {{screen.itemValueDisplay.label}}
+                    {{promo.promotionName}}
                 </div>
                 <div class="price">
-                    {{screen.itemValueDisplay.value}}
+                    {{promo.promotionPrice}}
                 </div>
             </span>
-            <ng-container *ngFor="let promo of screen.promotions; let i = index">
-                <span class="promotion-items" [ngClass]="{'promotion-item-gray': 0 === (i + 1) % 2}">
-                    <div class="promotion-item-icon">
-                        <app-icon [iconName]="promo.icon" color="primary" class="promotion-icon" iconClass="md"></app-icon>
-                    </div>
-                    <div class="promotion-item-name">
-                        {{promo.promotionName}}
-                    </div>
-                    <div class="price">
-                        {{promo.promotionPrice}}
-                    </div>
-                </span>
             </ng-container>
         </div>
     </mat-card>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.scss
@@ -1,10 +1,18 @@
 @import "../../styles/mixins/typography";
 @import "../../styles/variables/spacing";
 
+.item-details {
+    display: flex;
+    flex-direction: column;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    top: 100px;
+}
 
-:host{
-    height: 100%;
-    display: grid;
+.padding-none {
+    padding: 0 0 0 0;
 }
 
 h1{
@@ -25,29 +33,21 @@ p{
     @extend %page-gutter
 }
 
+.page-element {
+    @extend %page-element
+}
+
+.margin-bottom {
+    margin-bottom: 1rem !important;
+}
+
 .item-card{
     display: grid;
-    @extend %sub-element-container;
-    @extend %page-element;
     overflow-y: auto;
-    align-self: center;
-    justify-self: center;
     grid-template: "image title" auto
                     "image summary" auto
-                    "image properties" 1fr
-                    "image promotions" 1fr
-                    "actions actions" auto/ auto 1fr;
-    &.mobile,
-    &.tablet-portrait{
-        grid-template: "title" auto
-                        "image" auto
-                        "summary" auto
-                        "properties" auto
-                        "promotions" auto
-                        "actions" auto/auto;
-        width: 100%;
-        align-self: start;
-    }
+                    "image properties" auto
+                    "actions actions" auto/auto;
 }
 
 app-options-list {
@@ -60,24 +60,17 @@ app-options-list {
 }
 
 .promotions {
-    grid-area: promotions;
-    align-self: start;
-    width: auto;
-    float: right;
+    width: 50%;
+    align-self: flex-end;
+    overflow: auto;
+    /* for Firefox */
+    min-height: 0;
+    margin-top: 0;
     @extend %text-md;
     &.mobile,
     &.tablet {
-        float: none;
-    }
-}
-
-.promotion-list {
-    list-style-type: none;
-    padding-inline-start: 0;
-
-    > li {
-        display: flex;
-        align-items: center;
+        width: auto;
+        align-self: auto;
     }
 }
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.ts
@@ -1,7 +1,9 @@
 import { ItemDetailInterface } from './item-detail.interface';
 import { ScreenComponent } from '../../shared/decorators/screen-component.decorator';
-import { Component } from '@angular/core';
+import {Component, Injector, Optional} from '@angular/core';
 import { PosScreen } from '../pos-screen/pos-screen.component';
+import {MediaBreakpoints, OpenposMediaService} from "../../core/media/openpos-media.service";
+import {Observable} from "rxjs";
 
 @ScreenComponent({
     name: 'ItemDetail'
@@ -12,6 +14,28 @@ import { PosScreen } from '../pos-screen/pos-screen.component';
     styleUrls: ['./item-detail.component.scss'],
 })
 export class ItemDetailComponent extends PosScreen<ItemDetailInterface> {
+    isMobile: Observable<boolean>;
+    carouselSize: String;
+    constructor( @Optional() injector: Injector, media: OpenposMediaService) {
+        super(injector);
+        this.isMobile = media.observe(new Map([
+            [MediaBreakpoints.MOBILE_PORTRAIT, true],
+            [MediaBreakpoints.MOBILE_LANDSCAPE, true],
+            [MediaBreakpoints.TABLET_PORTRAIT, true],
+            [MediaBreakpoints.TABLET_LANDSCAPE, true],
+            [MediaBreakpoints.DESKTOP_PORTRAIT, false],
+            [MediaBreakpoints.DESKTOP_LANDSCAPE, false]
+        ]));
+
+        this.isMobile.subscribe(mobile => {
+            if (mobile) {
+                this.carouselSize = 'sm';
+            } else {
+                this.carouselSize = 'xl';
+            }
+        });
+    }
+
     buildScreen() {
     }
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/option-button/option-button.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/option-button/option-button.component.scss
@@ -84,7 +84,6 @@
 
     &.mobile {
         .mat-button-wrapper {
-            grid-template-columns: auto 1fr;
             display: grid !important;
             column-gap: 4px;
         }


### PR DESCRIPTION
### Issues Fixed
https://petcoalm.atlassian.net/browse/PDPOS-3715

### Summary
Adjusted styling on item detail components to be responsive on mobile/tablet. Preventing screen from scrolling, and allowing promo card to scroll if necessary.

- Add listener for mobile/tablet breakpoints and decrease the size of the carousel images
- Remove padding from elements (pushing items out of flex view)
- Make promo card scrollable

### Screenshots
Desktop size:

![Screen Shot 2021-01-15 at 3 41 00 PM](https://user-images.githubusercontent.com/74971030/104777291-68f44480-5749-11eb-8c8d-826883c21f5e.png)

Reponsive:

https://user-images.githubusercontent.com/74971030/104777305-6eea2580-5749-11eb-9948-2b896f752706.mov
