### PR TITLE
Fix error in the log file during session disconnect

### DIFF
--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/service/SessionDisconnectedListener.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/service/SessionDisconnectedListener.java
@@ -37,9 +37,10 @@ public class SessionDisconnectedListener implements ApplicationListener<SessionD
         log.info("session disconnected: {}", sessionId);
         
         DeviceModel deviceModel = sessionAuthTracker.getDeviceModel(sessionId);
-        devicesService.disconnectDevice(new DisconnectDeviceRequest(deviceModel.getDeviceId(), deviceModel.getAppId()));
 
         if (deviceModel != null) {
+            devicesService.disconnectDevice(new DisconnectDeviceRequest(deviceModel.getDeviceId(), deviceModel.getAppId()));
+
             try {
                 eventPublisher.publish(new DeviceDisconnectedEvent(deviceModel.getDeviceId(), deviceModel.getAppId()));
             } catch (Exception ex) {


### PR DESCRIPTION
### Summary
Fix error in the log file during session disconnect.  Device can be null.  Account for it.
