### PR TITLE
Feature/display employee sale

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/return/return.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/return/return.component.html
@@ -25,6 +25,7 @@
             <app-sale-total-panel></app-sale-total-panel>
         </div>
         <div *ngIf="(isMobile | async)" class="return-body-mobile">
+            <app-mobile-employee-part class="return-employee-mobile"></app-mobile-employee-part>
             <app-mobile-loyalty-part class="return-loyalty-mobile"></app-mobile-loyalty-part>
             <app-mobile-sale-item-list class="return-list-background-mobile"></app-mobile-sale-item-list>
         </div>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/return/return.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/return/return.component.scss
@@ -80,6 +80,10 @@
             .scan-or-search-mobile {
                 margin-bottom: 8px;
             }
+
+            .return-employee-mobile {
+                margin-bottom: 8px;
+            }
             
             .return-loyalty-mobile {
                 margin-bottom: 8px;

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/sale.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/sale.component.html
@@ -28,6 +28,7 @@
             <app-sale-total-panel></app-sale-total-panel>
         </div>
         <div *ngIf="(isMobile | async)" class="sale-body-mobile">
+            <app-mobile-employee-part class="sale-employee-mobile"></app-mobile-employee-part>
             <app-mobile-loyalty-part class="sale-loyalty-mobile"></app-mobile-loyalty-part>
             <app-mobile-sale-item-list class="sale-list-background-mobile"></app-mobile-sale-item-list>
         </div>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/sale.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/sale.component.scss
@@ -79,6 +79,10 @@
             display: grid;
             grid-template-rows: auto auto 1fr;
 
+            .sale-employee-mobile {
+                margin-bottom: 8px;
+            }
+            
             .sale-loyalty-mobile {
                 margin-bottom: 8px;
             }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/_screen-part-themes.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/_screen-part-themes.scss
@@ -6,6 +6,7 @@
 @import './notifications/notifications-theme';
 @import './mobile-totals-part/mobile-totals-part-theme';
 @import './mobile-loyalty-part/mobile-loyalty-part-theme';
+@import './mobile-employee-part/mobile-employee-part-theme';
 @import './mobile-sale-item-list/mobile-sale-item-list-theme';
 @import './sale-item-card-list/sale-item-card-list-theme';
 @import './search-expand-input/search-expand-input-theme';
@@ -22,6 +23,7 @@
     @include notification-theme($theme);
     @include mobile-totals-part-theme($theme);
     @include mobile-loyalty-part-theme($theme);
+    @include mobile-employee-part-theme($theme);
     @include mobile-sale-item-list-theme($theme);
     @include sale-item-card-list-theme($theme);
     @include search-expand-input-theme($theme);

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/mobile-employee-part/mobile-employee-part-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/mobile-employee-part/mobile-employee-part-theme.scss
@@ -1,0 +1,17 @@
+@mixin mobile-employee-part-theme($theme) {
+    $app-primary: mat-color(map-get($theme, primary));
+    $app-accent: mat-color(map-get($theme, accent));
+    $app-warn: mat-color(map-get($theme, warn));
+
+    $foreground: map-get($theme, foreground);
+    $background: map-get($theme, background);
+    $dark: map-get($mat-grey, 600);
+
+    .mobile-employee-name {
+        color: $dark;
+    }
+
+    .mobile-employee-id {
+        color: $dark;
+    }
+}

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/mobile-employee-part/mobile-employee-part.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/mobile-employee-part/mobile-employee-part.component.html
@@ -1,0 +1,12 @@
+<button *ngIf="screenData.employee && screenData.linkedEmployeeButton" mat-raised-button
+    class="mobile-employee-sale-outer" (click)="doAction(screenData.linkedEmployeeButton)">
+    <app-icon responsive-class *ngIf="screenData.employee.icon" [iconName]="screenData.employee.icon" [iconClass]="'primary xs'"></app-icon>
+    <div class="mobile-employee-sale-name">
+        <div responsive-class *ngIf="screenData.employee.name" class="mobile-employee-name">
+            {{screenData.employee.name}}
+        </div>
+        <div responsive-class *ngIf="screenData.employee.label && screenData.employee.id" class="mobile-employee-id">
+            {{screenData.employee.label}}: {{screenData.employee.id}}
+        </div>
+    </div>
+</button>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/mobile-employee-part/mobile-employee-part.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/mobile-employee-part/mobile-employee-part.component.scss
@@ -1,0 +1,29 @@
+@import '../../../styles/mixins/typography';
+
+::ng-deep .mobile-employee-sale-outer {
+    margin: 0px !important;
+    padding: 8px 16px !important;
+    width: 100%;
+
+    .mat-button-wrapper {
+        grid-template-columns: auto 1fr;
+        display: grid;
+        margin: 0px;
+        line-height: normal;
+    }
+}
+
+.mobile-employee-sale-name {
+    display: grid;
+    justify-self: end;
+}
+
+.mobile-employee-name {
+    @extend %text-sm;
+    justify-self: end;
+}
+
+.mobile-employee-id {
+    @extend %text-sm;
+    justify-self: end;
+}

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/mobile-employee-part/mobile-employee-part.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/mobile-employee-part/mobile-employee-part.component.ts
@@ -1,0 +1,20 @@
+import { Component } from '@angular/core';
+import { ScreenPart } from '../../decorators/screen-part.decorator';
+import { ScreenPartComponent } from '../screen-part';
+import { MobileEmployeePartInterface } from './mobile-employee-part.interface';
+
+
+@ScreenPart({
+    name: 'MobileEmployeePart'
+})
+@Component({
+    selector: 'app-mobile-employee-part',
+    templateUrl: './mobile-employee-part.component.html',
+    styleUrls: ['./mobile-employee-part.component.scss']
+})
+export class MobileEmployeePartComponent extends ScreenPartComponent<MobileEmployeePartInterface> {
+
+    screenDataUpdated() {
+    }
+
+}

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/mobile-employee-part/mobile-employee-part.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/mobile-employee-part/mobile-employee-part.interface.ts
@@ -1,0 +1,7 @@
+import { IAbstractScreen } from '../../../core/interfaces/abstract-screen.interface';
+import { IActionItem } from '../../../core/actions/action-item.interface';
+
+export interface MobileEmployeePartInterface extends IAbstractScreen {
+    linkedEmployeeButton: IActionItem;
+    employee: { name: string, label: string, icon: string, id: string };
+}

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel-theme.scss
@@ -20,19 +20,41 @@
     }
 
     .sale-total-customer-button {
-        .mat-button-wrapper {
+        button {
             @extend %text-sm;
-            display: grid;
-            
-            div {
-                line-height: normal;
+            .mat-button-wrapper {
+                display: grid;
+                
+                div {
+                    line-height: normal;
+                }
             }
         }
+
 
         .sale-total-loyalty-icon {
             padding: 0 8px;
             max-width: 100%;
             max-height: 3em;
+        }
+    }
+
+    .sale-total-employee-sale-button {
+        button {
+            @extend %text-sm;
+            .mat-button-wrapper {
+                display: grid;
+                
+                div {
+                    line-height: normal;
+                }
+            }    
+        }
+
+        .sale-total-employee-sale-name {
+            display: grid;
+            grid-template-columns: auto 1fr;
+            grid-gap: 0px 5px;
         }
     }
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.html
@@ -34,10 +34,24 @@
     </div>
 
     <div class="sale-total-buttons">
-        <div *ngIf="!screenData.customer && screenData.taxExemptCertificateDetail"
+        <div responsive-class *ngIf="!screenData.customer && screenData.taxExemptCertificateDetail"
              class="muted-color sale-total-tax-exempt-label-no-customer">
             {{screenData.taxExemptCertificateDetail.label}}: {{screenData.taxExemptCertificateDetail.value}}
         </div>
+        <app-secondary-button responsive-class 
+                              *ngIf="screenData.employee"
+                              class="sale-total-employee-sale-button"
+                              [actionItem]="screenData.linkedEmployeeButton"
+                              (actionClick)="doMenuItemAction(screenData.linkedEmployeeButton)" 
+                              (click)="doMenuItemAction(screenData.linkedEmployeeButton)">
+            <div *ngIf="screenData.employee.name" class="muted-color sale-total-employee-sale-name">
+                <app-icon responsive-class *ngIf="screenData.employee.icon" [iconName]="screenData.employee.icon" [iconClass]="'xs'"></app-icon>
+                <b>{{screenData.employee.name}}</b>
+            </div>
+            <div *ngIf="screenData.employee.label && screenData.employee.id" class="muted-color">
+                {{screenData.employee.label}}: {{screenData.employee.id}}
+            </div>
+        </app-secondary-button>
         <app-secondary-button responsive-class
                               *ngIf="!screenData.readOnly && !screenData.linkedCustomerButton && screenData.loyaltyButton"
                               [actionItem]="screenData.loyaltyButton"
@@ -47,7 +61,7 @@
             <img [src]="screenData.loyaltyButton.icon | imageUrl" class="sale-total-loyalty-button-icon">
             <span *ngIf="loyaltyAfter">{{loyaltyAfter}}</span>
             <span *ngIf="keybindsEnabled(screenData.loyaltyButton)"
-                  class="muted-color">{{screenData.loyaltyButton.keybindDisplayName}}</span>
+                  class="muted-color loyalty-keybind">{{screenData.loyaltyButton.keybindDisplayName}}</span>
         </app-secondary-button>
         <app-secondary-button responsive-class *ngIf="screenData.helpButton"
                               [actionItem]="screenData.helpButton"
@@ -59,9 +73,11 @@
             <span *ngIf="keybindsEnabled(screenData.helpButton)"
                   class="muted-color">{{screenData.helpButton.keybindDisplayName}}</span>
         </app-secondary-button>
-        <app-secondary-button *ngIf="screenData.customer && screenData.linkedCustomerButton" responsive-class
-            class="sale-total-customer-button" [actionItem]="screenData.linkedCustomerButton"
-            (actionClick)="doMenuItemAction(screenData.linkedCustomerButton)" (click)="doMenuItemAction(screenData.linkedCustomerButton)">
+        <app-secondary-button responsive-class *ngIf="screenData.customer && screenData.linkedCustomerButton" 
+                              class="sale-total-customer-button" 
+                              [actionItem]="screenData.linkedCustomerButton"
+                              (actionClick)="doMenuItemAction(screenData.linkedCustomerButton)" 
+                              (click)="doMenuItemAction(screenData.linkedCustomerButton)">
             <img *ngIf="screenData.customer.icon" [src]="screenData.customer.icon | imageUrl" class="sale-total-loyalty-icon"
                 responsive-class>
             <div *ngIf="screenData.customer.name" class="muted-color">{{screenData.customer.name}}</div>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
@@ -117,21 +117,22 @@
         grid-area: buttons;
         display: grid;
         align-self: end;
+        grid-row-gap: 16px;
 
         .sale-total-tax-exempt-label-no-customer {
             @extend %text-sm;
             text-align: center;
             justify-self: center;
-            margin-bottom: 8px;
+            margin-bottom: -8px;
         }
 
         .sale-total-button {
             min-height: 70px;
-            margin-top: 16px;
             width: 100%;
         }
     }
 
+    .loyalty-keybind,
     .checkout-keybind {
         padding-left: 8px;
     }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.interface.ts
@@ -11,8 +11,10 @@ export interface SaleTotalPanelInterface extends IAbstractScreen {
     logoutButton: IActionItem;
     loyaltyButton: IActionItem;
     linkedCustomerButton: IActionItem;
+    linkedEmployeeButton: IActionItem;
     promoButton: IActionItem;
     customer: { name: string, label: string, icon: string, id: string };
+    employee: {name: string, label: string, icon: string, id: string};
     taxExemptCertificateDetail: {label: string, value: string};
     readOnly: boolean;
     prompt: string;

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/shared.module.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/shared.module.ts
@@ -128,6 +128,7 @@ import {BaconDrawerComponent} from './screen-parts/bacon-strip/bacon-drawer/baco
 import {CarouselComponent} from './components/carousel/carousel.component';
 import {MobileTotalsPartComponent} from './screen-parts/mobile-totals-part/mobile-totals-part.component';
 import {MobileLoyaltyPartComponent} from './screen-parts/mobile-loyalty-part/mobile-loyalty-part.component';
+import {MobileEmployeePartComponent} from './screen-parts/mobile-employee-part/mobile-employee-part.component';
 import {MobileSaleItemListComponent} from './screen-parts/mobile-sale-item-list/mobile-sale-item-list.component';
 import {MobileItemComponent} from './components/mobile-item/mobile-item.component';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
@@ -181,6 +182,7 @@ const screenParts = [
     SaleTotalPanelComponent,
     MobileTotalsPartComponent,
     MobileLoyaltyPartComponent,
+    MobileEmployeePartComponent,
     MobileSaleItemListComponent,
     OptionsListComponent,
     ScanPartComponent,

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/ReturnUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/ReturnUIMessage.java
@@ -26,11 +26,13 @@ public class ReturnUIMessage extends UIMessage {
     private ActionItem checkoutButton;
     private ActionItem loyaltyButton;
     private ActionItem linkedCustomerButton;
+    private ActionItem linkedEmployeeButton;
     private ActionItem removeReceiptAction;
 
     private boolean transactionActive = false;
 
     private UICustomer customer;
+    private UICustomer employee;
 
     private boolean locationEnabled;
     private String locationOverridePrompt;

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/SaleUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/SaleUIMessage.java
@@ -3,6 +3,7 @@ package org.jumpmind.pos.core.ui.message;
 import java.util.ArrayList;
 import java.util.List;
 
+import lombok.Data;
 import org.jumpmind.pos.core.model.Total;
 import org.jumpmind.pos.core.ui.ActionItem;
 import org.jumpmind.pos.core.ui.AssignKeyBindings;
@@ -11,6 +12,7 @@ import org.jumpmind.pos.core.ui.data.AdditionalLabel;
 import org.jumpmind.pos.core.ui.data.OrderSummary;
 
 @AssignKeyBindings
+@Data
 public class SaleUIMessage extends UIMessage {
     private static final long serialVersionUID = 1L;
 
@@ -30,11 +32,13 @@ public class SaleUIMessage extends UIMessage {
     private ActionItem loyaltyButton;
     private ActionItem mobileLoyaltyButton;
     private ActionItem linkedCustomerButton;
+    private ActionItem linkedEmployeeButton;
     private ActionItem promoButton;
 
     private boolean transactionActive = false;
 
     private UICustomer customer;
+    private UICustomer employee;
     private AdditionalLabel taxExemptCertificateDetail;
 
     private boolean locationEnabled;
@@ -47,22 +51,6 @@ public class SaleUIMessage extends UIMessage {
         this.setId("sale");
     }
 
-    public String getProviderKey() {
-        return providerKey;
-    }
-
-    public void setProviderKey(String providerKey) {
-        this.providerKey = providerKey;
-    }
-
-    public List<Total> getTotals() {
-        return totals;
-    }
-
-    public void setTotals(List<Total> totals) {
-        this.totals = totals;
-    }
-
     public void addTotal(String name, String amount) {
         if (totals == null) {
             totals = new ArrayList<>();
@@ -70,24 +58,8 @@ public class SaleUIMessage extends UIMessage {
         totals.add(new Total(name, amount));
     }
 
-    public Total getGrandTotal() {
-        return grandTotal;
-    }
-
-    public void setGrandTotal(Total grandTotal) {
-        this.grandTotal = grandTotal;
-    }
-
     public void setGrandTotal(String name, String amount) {
         this.grandTotal = new Total(name, amount);
-    }
-
-    public List<OrderSummary> getOrders() {
-        return orders;
-    }
-
-    public void setOrders(List<OrderSummary> orders) {
-        this.orders = orders;
     }
 
     public void addOrder(OrderSummary orderSummary) {
@@ -97,131 +69,12 @@ public class SaleUIMessage extends UIMessage {
         this.orders.add(orderSummary);
     }
 
-    public ActionItem getRemoveOrderAction() {
-        return removeOrderAction;
-    }
-
-    public void setRemoveOrderAction(ActionItem removeOrderAction) {
-        this.removeOrderAction = removeOrderAction;
-    }
-
-    public UICustomer getCustomer() {
-        return customer;
-    }
-
-    public void setCustomer(UICustomer customer) {
-        this.customer = customer;
-    }
-
-    public AdditionalLabel getTaxExemptCertificateDetail() {
-        return taxExemptCertificateDetail;
-    }
-
-    public void setTaxExemptCertificateDetail(AdditionalLabel taxExemptCertificateDetail) {
-        this.taxExemptCertificateDetail = taxExemptCertificateDetail;
-    }
-
     public void setTaxExemptCertificateDetail(String label, String value) {
         this.taxExemptCertificateDetail = new AdditionalLabel(label, value);
-    }
-
-    public ActionItem getLoyaltyButton() {
-        return loyaltyButton;
-    }
-
-    public void setLoyaltyButton(ActionItem loyaltyButton) {
-        this.loyaltyButton = loyaltyButton;
-    }
-
-    public ActionItem getMobileLoyaltyButton() {
-        return mobileLoyaltyButton;
-    }
-
-    public void setMobileLoyaltyButton(ActionItem mobileLoyaltyButton) {
-        this.mobileLoyaltyButton = mobileLoyaltyButton;
-    }
-
-    public boolean isLocationEnabled() {
-        return locationEnabled;
-    }
-
-    public void setLocationEnabled(boolean locationEnabled) {
-        this.locationEnabled = locationEnabled;
-    }
-
-    public String getLocationOverridePrompt() {
-        return locationOverridePrompt;
-    }
-
-    public void setLocationOverridePrompt(String locationOverridePrompt) {
-        this.locationOverridePrompt = locationOverridePrompt;
-    }
-
-    public ActionItem getPromoButton() {
-        return promoButton;
-    }
-
-    public void setPromoButton(ActionItem promoButton) {
-        this.promoButton = promoButton;
-    }
-    
-    public void setTransactionActive(boolean isTransactionActive) {
-        this.transactionActive = isTransactionActive;
-    }
-
-    public boolean isTransactionActive() {
-        return transactionActive;
-    }
-
-    public Total getItemCount() {
-        return itemCount;
     }
 
     public void setItemCount(String name, String amount) {
         this.setItemCount(new Total(name, amount));
     }
     
-    public void setItemCount(Total itemCount) {
-        this.itemCount = itemCount;
-    }
-
-    public ActionItem getCheckoutButton() {
-        return checkoutButton;
-    }
-
-    public void setCheckoutButton(ActionItem checkoutButton) {
-        this.checkoutButton = checkoutButton;
-    }
-
-    public ActionItem getLogoutButton() {
-        return logoutButton;
-    }
-
-    public void setLogoutButton(ActionItem logoutButton) {
-        this.logoutButton = logoutButton;
-    }
-
-    public ActionItem getHelpButton() {
-        return helpButton;
-    }
-
-    public void setHelpButton(ActionItem helpButton) {
-        this.helpButton = helpButton;
-    }
-
-    public boolean isEnableCollapsibleItems() {
-        return enableCollapsibleItems;
-    }
-
-    public void setEnableCollapsibleItems(boolean enableCollapsibleItems) {
-        this.enableCollapsibleItems = enableCollapsibleItems;
-    }
-
-    public ActionItem getLinkedCustomerButton() {
-        return linkedCustomerButton;
-    }
-
-    public void setLinkedCustomerButton(ActionItem linkedCustomerButton) {
-        this.linkedCustomerButton = linkedCustomerButton;
-    }
 }


### PR DESCRIPTION
### Issues Fixed
[PDPOS-3214](https://petcoalm.atlassian.net/browse/PDPOS-3214)

### Summary
Update sale-total-panel to add visual representation on the screen when an employee is linked for employee discount. Additionally add mobile-employee-part screen part for displaying the employee during mobile view.

### Screenshots
<img width="1679" alt="Screen Shot 2021-01-29 at 11 20 07 AM" src="https://user-images.githubusercontent.com/6811136/106301755-1a08dd80-6226-11eb-8d30-ba828a57cb5d.png">
<img width="769" alt="Screen Shot 2021-01-29 at 11 20 31 AM" src="https://user-images.githubusercontent.com/6811136/106301767-1d9c6480-6226-11eb-8843-d5f1b686870a.png">
<img width="283" alt="Screen Shot 2021-01-29 at 11 20 51 AM" src="https://user-images.githubusercontent.com/6811136/106301774-212feb80-6226-11eb-909b-282b2709a731.png">
<img width="580" alt="Screen Shot 2021-01-29 at 11 21 08 AM" src="https://user-images.githubusercontent.com/6811136/106301792-255c0900-6226-11eb-81c9-ec13fea3d44a.png">

