### PR TITLE
Status Codes for Printer Exception

### DIFF
--- a/openpos-peripheral/src/main/java/org/jumpmind/pos/print/PrintException.java
+++ b/openpos-peripheral/src/main/java/org/jumpmind/pos/print/PrintException.java
@@ -1,28 +1,73 @@
 package org.jumpmind.pos.print;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.EnumSet;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class PrintException extends RuntimeException {
+    public enum StatusCode {
+        CoverOpened,
+        OutOfPaper
+    }
 
-    static final int PRINT_ERROR_SLIP_INSERT_TIMEOUT = 1;
+    final EnumSet<StatusCode> status;
 
-    int errorCode;
+    private static String createMessageFromStatus(EnumSet<StatusCode> status) {
+        final StringBuilder msg = new StringBuilder("printer operation failed");
+
+        for (StatusCode code : status) {
+            String codeMsg;
+
+            switch (code) {
+                case CoverOpened:
+                    codeMsg = "cover opened";
+                    break;
+
+                case OutOfPaper:
+                    codeMsg = "out of paper";
+                    break;
+
+                default:
+                    continue;
+            }
+
+            msg.append("; ");
+            msg.append(codeMsg);
+        }
+
+        return msg.toString();
+    }
 
     public PrintException() {
-        super();
+        this("printer operation failed");
+    }
+
+    public PrintException(EnumSet<StatusCode> status) {
+        this(createMessageFromStatus(status), status);
     }
 
     public PrintException(String message) {
-        super(message);
+        this(message, EnumSet.noneOf(StatusCode.class));
+    }
+
+    public PrintException(String message, EnumSet<StatusCode> status) {
+        this(message, status, null);
+    }
+
+    public PrintException(String message, EnumSet<StatusCode> status, Throwable cause) {
+        super(message, cause);
+        this.status = status;
     }
 
     public PrintException(String message, Throwable cause) {
-        super(message, cause);
+        this(message, EnumSet.noneOf(StatusCode.class), cause);
     }
 
     public PrintException(Throwable cause) {
-        super(cause);
+        this("printer operation failed", cause);
     }
 
     public String toString() {


### PR DESCRIPTION
## Summary
This  change adds the ability to append status flags to a `PrintException`. There are two basic flags supported currently, a `CoverOpened` and a `OutOfPaper` flag.