### PR TITLE
Reduce size of image to allow more space for promotions

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.ts
@@ -31,7 +31,7 @@ export class ItemDetailComponent extends PosScreen<ItemDetailInterface> {
             if (mobile) {
                 this.carouselSize = 'sm';
             } else {
-                this.carouselSize = 'xl';
+                this.carouselSize = 'md';
             }
         });
     }


### PR DESCRIPTION
### Issues Fixed
https://petcoalm.atlassian.net/browse/PDPOS-5116

### Summary
Image in item details is too large and is not allowing for enough space for the promotion window without scrolling. Reduce the size of the image to allow for more area.

![image](https://user-images.githubusercontent.com/74971030/109717999-c6ffae80-7b74-11eb-818d-02db44cc4ad4.png)
