### PR TITLE
Fixed missing image placeholder showing on loyalty button when there's no image to display

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.html
@@ -57,9 +57,9 @@
                               [actionItem]="screenData.loyaltyButton"
                               (actionClick)="doMenuItemAction(screenData.loyaltyButton)"
                               (click)="doMenuItemAction(screenData.loyaltyButton)" class="sale-total-loyalty-button">
-            <span *ngIf="loyaltyBefore">{{loyaltyBefore}}</span>
-            <img [src]="screenData.loyaltyButton.icon | imageUrl" class="sale-total-loyalty-button-icon">
-            <span *ngIf="loyaltyAfter">{{loyaltyAfter}}</span>
+            <span *ngIf="loyaltyBefore" class="loyalty-before">{{loyaltyBefore}}</span>
+            <img *ngIf="screenData.loyaltyButton.icon" [src]="screenData.loyaltyButton.icon | imageUrl" class="sale-total-loyalty-button-icon">
+            <span *ngIf="loyaltyAfter" class="loyalty-after">{{loyaltyAfter}}</span>
             <span *ngIf="keybindsEnabled(screenData.loyaltyButton)"
                   class="muted-color loyalty-keybind">{{screenData.loyaltyButton.keybindDisplayName}}</span>
         </app-secondary-button>
@@ -84,11 +84,11 @@
                 <span *ngIf="keybindsEnabled(screenData.linkedCustomerButton)"
                     class="muted-color loyalty-keybind">{{screenData.linkedCustomerButton.keybindDisplayName}}</span>
             </div>
-            <div *ngIf="screenData.customer.name" class="muted-color">{{screenData.customer.name}}</div>
-            <div *ngIf="screenData.customer.label && screenData.customer.id" class="muted-color">
+            <div *ngIf="screenData.customer.name" class="muted-color loyalty-name">{{screenData.customer.name}}</div>
+            <div *ngIf="screenData.customer.label && screenData.customer.id" class="muted-color loyalty-id">
                 {{screenData.customer.label}}: {{screenData.customer.id}}
             </div>
-            <div *ngIf="screenData.taxExemptCertificateDetail" class="muted-color">
+            <div *ngIf="screenData.taxExemptCertificateDetail" class="muted-color tax-exempt-cert-detail">
                 {{screenData.taxExemptCertificateDetail.label}}: {{screenData.taxExemptCertificateDetail.value}}
             </div>
         </app-secondary-button>


### PR DESCRIPTION
### Issues Fixed
[PDPOS-4652](https://petcoalm.atlassian.net/browse/PDPOS-4652)

### Summary
Fixed a style issue where a missing image placeholder is shown, on the loyalty button in the sale/return screen, where there is no image to display.

Also, I added a few extra CSS classes to some elements to facilitate theming.

### Screenshots
**Before**

<img width="1792" alt="loyalty-button-unlinked-no-image--before" src="https://user-images.githubusercontent.com/3991426/108126702-1ffd1c00-7078-11eb-85af-87a3c4967ea9.png">

**After**

<img width="1792" alt="loyalty-button-unlinked-no-image--after" src="https://user-images.githubusercontent.com/3991426/108126682-1a9fd180-7078-11eb-80a5-a13ff6892500.png">

