### PR TITLE
Build Updates For Cash Management Feature

### DIFF
--- a/openpos-client-libs/package.json
+++ b/openpos-client-libs/package.json
@@ -80,6 +80,6 @@
     "tsickle": "0.34.0",
     "tslib": "^1.9.0",
     "tslint": "~5.11.0",
-    "typescript": ">=3.1.1 <3.3"
+    "typescript": "^3.2.4"
   }
 }


### PR DESCRIPTION
### Issues Fixed
Points the build to Openpos 0.9.2.

### Summary
Move from using Openpos 0.9.1 to 0.9.2 and related build changes.