### PR TITLE
Fixed app-dynamic-form-part throwing Angular error "Expression changed after it was checked" 

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/dynamic-form-part/dynamic-form-part.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/dynamic-form-part/dynamic-form-part.component.html
@@ -16,7 +16,7 @@
                 <span>{{button.label}}</span>
                 <app-icon *ngIf="button.icon" [iconName]="button.icon"></app-icon>
             </app-secondary-button>
-            <app-primary-button *ngIf="submitButton" type="submit" [disabled]="!form.valid || form.pending">
+            <app-primary-button *ngIf="submitButton" type="submit" [disabled]="disableSubmitButton">
                 <span>{{submitButton.title}}</span>
                 <app-icon *ngIf="submitButton.icon" [iconName]="submitButton.icon"></app-icon>
             </app-primary-button>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/dynamic-form-part/dynamic-form-part.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/dynamic-form-part/dynamic-form-part.component.ts
@@ -61,10 +61,11 @@ export class DynamicFormPartComponent extends ScreenPartComponent<IForm> impleme
         }
 
         this.form = this.formBuilder.group(this.screenData);
+        this.updateSubmitButtonState();
 
         this.form.statusChanges
             .pipe(
-                tap(() => this.disableSubmitButton = this.isFormInvalid()),
+                tap(() => this.updateSubmitButtonState()),
                 takeUntil(this.beforeScreenDataUpdated$)
             )
             // Let Angular know that changes in a child view (app-dynamic-form-field) will cause the UI
@@ -94,13 +95,17 @@ export class DynamicFormPartComponent extends ScreenPartComponent<IForm> impleme
         }
     }
 
+    updateSubmitButtonState(): void {
+        this.disableSubmitButton = this.isFormInvalid();
+    }
+
     isFormInvalid(): boolean {
         return this.form.invalid || this.form.pending;
     }
 
     ngOnInit() {
         super.ngOnInit();
-        this.disableSubmitButton = this.isFormInvalid();
+        this.updateSubmitButtonState();
     }
 
     ngAfterViewInit(): void {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/dynamic-form-part/dynamic-form-part.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/dynamic-form-part/dynamic-form-part.component.ts
@@ -1,9 +1,9 @@
 import {
-    AfterViewInit,
+    AfterViewInit, ChangeDetectorRef,
     Component,
     EventEmitter,
     Injector,
-    Input,
+    Input, OnInit,
     Output,
     QueryList,
     ViewChild,
@@ -18,13 +18,14 @@ import {IForm} from '../../../core/interfaces/form.interface';
 import {IFormElement} from '../../../core/interfaces/form-field.interface';
 import {IActionItem} from '../../../core/actions/action-item.interface';
 import {IDynamicFormPartEventArg} from './dynamic-form-part-event-arg.interface';
+import { takeUntil, tap } from 'rxjs/operators';
 
 @Component({
     selector: 'app-dynamic-form-part',
     templateUrl: './dynamic-form-part.component.html',
     styleUrls: ['./dynamic-form-part.component.scss']
 })
-export class DynamicFormPartComponent extends ScreenPartComponent<IForm> implements AfterViewInit{
+export class DynamicFormPartComponent extends ScreenPartComponent<IForm> implements OnInit, AfterViewInit {
     @Output() formInit = new EventEmitter<IDynamicFormPartEventArg>();
     @Output() formChanges = new EventEmitter<IDynamicFormPartEventArg>();
     @ViewChildren(DynamicFormFieldComponent) children: QueryList<DynamicFormFieldComponent>;
@@ -32,6 +33,7 @@ export class DynamicFormPartComponent extends ScreenPartComponent<IForm> impleme
     form: FormGroup;
 
     buttons: IFormElement[];
+    disableSubmitButton: boolean;
 
     private _alternateSubmitActions: string[];
     private  lastFocusedId;
@@ -43,7 +45,7 @@ export class DynamicFormPartComponent extends ScreenPartComponent<IForm> impleme
 
     @Input() submitButton: IActionItem;
 
-    constructor(private formBuilder: FormBuilder, injector: Injector) {
+    constructor(private changeDetectorRef: ChangeDetectorRef, private formBuilder: FormBuilder, injector: Injector) {
         super(injector);
     }
 
@@ -59,6 +61,15 @@ export class DynamicFormPartComponent extends ScreenPartComponent<IForm> impleme
         }
 
         this.form = this.formBuilder.group(this.screenData);
+
+        this.form.statusChanges
+            .pipe(
+                tap(() => this.disableSubmitButton = this.isFormInvalid()),
+                takeUntil(this.beforeScreenDataUpdated$)
+            )
+            // Let Angular know that changes in a child view (app-dynamic-form-field) will cause the UI
+            // in this control to update
+            .subscribe(() => this.changeDetectorRef.detectChanges());
 
         this.formInit.emit({
             form: this.screenData,
@@ -81,6 +92,15 @@ export class DynamicFormPartComponent extends ScreenPartComponent<IForm> impleme
                 }
             });
         }
+    }
+
+    isFormInvalid(): boolean {
+        return this.form.invalid || this.form.pending;
+    }
+
+    ngOnInit() {
+        super.ngOnInit();
+        this.disableSubmitButton = this.isFormInvalid();
     }
 
     ngAfterViewInit(): void {


### PR DESCRIPTION
### Issues Fixed
[PDPOS-4697](https://petcoalm.atlassian.net/browse/PDPOS-4697)

### Summary
This fixes a bug, in the `app-dynamic-form-part`, where some form changes would cause the dreaded Angular exception, *"Expression was changed after it was checked"*.

### Screenshots
**Before Fix**
![manual-capture-id-expression-changed-error](https://user-images.githubusercontent.com/3991426/105769789-5be70a80-5f2c-11eb-8679-cddff0fc32d3.gif)

**After Fix**
![manual-capture-id-expression-changed-fixed](https://user-images.githubusercontent.com/3991426/105769806-60132800-5f2c-11eb-93ad-3bdb6ec2d298.gif)
