### PR TITLE
Feature/record sql statement values in data access violation error

### DIFF
--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/DBSession.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/DBSession.java
@@ -550,7 +550,7 @@ public class DBSession {
             message = message.substring(0, message.indexOf("SQL statement"));
         }
         errorStatement.append(": " + message);
-        log.warn(errorStatement.toString());
+        throw new DuplicateKeyException(errorStatement.toString(), e);
     }
 
     protected void batchInternal(List<? extends  AbstractModel> models, DmlType dmlType) {

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/DBSession.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/DBSession.java
@@ -541,9 +541,9 @@ public class DBSession {
     protected void logDMLError(DmlType type, String sql, Object[] values, DataAccessException e) {
         StringBuilder errorStatement = new StringBuilder();
         errorStatement.append("There was a data access violation in " + type + " statement: ");
-        for (Object value : values) {
-            sql = sql.replaceFirst("[?]", String.valueOf(value));
-        }
+        LogSqlBuilder builder = new LogSqlBuilder();
+        Object[] rawArgs = cleanArgs(values);
+        sql = builder.buildDynamicSqlForLog(sql, rawArgs, null);
         errorStatement.append(sql);
         String message = e.getCause().getMessage();
         if (message.contains("SQL statement")) {

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/DBSession.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/DBSession.java
@@ -534,21 +534,23 @@ public class DBSession {
             return jdbcTemplate.getJdbcOperations().update(sql, values, types);
         } catch (DataAccessException e) {
             logDMLError(type, sql, values, e);
-            return 0;
+            return jdbcTemplate.getJdbcOperations().update(sql, values, types);
         }
     }
 
     protected void logDMLError(DmlType type, String sql, Object[] values, DataAccessException e) {
         StringBuilder errorStatement = new StringBuilder();
-        errorStatement.append("There was an error with " + type + " statement: ");
-        errorStatement.append(sql.substring(0, sql.indexOf("(?")));
-        errorStatement.append("(");
+        errorStatement.append("There was a data access violation in " + type + " statement: ");
         for (Object value : values) {
-            errorStatement.append(String.valueOf(value) + ",");
+            sql = sql.replaceFirst("[?]", String.valueOf(value));
         }
-        errorStatement.deleteCharAt(errorStatement.lastIndexOf(","));
-        errorStatement.append(")");
-        throw new PersistException(errorStatement.toString(), e);
+        errorStatement.append(sql);
+        String message = e.getCause().getMessage();
+        if (message.contains("SQL statement")) {
+            message = message.substring(0, message.indexOf("SQL statement"));
+        }
+        errorStatement.append(": " + message);
+        log.warn(errorStatement.toString());
     }
 
     protected void batchInternal(List<? extends  AbstractModel> models, DmlType dmlType) {

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/ModelWrapper.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/ModelWrapper.java
@@ -220,7 +220,7 @@ public class ModelWrapper {
                 if (fieldName.toUpperCase().startsWith(TagModel.TAG_PREFIX)) {
                     String tagValue = ((ITaggedModel) model).getTagValue(fieldName.substring(TagModel.TAG_PREFIX.length()));
                     if (StringUtils.isEmpty(tagValue)) {
-                        log.warn("Tag \'" + fieldName.substring(TagModel.TAG_PREFIX.length()) + "\' in model \'" + model.getClass().getName() + "\' was set to an empty value.");
+                        log.warn("Tag \'" + fieldName.substring(TagModel.TAG_PREFIX.length()) + "\' in model \'" + model.getClass().getSimpleName() + "\' was set to an empty value.");
                     }
                     columnNamesToObjectValues.put(fieldName, tagValue);
                 } else if (config != null) {

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/ModelWrapper.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/ModelWrapper.java
@@ -219,6 +219,9 @@ public class ModelWrapper {
                 AugmenterConfig config = getAugmentedConfigWithPrefix(configs, fieldName);
                 if (fieldName.toUpperCase().startsWith(TagModel.TAG_PREFIX)) {
                     String tagValue = ((ITaggedModel) model).getTagValue(fieldName.substring(TagModel.TAG_PREFIX.length()));
+                    if (StringUtils.isEmpty(tagValue)) {
+                        log.warn("Tag \'" + fieldName.substring(TagModel.TAG_PREFIX.length()) + "\' in model \'" + model.getClass().getName() + "\' was set to an empty value.");
+                    }
                     columnNamesToObjectValues.put(fieldName, tagValue);
                 } else if (config != null) {
                     String augmentValue = ((IAugmentedModel) model).getAugmentValue(fieldName.substring(config.getPrefix().length()));


### PR DESCRIPTION
### Issues Fixed
 - Logging to help diagnose [5009](https://petcoalm.atlassian.net/browse/PDPOS-5009)

### Summary
Adds logging for data violations exceptions when performing insert, update, or delete statements and records the values trying to be altered. Also adds a small bit of warning logging to note when tag values are inserted with an empty value instead of the default '*' or some other non-empty value. Both are set at the **warning** level as they should not often happen.

### Screenshots
![image](https://user-images.githubusercontent.com/39058176/109034600-cf984680-7695-11eb-8c71-1a5fdabc8719.png)