### PR TITLE
Fixed enter key triggering "back" action on Tendering screen

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/choose-options-part/choose-options-part.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/choose-options-part/choose-options-part.component.html
@@ -1,8 +1,8 @@
 <div>
     <div *ngIf="showOptions" fxLayout="column" appArrowTab>   
         <button 
-        *ngFor="let formOption of options; let i = index" 
-        [attr.cdkFocusInitial]="0 == i ? '' : null"
+        *ngFor="let formOption of options; let i = index"
+        cdkFocusInitial
         mat-button 
         appArrowTabItem 
         (click)="onMakeOptionSelection(formOption, formGroups[i])"

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/options-list/options-list.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/options-list/options-list.component.html
@@ -11,7 +11,7 @@
     <div *ngIf="options && options.length > 0" appArrowTab>
         <app-option-button *ngFor="let o of options; let i = index"
             appArrowTabItem
-            [attr.cdkFocusInitial]="isFirstElementFocused ? '' : null"
+            cdkFocusInitial
             [attr.tabindex]="i"
             [disabled]="!o.enabled"
             [optionTitle]="o.title"


### PR DESCRIPTION
### Issues Fixed
[PDPOS-3333](https://petcoalm.atlassian.net/browse/PDPOS-3333)

### Summary
This fixes a bug where the `enter` key, on the **Tendering** screen, triggered the **Back** action. It was caused because the `cdkFocusInitial` directive wasn't used correctly.

*NOTE*: The `cdkFocusInitial` directive will use the first occurrence when used on multiple elements like in these `*ngFor` loops.

### Screenshots
**Enter Key Does NOT Trigger Back Action**

*NOTE*: The first tendering option, **Card**, is now focused by default on this screen.

![keybind-enter-no-longer-goes-back](https://user-images.githubusercontent.com/3991426/108421658-7cd90d80-7203-11eb-9099-343e7883881e.gif)

**Escape Key Still Triggers Back Action**

![keybind-escape-still-goes-back](https://user-images.githubusercontent.com/3991426/108421691-86fb0c00-7203-11eb-98a5-eff0d2b1e8b1.gif)

