### PR TITLE
Upgrade SymmetricDS to 3.12.6 to fix postgres deadlock

### DIFF
--- a/openpos-assemble/gradle.properties
+++ b/openpos-assemble/gradle.properties
@@ -1,7 +1,7 @@
 #Wed Jun 17 12:11:05 UTC 2020
 version=2.0.0-SNAPSHOT
 deployPassword=
-symmetricVersion=3.12.5
+symmetricVersion=3.12.6
 systemProp.org.gradle.internal.http.socketTimeout=120000
 personalAccessToken=?
 remoteRepoUrl=https\://${personalAccessToken}@github.com/JumpMind/openpos-framework.git


### PR DESCRIPTION
### Summary
Upgrade SymmetricDS to 3.12.6 to fix postgres deadlock