### PR TITLE
Update sale-total-panel component to show the linkedCustomerButton ke…

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel-theme.scss
@@ -31,12 +31,16 @@
             }
         }
 
+        .sale-total-loyalty-linked-icon {
+            display: grid;
+            grid-template-columns: 1fr auto;
 
-        .sale-total-loyalty-icon {
-            padding: 0 8px;
-            max-width: 100%;
-            max-height: 3em;
+            .sale-total-loyalty-icon {
+                max-width: 100%;
+                max-height: 3em;
+            }
         }
+
     }
 
     .sale-total-employee-sale-button {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.html
@@ -78,8 +78,12 @@
                               [actionItem]="screenData.linkedCustomerButton"
                               (actionClick)="doMenuItemAction(screenData.linkedCustomerButton)" 
                               (click)="doMenuItemAction(screenData.linkedCustomerButton)">
-            <img *ngIf="screenData.customer.icon" [src]="screenData.customer.icon | imageUrl" class="sale-total-loyalty-icon"
-                responsive-class>
+            <div *ngIf="screenData.customer.icon" class="sale-total-loyalty-linked-icon">
+                <img [src]="screenData.customer.icon | imageUrl" class="sale-total-loyalty-icon"
+                    responsive-class>
+                <span *ngIf="keybindsEnabled(screenData.linkedCustomerButton)"
+                    class="muted-color loyalty-keybind">{{screenData.linkedCustomerButton.keybindDisplayName}}</span>
+            </div>
             <div *ngIf="screenData.customer.name" class="muted-color">{{screenData.customer.name}}</div>
             <div *ngIf="screenData.customer.label && screenData.customer.id" class="muted-color">
                 {{screenData.customer.label}}: {{screenData.customer.id}}

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
@@ -135,5 +135,6 @@
     .loyalty-keybind,
     .checkout-keybind {
         padding-left: 8px;
+        align-self: center;
     }
 }


### PR DESCRIPTION
### Issues Fixed
[PDPOS-3047](https://petcoalm.atlassian.net/browse/PDPOS-3047)

### Summary
Update sale-total-panel component to show the linkedCustomerButton keybind name if there is a keybind on the button

### Screenshots
<img width="841" alt="Screen Shot 2021-02-04 at 9 54 42 AM" src="https://user-images.githubusercontent.com/6811136/106910888-a8baa600-66cf-11eb-88b8-fdcf3b0f7211.png">

