### PR TITLE
Transaction Date/Time on Safari

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/transaction-summary/transaction-summary.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/transaction-summary/transaction-summary.component.html
@@ -36,7 +36,7 @@
         <div>
             <div class="summary-field" responsive-class>
                 <span class="summary-field-label"  *ngIf="transactionSummary.labels">{{transactionSummary.labels.transactionDate}}</span>
-                <span class="summary-field-value">{{transactionSummary.transactionDate | date:'M/d/yyy h:mm a'}}</span>
+                <span class="summary-field-value">{{transactionDate | date:'M/d/yyy h:mm a'}}</span>
             </div>
             <div class="summary-field" responsive-class>
                 <span class="summary-field-label" *ngIf="transactionSummary.labels">{{transactionSummary.labels.username}}</span>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/transaction-summary/transaction-summary.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/transaction-summary/transaction-summary.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnChanges, SimpleChanges} from '@angular/core';
+import {Component, Input, OnChanges, OnInit, SimpleChanges} from '@angular/core';
 import {ITransactionSummary} from './transaction-summary.interface';
 import {IActionItem} from '../../../core/actions/action-item.interface';
 import {ActionService} from '../../../core/actions/action.service';
@@ -16,6 +16,13 @@ export class TransactionSummaryComponent implements OnChanges {
 
   statusClass: string;
   TransTypeEnum = TransTypeEnum;
+
+  get transactionDate(): Date {
+    // safari will throw an invalid date error if the date 
+    // and time isn't seperatd by a T. The data comes in 
+    // with the separation of a space.
+    return new Date(this.transactionSummary.transactionDate.replace(' ', 'T'));
+  };
 
   constructor(private actionService: ActionService, private transactionService: TransactionService) { }
 


### PR DESCRIPTION
### Issues Fixed
AEO PCOM-1634

### Summary
On WebKit based browsers, the Date/Time of a transaction item would not display. This was because Safari was rejecting the conversion of `string` -> `Date`. Safari accepts `yyyy/MM/ddThh:mm:ss` where the '`T'` character separates the date and time. The standard ISO format provided by the server separates the date and time with a space (`' '`). Other browsers seem happy supporting it either way.
