### PR TITLE
Fix performance problem of querying for virtual device

### DIFF
--- a/openpos-devices/src/main/java/org/jumpmind/pos/devices/model/DevicesRepository.java
+++ b/openpos-devices/src/main/java/org/jumpmind/pos/devices/model/DevicesRepository.java
@@ -22,6 +22,9 @@ public class DevicesRepository {
     @Lazy
     DBSession devSession;
 
+    @Autowired
+    VirtualDeviceRepository virtualDeviceRepository;
+
     @Cacheable(value="/devices/device", key="#deviceId + '-' + #appId")
     public DeviceModel getDevice(String deviceId, String appId) {
         DeviceModel device = devSession.findByNaturalId(DeviceModel.class, new ModelId("deviceId", deviceId, "appId", appId));
@@ -29,6 +32,10 @@ public class DevicesRepository {
             device.setDeviceParamModels(getDeviceParams(device.getDeviceId(), device.getAppId()));
             return device;
         } else {
+            DeviceModel virtualDevice = virtualDeviceRepository.getByDeviceIdAppId(deviceId, appId);
+            if (virtualDevice != null) {
+                return virtualDevice;
+            }
             throw new DeviceNotFoundException("No device found for appId=" + appId + " deviceId=" + deviceId);
         }
     }


### PR DESCRIPTION
### Summary
- Existing APIs that directly query the DevicesRepository and are unaware of the VirtualDeviceRepository, could never resolve the current device.  Furthermore, since the virtual device was never resolved, the cache is effectively never used and every time the DeviceModel is fetched, it would query the database.  This is a big performance problem when running over a slow database connection.
- This change transparently fetches and caches the virtual device.