### PR TITLE
The device model drives queries to other tables.  It should not include tag_ columns that are not defined in the yml config

### DIFF
--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/TagConfig.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/TagConfig.java
@@ -23,6 +23,10 @@ public class TagConfig {
     public void setTags(List<TagModel> tags) {
         this.tags = tags;
     }
+
+    public boolean hasTag(String tag) {
+        return tags.stream().filter(t->t.getName().equalsIgnoreCase(tag)).map(t->true).findFirst().orElse(false);
+    }
     
     public Map<String, List<TagModel>> getTagsByGroup() {
         Map<String, List<TagModel>> tagsByGroup = new LinkedHashMap<>();

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/TagHelper.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/TagHelper.java
@@ -122,7 +122,9 @@ public class TagHelper {
              if (columnUpper.startsWith(TagModel.TAG_PREFIX)) {
                  Object value = additionalFields.get(columnName);
                  String tagName = columnUpper.substring(TagModel.TAG_PREFIX.length());
-                 tags.put(tagName, value.toString());
+                 if (tagConfig.hasTag(tagName)) {
+                     tags.put(tagName, value.toString());
+                 }
              }
          }
          


### PR DESCRIPTION
### Summary
The device model drives queries to other tables.  It should not include tag_ columns that are not defined in the yml config.  If device model had an undefined tag_ column and ctx_config did not, a sql error occurred.
