### PR TITLE
Initialization Bug

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/services/session.service.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/services/session.service.ts
@@ -6,7 +6,7 @@ import { IMessageHandler } from './../interfaces/message-handler.interface';
 import { PersonalizationService } from '../personalization/personalization.service';
 
 import { Observable, Subscription, BehaviorSubject, Subject, merge, timer, ConnectableObservable } from 'rxjs';
-import { map, filter, takeWhile, publishBehavior, refCount, publish, shareReplay, publishReplay } from 'rxjs/operators';
+import { map, filter, takeWhile, publishReplay } from 'rxjs/operators';
 import { Message } from '@stomp/stompjs';
 import { Injectable, NgZone, Inject, } from '@angular/core';
 import { StompState, StompRService } from '@stomp/ng2-stompjs';
@@ -417,10 +417,9 @@ export class SessionService implements IMessageHandler<any> {
         if (this.personalization.getIsManagedServer$().getValue()) {
             this.unsubscribe();
             this.reconnecting = true;
-            this.reconnectTimerSub = timer(5000, 5000).pipe(takeWhile(v => this.reconnecting)).subscribe(async () => {
+            this.reconnectTimerSub = timer(5000, 5000).pipe(takeWhile(() => this.reconnecting)).subscribe(async () => {
                 if (await this.discovery.isManagementServerAlive()) {
                     console.debug(`Management server is alive`);
-                    const response = await this.discovery.discoverDeviceProcess({maxWaitMillis: 2500});
                     if (this.discovery.getWebsocketUrl()) {
                         // TODO: May not be necessary to run in zone, check.
                         this.zone.run(() => {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/services/session.service.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/services/session.service.ts
@@ -129,20 +129,20 @@ export class SessionService implements IMessageHandler<any> {
         this.registerMessageHandler(this);
 
         const screenMessagesBehavior = this.stompJsonMessages$.pipe(
-            filter(message => message.type === 'Screen' && message.screenType !== 'NoOp'),
+            filter(message => message.type === MessageTypes.SCREEN && message.screenType !== 'NoOp'),
             publishReplay(1)
         ) as ConnectableObservable<any>;
 
         this.screenMessage$ = screenMessagesBehavior;
 
-        // We need to capture incomming screen messages so make this hot 🔥
+        // We need to capture incomming screen messages even with no subscribers, so make this hot 🔥
         screenMessagesBehavior.connect();
     }
 
     public sendMessage<T extends OpenposMessage>(message: T) {
         if ( message.type === MessageTypes.ACTION && message instanceof ActionMessage ) {
             const actionMessage = message as ActionMessage;
-            this.publish(actionMessage.actionName, 'Screen', actionMessage.payload, actionMessage.doNotBlockForResponse);
+            this.publish(actionMessage.actionName, MessageTypes.SCREEN, actionMessage.payload, actionMessage.doNotBlockForResponse);
         } else if (message.type === MessageTypes.PROXY && message instanceof ActionMessage) {
             const actionMessage = message as ActionMessage;
             this.publish(actionMessage.actionName, actionMessage.type, actionMessage.payload, actionMessage.doNotBlockForResponse);

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/startup/subscribe-to-session-task.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/startup/subscribe-to-session-task.ts
@@ -29,10 +29,10 @@ export class SubscribeToSessionTask implements IStartupTask {
                 this.session.unsubscribe();
                 this.session.subscribe()
                     .then(() => {
-                        messages.next('Subscribed to server');
-                        messages.complete();
+                        observer.next('Subscribed to server');
+                        observer.complete();
                     })
-                    .catch(e => messages.error(e));
+                    .catch(e => observer.error(e));
             }) as Observable<string>;
 
             return concat(

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/public-api.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/public-api.ts
@@ -339,3 +339,5 @@ export * from './lib/utilites/deep-assign';
 export * from './lib/utilites/time-utils';
 
 export * from './lib/styles/theme-test.module';
+
+export * from './lib/shared/status/status.service';


### PR DESCRIPTION
### Summary
A bug was discovered that that allowed the client application to begin operation when the initialization sequence wasn't complete. It was discovered that the initialization service is implemented as a router guard, but there was no outlet in the application. This allowed the router to work in the background, but not actually handle the displaying of views.

A router outlet was in place and guards against the app component. This provides the least invasive fix. After fixing the guard, it was discovered that screens weren't actually been picked up because the message subscription happens too late, after the server already sent them. Resolving this issue was just creating a hot observable on the messages that replay's the last screen message its seen on subscription.

Finally the splash screen had to be partially brought up above the guard so that it can display while initializing. The screen message still function as it did before.

This change requires changes in commerce too.
