### PR TITLE
Fix Cucumber Test Failures Caused By Training Mode Changes

### DIFF
--- a/openpos-service/src/main/java/org/jumpmind/pos/service/EndpointInvoker.java
+++ b/openpos-service/src/main/java/org/jumpmind/pos/service/EndpointInvoker.java
@@ -289,6 +289,14 @@ public class EndpointInvoker implements InvocationHandler {
 
     private void log(Method method, Object[] args, Endpoint annotation) {
         if (!method.isAnnotationPresent(SuppressMethodLogging.class)) {
+            /*
+            **  The code below came over from master. It logs each argument to the
+            **  endpoint call. Some might have sensitive information, but some want
+            **  to try to serialize autowired services and such. The @ToString
+            **  annotation can be used to control what iss logged.  For now, disable
+            **  this until a time when arguments can be looked at more globally.
+            **  Enabling this will cause Cucumber test to fail.
+            **
             StringBuilder logArgs = new StringBuilder();
             if (args != null && args.length > 0) {
                 for(int i = 0; i < args.length; i++) {
@@ -311,6 +319,12 @@ public class EndpointInvoker implements InvocationHandler {
                     method.getDeclaringClass().getSimpleName(),
                     method.getName(),
                     logArgs,
+                    annotation == null || annotation.implementation().equals(Endpoint.IMPLEMENTATION_DEFAULT) ?
+                            "" : annotation.implementation() + " implementation");
+            */
+            log.info("{}.{}() {}",
+                    method.getDeclaringClass().getSimpleName(),
+                    method.getName(),
                     annotation == null || annotation.implementation().equals(Endpoint.IMPLEMENTATION_DEFAULT) ?
                             "" : annotation.implementation() + " implementation");
         }

--- a/openpos-util/src/main/java/org/jumpmind/pos/util/clientcontext/ClientContext.java
+++ b/openpos-util/src/main/java/org/jumpmind/pos/util/clientcontext/ClientContext.java
@@ -31,6 +31,10 @@ public class ClientContext {
             propertiesMap.set(new HashMap<>());
         }
 
+        if ("deviceMode".equals(name))  {
+            value = ((value == null) || value.equals("'not set'") ? "default" : value);
+        }
+
         propertiesMap.get().put(name, value);
     }
 


### PR DESCRIPTION
### Issues Fixed
Changes to mitigate problems with Cucumber tests created by the recent Training Mode changes.

### Summary
Two fixes here: First one protects the ClientContext against odd Device Mode values. The second disables logging every argument to each endpoint call. That can create problems with sensitive data being logged. That can be prevented by annotating the calling classes with sensitiive arguments, but that's a task for another day. Also, not all classes play well with the toString() functionality. Some that are services it actually tries to run when logging them. For now, this behavior is commented out.