### PR TITLE
Allow markdown in the selectable item list dialog titles

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/selection-list/selection-list-screen-dialog.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/selection-list/selection-list-screen-dialog.component.html
@@ -17,10 +17,8 @@
                                         class="item-card-image">
                                 </div>
                                 <div gdArea="info">
-                                    <div fxShow fxHide.xs="true" fxHide.lg="false" *ngIf="item.title" class="text-sm">
-                                        {{item.title}}</div>
-                                    <div fxHide fxHide.xs="false" fxHide.lg="true" *ngIf="item.title" class="text-md">
-                                        {{item.title}}</div>
+                                    <div fxShow fxHide.xs="true" fxHide.lg="false" *ngIf="item.title" class="text-sm" [innerHtml]="item.title | markdownFormatter"></div>
+                                    <div fxHide fxHide.xs="false" fxHide.lg="true" *ngIf="item.title" class="text-md" [innerHtml]="item.title | markdownFormatter"></div>
                                     <div *ngIf="item.properties" fxLayout="row wrap" fxLayoutAlign="space-between">
                                         <div *ngFor="let property of item.properties">
                                             <div *ngIf="property.label" class="item-property-label">{{property.label}}</div>


### PR DESCRIPTION
### Issues Fixed
https://petcoalm.atlassian.net/browse/PDPOS-4247

### Summary
Allow markdown in the selectable items title. This will be in support of showing the primary account in bold for Petco when multiple accounts for a single person exist

![image](https://user-images.githubusercontent.com/74971030/108265806-45049400-7137-11eb-80ed-e922fce931fa.png)

