### PR TITLE
Feature/display keybind on round up button

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/tender-part/tender-part.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/tender-part/tender-part.component.html
@@ -30,6 +30,10 @@
         <app-icon responsive-class class = "round-up-icon" *ngIf="isRoundUpAvailable" [iconName]="screenData.roundUpButton.icon" [iconClass]="'sm'"></app-icon>
         <app-icon responsive-class class = "round-up-icon" *ngIf="!isRoundUpAvailable" [iconName]="'Checkmark'" [iconClass]="'sm'"></app-icon>
         {{screenData.roundUpButton.title}}
+        <div  *ngIf="keybindsEnabled()" class="round-up-right">
+            <span responsive-class class="round-up-keybind muted-color">
+                {{screenData.roundUpButton.keybindDisplayName}}</span>
+        </div>
     </app-secondary-button>
 </div>
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/tender-part/tender-part.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/tender-part/tender-part.component.scss
@@ -16,6 +16,15 @@
     }
 }
 
+.round-up-right {
+    min-width: 32px;
+    margin-left: 15px;
+}
+
+.round-up-keybind {
+    @extend %text-md;
+}
+
 .tender-options {
     justify-self: center;
     width: 50%;
@@ -40,7 +49,7 @@
 }
 
 .round-up-icon {
-    margin-right: 10px;
+    margin-right: 15px;
 }
 
 .tender-amount-due-outer {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/tender-part/tender-part.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/tender-part/tender-part.component.ts
@@ -5,6 +5,7 @@ import { ScreenPartComponent } from '../screen-part';
 import {IActionItem} from '../../../core/actions/action-item.interface';
 import {takeUntil} from 'rxjs/operators';
 import { ITender } from './tender.interface';
+import { Configuration } from '../../../configuration/configuration';
 
 @ScreenPart({
     name: 'TenderPart'
@@ -67,5 +68,9 @@ export class TenderPartComponent extends ScreenPartComponent<TenderPartInterface
         {
             this.doAction(this.screenData.roundUpButton.action);
         }
+    }
+
+    public keybindsEnabled(): boolean {
+        return Configuration.enableKeybinds && !!this.screenData.roundUpButton.keybindDisplayName;
     }
 }


### PR DESCRIPTION
### Issues Fixed
 - [5083](https://petcoalm.atlassian.net/browse/PDPOS-5083)

### Summary
Very small change to the new Round Up button that adds a keybind display on the button. The button previously had the ability to have a keybind bound to it, so this is a strictly visual change.

### Screenshots
![image](https://user-images.githubusercontent.com/39058176/109547075-f80ab100-7a98-11eb-98fc-3df7e608767f.png)
