### PR TITLE
Include petco/2.0-central branch in azure builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,7 @@ trigger:
     - releases/0.4
     - releases/0.5
     - burl/0.9
+    - petco/2.0-central
 
 pool:
   vmImage: 'ubuntu-18.04'


### PR DESCRIPTION
### Summary
I am setting up a `petco/2.0-central` branch in order to freeze changes for upcoming release of the petco central office application.  This enables the azure build for openpos on that branch.

