### PR TITLE
Fixed Audio service throwing null pointer exception

### DIFF
--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/audio/AudioActionListener.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/audio/AudioActionListener.java
@@ -1,6 +1,7 @@
 package org.jumpmind.pos.core.audio;
 
 import lombok.extern.slf4j.Slf4j;
+import org.jumpmind.pos.core.content.ContentProviderService;
 import org.jumpmind.pos.core.flow.IStateManager;
 import org.jumpmind.pos.core.flow.IStateManagerContainer;
 import org.jumpmind.pos.server.model.Action;
@@ -26,6 +27,9 @@ public class AudioActionListener implements IActionListener {
     @Autowired()
     AudioConfig audioConfig;
 
+    @Autowired
+    ContentProviderService contentProviderService;
+
     @Override
     public Collection<String> getRegisteredTypes() {
         return Collections.singletonList("Audio");
@@ -46,8 +50,8 @@ public class AudioActionListener implements IActionListener {
     }
 
     public void onGetConfig(IStateManager stateManager) {
-        AudioConfigMessage message = AudioUtil.getInteractionMessageFromConfig(stateManager, audioConfig);
-        log.warn("Sending audio configuration", message);
+        AudioConfigMessage message = AudioUtil.getInteractionMessageFromConfig(contentProviderService, stateManager, audioConfig);
+        log.warn("Sending audio configuration {}", message);
         this.messageService.sendMessage(stateManager.getAppId(), stateManager.getDeviceId(), message);
     }
 
@@ -56,7 +60,7 @@ public class AudioActionListener implements IActionListener {
         List<String> urls = new ArrayList<>();
 
         if (audioConfig.getEnabled() != null && audioConfig.getEnabled()) {
-            urls = AudioUtil.getAllContentUrls(stateManager);
+            urls = AudioUtil.getAllContentUrls(contentProviderService, stateManager);
         } else {
             log.warn("Not getting content URLs to preload because audio is disabled");
         }

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/audio/AudioUtil.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/audio/AudioUtil.java
@@ -19,33 +19,37 @@ public final class AudioUtil {
     public static final String AUDIO_LICENSE = "licenses.csv";
     public static final String AUDIO_CONTENT_ROOT = "audio/";
 
-    public static AudioConfigMessage getInteractionMessageFromConfig(IStateManager stateManager, AudioConfig config) {
+    public static AudioConfigMessage getInteractionMessageFromConfig(
+            ContentProviderService contentProviderService, IStateManager stateManager, AudioConfig config
+    ) {
         AudioConfig configCopy = (AudioConfig) config.clone();
 
         if (configCopy.getInteractions() != null && configCopy.getInteractions().getMouse() != null) {
-            setProviderUrl(stateManager, configCopy.getInteractions().getMouse().getMouseDown());
-            setProviderUrl(stateManager, configCopy.getInteractions().getMouse().getMouseUp());
+            setProviderUrl(contentProviderService, stateManager, configCopy.getInteractions().getMouse().getMouseDown());
+            setProviderUrl(contentProviderService, stateManager, configCopy.getInteractions().getMouse().getMouseUp());
         }
 
         if (configCopy.getInteractions() != null && configCopy.getInteractions().getDialog() != null) {
-            setProviderUrl(stateManager, configCopy.getInteractions().getDialog().getOpening());
-            setProviderUrl(stateManager, configCopy.getInteractions().getDialog().getClosing());
+            setProviderUrl(contentProviderService, stateManager, configCopy.getInteractions().getDialog().getOpening());
+            setProviderUrl(contentProviderService, stateManager, configCopy.getInteractions().getDialog().getClosing());
         }
 
         return new AudioConfigMessage(configCopy);
     }
 
-    public static void setProviderUrl(IStateManager stateManager, AudioRequest request) {
+    public static void setProviderUrl(ContentProviderService contentProviderService, IStateManager stateManager, AudioRequest request) {
+        if(contentProviderService == null) {
+            log.warn("Not setting provider URl because the ContentProviderService is 'null'");
+            return;
+        }
+
         if (request == null) {
             return;
         }
 
-        ContentProviderService contentProviderService = stateManager.getApplicationState().getScopeValue("contentProviderService");
-        if (contentProviderService != null) {
-            String audioKey = getKey(request.getSound());
-            String soundUrl = contentProviderService.resolveContent(stateManager.getDeviceId(), audioKey);
-            request.setUrl(soundUrl);
-        }
+        String audioKey = getKey(request.getSound());
+        String soundUrl = contentProviderService.resolveContent(stateManager.getDeviceId(), audioKey);
+        request.setUrl(soundUrl);
     }
 
     public static String getKey(String sound) {
@@ -77,8 +81,11 @@ public final class AudioUtil {
         return contentKeys;
     }
 
-    public static List<String> getAllContentUrls(IStateManager stateManager) {
-        ContentProviderService contentProviderService = stateManager.getApplicationState().getScopeValue("contentProviderService");
+    public static List<String> getAllContentUrls(ContentProviderService contentProviderService, IStateManager stateManager) {
+        if(contentProviderService == null) {
+            log.warn("Not getting the content URLs because the ContentProviderService is 'null'");
+            return new ArrayList<>();
+        }
 
         return getAllContentKeys().stream()
                 .map(contentKey -> contentProviderService.resolveContent(stateManager.getDeviceId(), AUDIO_CONTENT_ROOT + contentKey))

--- a/openpos-util/src/main/java/org/jumpmind/pos/util/DriversLicense.java
+++ b/openpos-util/src/main/java/org/jumpmind/pos/util/DriversLicense.java
@@ -74,4 +74,3 @@ public class DriversLicense {
     private boolean organDonorIndicator;
     private boolean veteranIndicator;
 }
-

--- a/openpos-util/src/main/java/org/jumpmind/pos/util/DriversLicense.java
+++ b/openpos-util/src/main/java/org/jumpmind/pos/util/DriversLicense.java
@@ -74,3 +74,4 @@ public class DriversLicense {
     private boolean organDonorIndicator;
     private boolean veteranIndicator;
 }
+


### PR DESCRIPTION
### Summary
This fixes a bug, in the `AudioService`, where it would throw a `NullPointerException` because the `AudioService.setProviderUrl(...)` could be called before the `ContentProviderService` is initialized.

To fix this, the `ContentProviderService` is autowired in the `AudioActionListener`, and passed into calls that require it.

Previously, I `autowired` the service in `InitDeviceStep` from this (now closed) PR https://github.com/JumpMind/commerce/pull/2896

Original exception stacktrace:

```
2021-01-20 09:47:35.602 ERROR [pos:00006-001] [clientInboundChannel-7] [AbstractMethodMessageHandler] Unhandled exception from message handler method StackTraceKey.init [java.lang.NullPointerException:4009215897]
java.lang.NullPointerException: null
	at org.jumpmind.pos.core.audio.AudioUtil.setProviderUrl(AudioUtil.java:46)
	at org.jumpmind.pos.core.audio.AudioUtil.getInteractionMessageFromConfig(AudioUtil.java:26)
	at org.jumpmind.pos.core.audio.AudioActionListener.onGetConfig(AudioActionListener.java:49)
	at org.jumpmind.pos.core.audio.AudioActionListener.actionOccured(AudioActionListener.java:40)
	at org.jumpmind.pos.server.service.MessageService.action(MessageService.java:89)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.springframework.messaging.handler.invocation.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:171)
	at org.springframework.messaging.handler.invocation.InvocableHandlerMethod.invoke(InvocableHandlerMethod.java:120)
	at org.springframework.messaging.handler.invocation.AbstractMethodMessageHandler.handleMatch(AbstractMethodMessageHandler.java:565)
	at org.springframework.messaging.simp.annotation.support.SimpAnnotationMethodMessageHandler.handleMatch(SimpAnnotationMethodMessageHandler.java:511)
	at org.springframework.messaging.simp.annotation.support.SimpAnnotationMethodMessageHandler.handleMatch(SimpAnnotationMethodMessageHandler.java:94)
	at org.springframework.messaging.handler.invocation.AbstractMethodMessageHandler.handleMessageInternal(AbstractMethodMessageHandler.java:520)
	at org.springframework.messaging.handler.invocation.AbstractMethodMessageHandler.handleMessage(AbstractMethodMessageHandler.java:454)
	at org.springframework.messaging.support.ExecutorSubscribableChannel$SendTask.run(ExecutorSubscribableChannel.java:144)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```