### PR TITLE
Improve Pole Display logging and status icon reliability

### DIFF
--- a/openpos-peripheral/src/main/java/org/jumpmind/pos/peripheral/poledisplay/PoleDisplay.java
+++ b/openpos-peripheral/src/main/java/org/jumpmind/pos/peripheral/poledisplay/PoleDisplay.java
@@ -66,6 +66,9 @@ public class PoleDisplay implements IStatusReporter {
             }
             peripheralConnection.getOut().write(CLEAR_DISPLAY);
             peripheralConnection.getOut().write(text.getBytes());
+            if (statusManager != null) {
+                statusManager.reportStatus(new StatusReport(STATUS_NAME, STATUS_ICON, Status.Online));
+            }
         } catch (Exception ex) {
             if (statusManager != null) {
                 statusManager.reportStatus(new StatusReport(STATUS_NAME, STATUS_ICON, Status.Error, ex.getMessage()));
@@ -96,6 +99,7 @@ public class PoleDisplay implements IStatusReporter {
                 log.info("Closing connection to the pole display.");
                 connectionFactory.close(peripheralConnection);
                 peripheralConnection = null;
+                log.info("Pole display appears to be successfully opened.");
             } catch (Exception ex) {
                 log.warn("Failed to cleanly close connection to the pole display.", ex);
             }


### PR DESCRIPTION
### Issues Fixed
- [5033](https://petcoalm.atlassian.net/browse/PDPOS-5033)

### Summary
Small update to pole display logging to note a successful connection close. Also makes the status manager more accurately report the pole display's status (if it can print text, it should display as online), compared to previously where it could falsely report an error state despite being able to print text.