### PR TITLE
Define explicit flag for logged in user on bacon strip

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/bacon-strip/bacon-strip.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/bacon-strip/bacon-strip.component.html
@@ -5,9 +5,9 @@
                          [iconClass]="'md'" (buttonClick)="buttonClick()">
         </app-icon-button>
         <app-icon-button *ngIf="helpTextService.isAvailable() | async" iconName="help"
-            (click)="helpTextService.toggle()"></app-icon-button>
+                         (click)="helpTextService.toggle()"></app-icon-button>
         <app-search-expand-input *ngIf="(isMobile | async)" (expanded)="onSearchExpand($event)"
-            class="bacon-strip-search"></app-search-expand-input>
+                                 class="bacon-strip-search"></app-search-expand-input>
     </div>
     <div *ngIf="!(isMobile | async) && !searchExpanded">
         <img *ngIf="screenData.logo" [src]="screenData.logo | imageUrl">
@@ -25,7 +25,7 @@
         <app-icon class="icon"
                   *ngIf="!screenData.operatorMenu"
                   [iconName]="screenData.operatorIcon"
-                         iconClass="md">
+                  iconClass="md">
         </app-icon>
     </div>
 </div>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/bacon-strip/bacon-strip.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/bacon-strip/bacon-strip.component.html
@@ -12,9 +12,9 @@
     <div *ngIf="!(isMobile | async) && !searchExpanded">
         <img *ngIf="screenData.logo" [src]="screenData.logo | imageUrl">
     </div>
-    <div *ngIf="!searchExpanded && screenData.operatorLine1" class="rightside">
-        <p class="operator-name">{{screenData.operatorLine1}}</p>
-        <p class="operator-id">{{screenData.operatorLine2}}</p>
+    <div *ngIf="!searchExpanded && screenData.hasCurrentUser" class="rightside">
+        <p *ngIf="screenData.operatorLine1" class="operator-name">{{screenData.operatorLine1}}</p>
+        <p *ngIf="screenData.operatorLine2" class="operator-id">{{screenData.operatorLine2}}</p>
         <app-kebab-button class="icon"
                           *ngIf="screenData.operatorMenu"
                           [iconName]="screenData.operatorIcon"

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/bacon-strip/bacon-strip.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/bacon-strip/bacon-strip.component.ts
@@ -27,6 +27,7 @@ export class BaconStripComponent extends ScreenPartComponent<BaconStripInterface
     isMobile: Observable<boolean>;
 
     searchExpanded = false;
+
     constructor(injector: Injector, public helpTextService: HelpTextService, private media: OpenposMediaService,
                 protected keyPresses: KeyPressProvider) {
         super(injector);
@@ -41,15 +42,15 @@ export class BaconStripComponent extends ScreenPartComponent<BaconStripInterface
         ]));
 
         this.subscriptions.add(
-          this.keyPresses.subscribe( 'Escape', 100, (event: KeyboardEvent) => {
-            // ignore repeats and check configuration
-            if ( event.repeat || event.type !== 'keydown' || !Configuration.enableKeybinds) {
-              return;
-            }
-            if ( event.type === 'keydown' && this.screenData.actions) {
-              this.buttonClick();
-            }
-          })
+            this.keyPresses.subscribe('Escape', 100, (event: KeyboardEvent) => {
+                // ignore repeats and check configuration
+                if (event.repeat || event.type !== 'keydown' || !Configuration.enableKeybinds) {
+                    return;
+                }
+                if (event.type === 'keydown' && this.screenData.actions) {
+                    this.buttonClick();
+                }
+            })
         );
     }
 
@@ -75,3 +76,4 @@ export class BaconStripComponent extends ScreenPartComponent<BaconStripInterface
         this.searchExpanded = expanded;
     }
 }
+

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/bacon-strip/bacon-strip.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/bacon-strip/bacon-strip.interface.ts
@@ -1,6 +1,7 @@
 import {IActionItem} from '../../../core/actions/action-item.interface';
 
 export interface BaconStripInterface {
+    hasCurrentUser: boolean;
     operatorLine1: string;
     operatorLine2: string;
     headerText: string;

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/messagepart/BaconStripPart.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/messagepart/BaconStripPart.java
@@ -1,9 +1,5 @@
 package org.jumpmind.pos.core.ui.messagepart;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -11,6 +7,10 @@ import lombok.NoArgsConstructor;
 import org.jumpmind.pos.core.ui.ActionItem;
 import org.jumpmind.pos.core.ui.IHasBackButton;
 import org.jumpmind.pos.core.ui.IconType;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 @Data
 @Builder

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/messagepart/BaconStripPart.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/messagepart/BaconStripPart.java
@@ -19,6 +19,7 @@ import org.jumpmind.pos.core.ui.IconType;
 public class BaconStripPart implements IHasBackButton, Serializable {
     private static final long serialVersionUID = 1L;
 
+    private boolean hasCurrentUser;
     private String operatorLine1;
     private String operatorLine2;
     private String headerText;


### PR DESCRIPTION
### Issues Fixed
https://petcoalm.atlassian.net/browse/PDPOS-4608

### Summary
User menu not showing in client when the logged in user is missing `operatorLine1` which is currently set to the nullable user first name. Changed to define an explicit flag for a logged in user instead of a DTO field.