### PR TITLE
Bugfix/keybindings not applying

### DIFF
--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/ActionItem.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/ActionItem.java
@@ -44,7 +44,8 @@ public class ActionItem implements Serializable {
     protected String defaultPayload;
 
     protected String icon;
-    @Builder.Default protected boolean enabled = true;
+    @Builder.Default
+    protected boolean enabled = true;
     protected ConfirmationDialog confirmationDialog;
     protected List<ActionItem> children;
     protected boolean sensitive;
@@ -59,7 +60,8 @@ public class ActionItem implements Serializable {
     protected ActionTimer actionTimer;
 
     @JsonIgnore
-    @Builder.Default protected boolean autoAssignEnabled = true;
+    @Builder.Default
+    protected boolean autoAssignEnabled = true;
 
     public final static String FONT_SIZE_XS = "text-xs";
     public final static String FONT_SIZE_SM = "text-sm";

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/ActionItem.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/ActionItem.java
@@ -76,10 +76,12 @@ public class ActionItem implements Serializable {
     public final static String BUTTON_SIZE_XL = "menuItem-xl";
 
     public ActionItem(String action) {
+        this();
         this.action = action;
     }
 
     public ActionItem(String action, String title) {
+        this();
         this.action = action;
         this.title = title;
     }
@@ -109,14 +111,14 @@ public class ActionItem implements Serializable {
     }
 
     public ActionItem(String title, String action, boolean enabled) {
-        super();
+        this();
         this.action = action;
         this.title = title;
         this.enabled = enabled;
     }
 
     public ActionItem(String title, String action, String icon, boolean enabled) {
-        super();
+        this();
         this.action = action;
         this.title = title;
         this.enabled = enabled;
@@ -124,7 +126,7 @@ public class ActionItem implements Serializable {
     }
 
     public ActionItem(String title, String action, boolean enabled, boolean sensitive) {
-        super();
+        this();
         this.action = action;
         this.title = title;
         this.enabled = enabled;

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/ActionItem.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/ActionItem.java
@@ -44,7 +44,7 @@ public class ActionItem implements Serializable {
     protected String defaultPayload;
 
     protected String icon;
-    protected boolean enabled = true;
+    @Builder.Default protected boolean enabled = true;
     protected ConfirmationDialog confirmationDialog;
     protected List<ActionItem> children;
     protected boolean sensitive;
@@ -59,7 +59,7 @@ public class ActionItem implements Serializable {
     protected ActionTimer actionTimer;
 
     @JsonIgnore
-    protected boolean autoAssignEnabled = true;
+    @Builder.Default protected boolean autoAssignEnabled = true;
 
     public final static String FONT_SIZE_XS = "text-xs";
     public final static String FONT_SIZE_SM = "text-sm";

--- a/openpos-flow/src/test/java/org/jumpmind/pos/core/ui/ActionItemTest.java
+++ b/openpos-flow/src/test/java/org/jumpmind/pos/core/ui/ActionItemTest.java
@@ -1,0 +1,134 @@
+package org.jumpmind.pos.core.ui;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ActionItemTest {
+
+    @Test
+    public void noArgsConstructorDefaultValues() {
+        ActionItem item = new ActionItem();
+        assertTrue(item.isEnabled());
+        assertTrue(item.isAutoAssignEnabled());
+    }
+
+    @Test
+    public void actionOnlyConstructorValues() {
+        ActionItem item = new ActionItem("Action");
+        assertTrue(item.isEnabled());
+        assertTrue(item.isAutoAssignEnabled());
+        assertEquals("Action", item.getAction());
+    }
+
+    @Test
+    public void actionTitleConstructorValues() {
+        ActionItem item = new ActionItem("Action", "Title");
+        assertTrue(item.isEnabled());
+        assertTrue(item.isAutoAssignEnabled());
+        assertEquals("Action", item.getAction());
+        assertEquals("Title", item.getTitle());
+    }
+
+    @Test
+    public void actionTitleIconConstructorValues() {
+        ActionItem item = new ActionItem("Action", "Title", "Icon");
+        assertTrue(item.isEnabled());
+        assertTrue(item.isAutoAssignEnabled());
+        assertEquals("Action", item.getAction());
+        assertEquals("Title", item.getTitle());
+        assertEquals("Icon", item.getIcon());
+    }
+
+    @Test
+    public void autoAssignActionTitleIconConstructorValues() {
+        ActionItem item = new ActionItem(false, "Action", "Title", "Icon");
+        assertTrue(item.isEnabled());
+        assertFalse(item.isAutoAssignEnabled());
+        assertEquals("Action", item.getAction());
+        assertEquals("Title", item.getTitle());
+        assertEquals("Icon", item.getIcon());
+    }
+
+    @Test
+    public void actionTitleIconConfirmationMessageConstructorValues() {
+        ActionItem item = new ActionItem("Action", "Title", "Icon", "ConfirmationMessage");
+        assertTrue(item.isEnabled());
+        assertTrue(item.isAutoAssignEnabled());
+        assertEquals("Action", item.getAction());
+        assertEquals("Title", item.getTitle());
+        assertEquals("Icon", item.getIcon());
+        assertEquals("Title", item.getConfirmationDialog().getTitle());
+        assertEquals("ConfirmationMessage", item.getConfirmationDialog().getMessage());
+    }
+
+    @Test
+    public void actionTitleIconNullConfirmationMessageConstructorValues() {
+        ActionItem item = new ActionItem("Action", "Title", "Icon", (String) null);
+        assertTrue(item.isEnabled());
+        assertTrue(item.isAutoAssignEnabled());
+        assertEquals("Action", item.getAction());
+        assertEquals("Title", item.getTitle());
+        assertEquals("Icon", item.getIcon());
+        assertNull(item.getConfirmationDialog());
+    }
+
+    @Test
+    public void actionTitleIconConfirmationDialogConstructorValues() {
+        ConfirmationDialog dialog = new ConfirmationDialog("ConfirmationMessage", "ConfirmationTitle");
+        ActionItem item = new ActionItem("Action", "Title", "Icon", dialog);
+        assertTrue(item.isEnabled());
+        assertTrue(item.isAutoAssignEnabled());
+        assertEquals("Action", item.getAction());
+        assertEquals("Title", item.getTitle());
+        assertEquals("Icon", item.getIcon());
+        assertEquals(dialog, item.getConfirmationDialog());
+    }
+
+    @Test
+    public void titleActionEnabledConstructorValues() {
+        ActionItem item = new ActionItem("Title", "Action", false);
+        assertFalse(item.isEnabled());
+        assertTrue(item.isAutoAssignEnabled());
+        assertEquals("Action", item.getAction());
+        assertEquals("Title", item.getTitle());
+    }
+
+    @Test
+    public void titleActionIconEnabledConstructorValues() {
+        ActionItem item = new ActionItem("Title", "Action", "Icon", false);
+        assertFalse(item.isEnabled());
+        assertTrue(item.isAutoAssignEnabled());
+        assertEquals("Action", item.getAction());
+        assertEquals("Title", item.getTitle());
+        assertEquals("Icon", item.getIcon());
+    }
+
+    @Test
+    public void titleActionEnabledSensitiveConstructorValues() {
+        ActionItem item = new ActionItem("Title", "Action", false, true);
+        assertFalse(item.isEnabled());
+        assertTrue(item.isAutoAssignEnabled());
+        assertEquals("Action", item.getAction());
+        assertEquals("Title", item.getTitle());
+        assertTrue(item.isSensitive());
+    }
+
+    @Test
+    public void builderDefaultValues() {
+        ActionItem item = ActionItem.builder().action("Action").title("Title").build();
+        assertTrue(item.isEnabled());
+        assertTrue(item.isAutoAssignEnabled());
+        assertEquals("Action", item.getAction());
+        assertEquals("Title", item.getTitle());
+    }
+
+    @Test
+    public void builderEnabledFalseValues() {
+        ActionItem item = ActionItem.builder().action("Action").title("Title").enabled(false).build();
+        assertFalse(item.isEnabled());
+        assertTrue(item.isAutoAssignEnabled());
+        assertEquals("Action", item.getAction());
+        assertEquals("Title", item.getTitle());
+    }
+}


### PR DESCRIPTION
### Issues Fixed
[PDPOS-4839](https://petcoalm.atlassian.net/browse/PDPOS-4839)

### Summary
An instantiation of ActionItem was switched from constructor to lombok builder. This wiped out the default value for these fields and would require them to be declared when building the action item.
From the lombok documentation:
```
If a certain field/parameter is never set during a build session, then it always gets 0 / null / false. 
If you've put @Builder on a class (and not a method or constructor) you can instead specify the 
default directly on the field, and annotate the field with @Builder.Default
```
Another note is that this new annotation will block the default assignment from explicitly defined constructors. To get past that, I'm calling the lombok generated NoArgsConstructor from our defined ones, which handles any Builder.Default assignments.