### PR TITLE
Ensure ActionService can be injected into NavListComponent dialog; Don't allow Splashscreen to show if dialog is being shown

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/services/dialog.service.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/services/dialog.service.ts
@@ -75,6 +75,8 @@ export class DialogService {
         DialogService.dialogs.set(name, type);
     }
 
+    
+
     public isDialogOpenOrOpening(): boolean {
         if (!this.dialogOpening) {
             return this.isDialogOpen();

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-deprecated/multiselect-item-list/multiselect-item-list.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-deprecated/multiselect-item-list/multiselect-item-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild, ElementRef, AfterViewInit, AfterViewChecked, Injector } from '@angular/core';
+import { Component, OnInit, ViewChild, ElementRef, AfterViewInit, AfterViewChecked, Injector, ViewContainerRef } from '@angular/core';
 import { MatDialog } from '@angular/material';
 import { NavListComponent } from '../../shared/components/nav-list/nav-list.component';
 import { PosScreen } from '../pos-screen/pos-screen.component';
@@ -44,7 +44,7 @@ export class MultiselectItemListComponent extends PosScreen<any> implements OnIn
     private nextActionPresent = false;
 
 
-    constructor(protected dialog: MatDialog, injector: Injector) {
+    constructor(protected dialog: MatDialog, injector: Injector, public vcRef: ViewContainerRef) {
         super(injector);
     }
 
@@ -122,8 +122,8 @@ export class MultiselectItemListComponent extends PosScreen<any> implements OnIn
 
     public onItemListChange(event: number[]): void {
         const indexes = event;
-        this.selectedItems = this.screen.items.array.filter(element => {
-            indexes.includes(element.index);
+        this.selectedItems = this.screen.items.filter(element => {
+            return indexes.includes(element.index);
         });
 
         if (this.individualMenuClicked) {
@@ -211,6 +211,7 @@ export class MultiselectItemListComponent extends PosScreen<any> implements OnIn
         }
 
         const dialogRef = this.dialog.open(NavListComponent, {
+            viewContainerRef:  this.vcRef,
             width: '70%',
             data: {
                 optionItems: options,

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/directives/screen-outlet.directive.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/directives/screen-outlet.directive.ts
@@ -115,6 +115,12 @@ export class OpenposScreenOutletDirective implements OnInit, OnDestroy {
         this.log.info(`updateTemplateAndScreen invoked for '${screen.hasOwnProperty('id') ? screen.id : '?'}'`);
         if (this.dialogService.isDialogOpenOrOpening()) {
             // Close any open dialogs
+            if (screen.hasOwnProperty('screenType') && screen.screenType === 'SplashScreen') {
+                this.log.info(`Not showing SplashScreen because a dialog is opening or opened`);
+                return;
+            }
+                // Close any open dialogs
+            
             this.log.info(`Not showing screen '${screen.hasOwnProperty('id') ? screen.id : '?'}' until dialog closes...`);
             await this.dialogService.closeDialog();
             this.log.info(`Dialog closed, will now resume showing screen '${screen.hasOwnProperty('id') ? screen.id : '?'}'`);


### PR DESCRIPTION
Fixes the following issues
1. When a dialog is open, and then close browser. open POS from the another browser, screen shows blank page
Cause: registeration splashscreen is overiding dialog
2. on item inquiry screen, select one item, click on menu, dialog is not showing up correctly
Cause: incorrect filter command and client side dialog does not have proper reference to actionService

## Issues Fixed
TS-9834

### Summary
- Fixes issue where server is showing a dialog on top of a screen, then the client is restarted.  When the client comes back up it shows the SplashScreen, and that ends up closing the current dialog that was being shown by the server.  The fix suppresses showing of the SplashScreen if there is already a dialog being shown.
- Fixes an issue with the MultiselectItemListComponent which shows a NavListComponent in a dialog.  The dialog was unable to be opened due to an error from angular due to inability to inject the ActionService into the NavListComponent.  To fix, added the viewContainerRef to the dialog configuration, which allowed the dialog to have access to the ActionService.
- Fixes incorrect javascript being used to filter the list of selected items
