### PR TITLE
Bugfix/gs1-vli-validation

### DIFF
--- a/openpos-util/src/main/java/org/jumpmind/pos/coupons/GS1Coupon.java
+++ b/openpos-util/src/main/java/org/jumpmind/pos/coupons/GS1Coupon.java
@@ -105,8 +105,10 @@ public class GS1Coupon {
                         i += 3;
 
                         secondaryPurchaseCompanyPrefixVLI = Integer.parseInt(gs1Databar.substring(i, ++i));
-                        secondaryPurchaseCompanyPrefix = gs1Databar.substring(i, i + 6 + +secondaryPurchaseCompanyPrefixVLI);
-                        i += 6 + +secondaryPurchaseCompanyPrefixVLI;
+                        if (secondaryPurchaseCompanyPrefixVLI <= 6) {
+                            secondaryPurchaseCompanyPrefix = gs1Databar.substring(i, i + 6 + +secondaryPurchaseCompanyPrefixVLI);
+                            i += 6 + +secondaryPurchaseCompanyPrefixVLI;
+                        }
                         break;
 
                     case 2:
@@ -120,8 +122,10 @@ public class GS1Coupon {
                         i += 3;
 
                         tertiaryPurchaseCompanyPrefixVLI = Integer.parseInt(gs1Databar.substring(i, ++i));
-                        tertiaryPurchaseCompanyPrefix = gs1Databar.substring(i, i + 6 + +tertiaryPurchaseCompanyPrefixVLI);
-                        i += 6 + +tertiaryPurchaseCompanyPrefixVLI;
+                        if (tertiaryPurchaseCompanyPrefixVLI <= 6) {
+                            tertiaryPurchaseCompanyPrefix = gs1Databar.substring(i, i + 6 + +tertiaryPurchaseCompanyPrefixVLI);
+                            i += 6 + +tertiaryPurchaseCompanyPrefixVLI;
+                        }
                         break;
 
                     case 3:


### PR DESCRIPTION
### Issues Fixed
 - [4907](https://petcoalm.atlassian.net/browse/PDPOS-4907)

### Summary
GS1 Coupons should now consider any value in the secondary and tertiary purchase company VLI greater than 6 as a flag to ignore the respective field. This should allow certain coupons with a "9" in those fields to work properly.