### PR TITLE
Allow username entry when current user null

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/lock-screen/lock-screen.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/lock-screen/lock-screen.component.html
@@ -3,8 +3,10 @@
         <div class="user">
             <app-icon [iconName]="data?.iconName" iconClass="xl"></app-icon>
             <h1>{{override ? data?.overrideText : data?.userText}}</h1>
-            <app-rounded-input *ngIf="override" [placeholder]="data.usernameHint" [(value)]="username" ></app-rounded-input>
-            <app-rounded-input [placeholder]="data.passwordHint" [(value)]="password" (keydown.enter)="submit($event)" inputType="password"></app-rounded-input>
+            <app-rounded-input *ngIf="override || (data && !data.userText)" [placeholder]="data.usernameHint"
+                [(value)]="username"></app-rounded-input>
+            <app-rounded-input [placeholder]="data.passwordHint" [(value)]="password" (keydown.enter)="submit($event)"
+                inputType="password"></app-rounded-input>
             <p *ngIf="!!data?.errorMessage" class="error">{{data?.errorMessage}}</p>
         </div>
         <div class="override">

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/lock-screen/lock-screen.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/lock-screen/lock-screen.component.ts
@@ -1,9 +1,9 @@
-import {Component, Inject, OnDestroy} from '@angular/core';
-import {Observable, Subject} from 'rxjs';
-import {takeUntil, tap} from 'rxjs/operators';
-import {ActionService} from '../actions/action.service';
-import {LockScreenMessage} from '../messages/lock-screen-message';
-import {LOCK_SCREEN_DATA} from './lock-screen.service';
+import { Component, Inject, OnDestroy } from '@angular/core';
+import { Observable, Subject } from 'rxjs';
+import { takeUntil, tap } from 'rxjs/operators';
+import { ActionService } from '../actions/action.service';
+import { LockScreenMessage } from '../messages/lock-screen-message';
+import { LOCK_SCREEN_DATA } from './lock-screen.service';
 
 @Component({
   selector: 'app-lock-screen',
@@ -20,12 +20,12 @@ export class LockScreenComponent implements OnDestroy {
   destroy = new Subject();
 
   constructor(
-      @Inject(LOCK_SCREEN_DATA) data: Observable<LockScreenMessage>,
-      private actionService: ActionService) {
-      data.pipe(
-          tap( message => this.data = message),
-          takeUntil(this.destroy)
-      ).subscribe();
+    @Inject(LOCK_SCREEN_DATA) data: Observable<LockScreenMessage>,
+    private actionService: ActionService) {
+    data.pipe(
+      tap(message => this.data = message),
+      takeUntil(this.destroy)
+    ).subscribe();
   }
 
   submit($event: any) {
@@ -39,11 +39,12 @@ export class LockScreenComponent implements OnDestroy {
   }
 
   submitPassword() {
-    this.actionService.doAction(this.data.passwordAction, this.password);
+    const payload = { username: this.username, password: this.password }
+    this.actionService.doAction(this.data.passwordAction, payload);
   }
 
   doOverride() {
-    this.actionService.doAction(this.data.overrideAction, {username: this.username, password: this.password});
+    this.actionService.doAction(this.data.overrideAction, { username: this.username, password: this.password });
   }
 
   toggleOverride() {


### PR DESCRIPTION
### Issues Fixed
[PDPOS-4986](https://petcoalm.atlassian.net/browse/PDPOS-4986)

### Summary
Toggle the username field on the lock screen based on data.userText. This is so when the currentUser is null, we can still unlock the screen. Also made the 2 submit actions be consistent in the data format they sent off.

### Screenshots
![image](https://user-images.githubusercontent.com/76953904/108563742-f5a59b80-72cf-11eb-8381-63bf0eeb3ceb.png)
