### PR TITLE
loyalty button on high pixel-ratio devices

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
@@ -19,7 +19,7 @@
         font-size: 36px;
     }
     .link-customer {
-        height: 102px;
+        min-height: 102px;
         @extend %text-md;
         border-width: 2px;
         padding: $text-md/2 $text-md*1.25;


### PR DESCRIPTION
### Summary
Fixed a styling issue for the Loyalty button when on high pixel-ratio devices that caused the typography to increase the font size instead of get smaller on widths in the 1175 to 840 range.

### Screenshots
Screenshots go here.
![image](https://user-images.githubusercontent.com/2406987/109537989-9133ca80-7a8d-11eb-9337-230477b7500d.png)

