### PR TITLE
if we have any endpoints with @EndpointOverride and also extend an En…

### DIFF
--- a/openpos-service/src/main/java/org/jumpmind/pos/service/EndpointInvoker.java
+++ b/openpos-service/src/main/java/org/jumpmind/pos/service/EndpointInvoker.java
@@ -94,6 +94,9 @@ public class EndpointInvoker implements InvocationHandler {
         Class<?>[] interfaces = service.getClass().getInterfaces();
         Collection<Object> endpointOverrides = applicationContext.getBeansWithAnnotation(EndpointOverride.class).values();
         Collection<Object> endpoints = applicationContext.getBeansWithAnnotation(Endpoint.class).values();
+        //if we have any endpoints that are an @EndpointOverride and extend an Endpoint with @Endpoint they were included
+        //in the collection of endpoints and should therefore be filtered out.
+        endpoints = endpoints.stream().filter(e -> ClassUtils.resolveAnnotation(EndpointOverride.class, e) == null).collect(Collectors.toList());
 
         for (Class<?> i : interfaces) {
             RestController controller = i.getAnnotation(RestController.class);

--- a/openpos-service/src/main/java/org/jumpmind/pos/service/EndpointInvoker.java
+++ b/openpos-service/src/main/java/org/jumpmind/pos/service/EndpointInvoker.java
@@ -96,7 +96,7 @@ public class EndpointInvoker implements InvocationHandler {
         Collection<Object> endpoints = applicationContext.getBeansWithAnnotation(Endpoint.class).values();
         //if we have any endpoints that are an @EndpointOverride and extend an Endpoint with @Endpoint they were included
         //in the collection of endpoints and should therefore be filtered out.
-        endpoints = endpoints.stream().filter(e -> ClassUtils.resolveAnnotation(EndpointOverride.class, e) == null).collect(Collectors.toList());
+        endpoints = endpoints.stream().filter(e -> !endpointOverrides.contains(e)).collect(Collectors.toList());
 
         for (Class<?> i : interfaces) {
             RestController controller = i.getAnnotation(RestController.class);


### PR DESCRIPTION
### Summary
if we have any endpoints with @EndpointOverride that also extend an Endpoint with @ Endpoint annotation, they were included in the collection of endpoints and should therefore be filtered out to avoid confusing and unnecessary warning messages such as these from logging during the findMatch function:
```
2021-02-10 12:19:49.134 WARN  [server] [main] [EndpointInvoker] No @Endpoint annotation found for endpoint class PetcoFindOriginalLineItemEndpoint, path /user/findPermission, implementation default 
2021-02-10 12:19:49.135 WARN  [server] [main] [EndpointInvoker] No @Endpoint annotation found for endpoint class PetcoFindOriginalLineItemEndpoint, path /user/findPermission, implementation training 
2021-02-10 12:19:49.135 WARN  [server] [main] [EndpointInvoker] No @Endpoint annotation found for endpoint class PetcoFindOriginalLineItemEndpoint, path /user/findPermission, implementation training 
2021-02-10 12:19:49.136 WARN  [server] [main] [EndpointInvoker] No @Endpoint annotation found for endpoint class PetcoFindOriginalLineItemEndpoint, path /user/authenticateSSO, implementation default 
2021-02-10 12:19:49.136 WARN  [server] [main] [EndpointInvoker] No @Endpoint annotation found for endpoint class PetcoFindOriginalLineItemEndpoint, path /user/authenticateSSO, implementation default 
```
