### PR TITLE
Image Scanner Support on Prompts

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/platform-plugins/barcode-scanners/image-scanner.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/platform-plugins/barcode-scanners/image-scanner.component.ts
@@ -8,7 +8,15 @@ import { BarcodeScanner } from './barcode-scanner.service';
 
 @Component({
     selector: 'app-image-scanner',
-    template: ''
+    template: '',
+    styles: [
+        `
+        :host {
+            width: 100%;
+            height: 100%;
+        }
+        `
+    ]
 })
 export class ImageScannerComponent implements OnInit, OnDestroy, ScannerViewRef {
     @Output() readonly scanChanged = new EventEmitter<boolean>();

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/prompt-input/prompt-input.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/prompt-input/prompt-input.component.html
@@ -1,30 +1,37 @@
 <div [formGroup]="promptFormGroup">
     <ng-container *ngIf="!isDateField(); else dateField" [ngSwitch]="true">
-        <div *ngSwitchDefault class="input-container">
-            <mat-form-field class="prompt-text grow" responsive-class>
-                <!-- Was using this:
-                    <mat-icon matPrefix class="material-icons" color="primary">{{promptIcon}}</mat-icon>
-                    but want to be able to use local icons.  TODO: problem with styling however, sizing not working
-                    for SVG icon
-                -->
-                
-                <app-icon matPrefix iconClass="material-icons md primary" [iconName]="promptIcon" responsive-class>
-                </app-icon>
-                <input matInput [errorStateMatcher]="errorMatcher" [formControlName]="'promptInputControl'"
-                    [formatterName]="responseType" cdkFocusInitial [attr.minlength]="minLength" [attr.maxlength]="maxLength"
-                    [readonly]="readOnly" [attr.type]="isNumericField() ? 'tel' : 'text'" [keyboardLayout]="keyboardLayout"
-                    class="prompt-input" autoSelectOnFocus responsive-class>
-                <mat-placeholder>{{placeholderText}}</mat-placeholder>
-                <mat-hint class="prompt-hint" align="start" responsive-class>{{hintText}}</mat-hint>
-                <mat-error class="prompt-error">
-                    <app-show-errors [control]="promptFormGroup.controls['promptInputControl']"
-                        [additionalValidationMessages]="validationMessages"></app-show-errors>
-                </mat-error>
-            </mat-form-field>
-            <app-primary-button responsive-class *ngIf="isScanAllowed()" type="button" mat-button color="primary"
-                (click)="onScan()">
-                <app-icon class="barcode-icon" iconName="barcode"></app-icon>
-            </app-primary-button>
+        <div *ngSwitchDefault class="input-barcode-container">
+            <div class="input-container">
+                <mat-form-field class="prompt-text grow" responsive-class>
+                    <!-- Was using this:
+                        <mat-icon matPrefix class="material-icons" color="primary">{{promptIcon}}</mat-icon>
+                        but want to be able to use local icons.  TODO: problem with styling however, sizing not working
+                        for SVG icon
+                    -->
+                    
+                    <app-icon matPrefix iconClass="material-icons md primary" [iconName]="promptIcon" responsive-class>
+                    </app-icon>
+                    <input matInput [errorStateMatcher]="errorMatcher" [formControlName]="'promptInputControl'"
+                        [formatterName]="responseType" cdkFocusInitial [attr.minlength]="minLength" [attr.maxlength]="maxLength"
+                        [readonly]="readOnly" [attr.type]="isNumericField() ? 'tel' : 'text'" [keyboardLayout]="keyboardLayout"
+                        class="prompt-input" autoSelectOnFocus responsive-class>
+                    <mat-placeholder>{{placeholderText}}</mat-placeholder>
+                    <mat-hint class="prompt-hint" align="start" responsive-class>{{hintText}}</mat-hint>
+                    <mat-error class="prompt-error">
+                        <app-show-errors [control]="promptFormGroup.controls['promptInputControl']"
+                            [additionalValidationMessages]="validationMessages"></app-show-errors>
+                    </mat-error>
+                </mat-form-field>
+                <app-primary-button responsive-class *ngIf="isScanAllowed()" type="button" mat-button color="primary"
+                    (click)="onScan()">
+                    <app-icon class="barcode-icon" iconName="barcode"></app-icon>
+                </app-primary-button>
+            </div>
+
+            <div class="barcode-scanner" *ngIf="showScanner">
+                <app-image-scanner>
+                </app-image-scanner>
+            </div>
         </div>
         
         <mat-form-field fxFlexFill *ngSwitchCase="responseType==='Weight'" ngClass="text-lg">

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/prompt-input/prompt-input.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/prompt-input/prompt-input.component.html
@@ -29,7 +29,7 @@
             </div>
 
             <div class="barcode-scanner" *ngIf="showScanner">
-                <app-image-scanner>
+                <app-image-scanner (onScan)="onBarcodeScanned($event)" (scanChanged)="showScanner = $event">
                 </app-image-scanner>
             </div>
         </div>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/prompt-input/prompt-input.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/prompt-input/prompt-input.component.html
@@ -1,78 +1,95 @@
 <div [formGroup]="promptFormGroup">
-    <ng-container  *ngIf="!isDateField(); else dateField" [ngSwitch]="true">
-        <mat-form-field fxFlexFill *ngSwitchDefault ngClass="prompt-text" responsive-class>
-            <!-- Was using this:
-                <mat-icon matPrefix class="material-icons" color="primary">{{promptIcon}}</mat-icon>
-                but want to be able to use local icons.  TODO: problem with styling however, sizing not working
-                for SVG icon
-            -->
-            <button *ngIf="isScanAllowed(); else iconBlock" type="button" mat-button matPrefix mat-icon-button (click)="onScan()">
+    <ng-container *ngIf="!isDateField(); else dateField" [ngSwitch]="true">
+        <div *ngSwitchDefault class="input-container">
+            <mat-form-field class="prompt-text grow" responsive-class>
+                <!-- Was using this:
+                    <mat-icon matPrefix class="material-icons" color="primary">{{promptIcon}}</mat-icon>
+                    but want to be able to use local icons.  TODO: problem with styling however, sizing not working
+                    for SVG icon
+                -->
+                
+                <app-icon matPrefix iconClass="material-icons md primary" [iconName]="promptIcon" responsive-class>
+                </app-icon>
+                <input matInput [errorStateMatcher]="errorMatcher" [formControlName]="'promptInputControl'"
+                    [formatterName]="responseType" cdkFocusInitial [attr.minlength]="minLength" [attr.maxlength]="maxLength"
+                    [readonly]="readOnly" [attr.type]="isNumericField() ? 'tel' : 'text'" [keyboardLayout]="keyboardLayout"
+                    class="prompt-input" autoSelectOnFocus responsive-class>
+                <mat-placeholder>{{placeholderText}}</mat-placeholder>
+                <mat-hint class="prompt-hint" align="start" responsive-class>{{hintText}}</mat-hint>
+                <mat-error class="prompt-error">
+                    <app-show-errors [control]="promptFormGroup.controls['promptInputControl']"
+                        [additionalValidationMessages]="validationMessages"></app-show-errors>
+                </mat-error>
+            </mat-form-field>
+            <app-primary-button responsive-class *ngIf="isScanAllowed()" type="button" mat-button color="primary"
+                (click)="onScan()">
+                <app-icon class="barcode-icon" iconName="barcode"></app-icon>
+            </app-primary-button>
+        </div>
+        
+        <mat-form-field fxFlexFill *ngSwitchCase="responseType==='Weight'" ngClass="text-lg">
+            <button *ngIf="isScanAllowed(); else iconBlock" type="button" mat-button matPrefix mat-icon-button
+                (click)="onScan()">
                 <mat-icon svgIcon="barcode"></mat-icon>
             </button>
             <ng-template #iconBlock>
-                <app-icon matPrefix iconClass="material-icons md primary" [iconName]="promptIcon" responsive-class></app-icon>
+                <app-icon matPrefix iconClass="material-icons md primary" [iconName]="promptIcon"></app-icon>
             </ng-template>
-            <input matInput [errorStateMatcher]="errorMatcher" [formControlName]="'promptInputControl'" [formatterName]="responseType" cdkFocusInitial
-                   [attr.minlength]="minLength" [attr.maxlength]="maxLength" [readonly]="readOnly" [attr.type]="isNumericField() ? 'tel' : 'text'"
-                   [keyboardLayout]="keyboardLayout" class="prompt-input" autoSelectOnFocus responsive-class>
+            <input matInput [errorStateMatcher]="errorMatcher" [formControlName]="'promptInputControl'"
+                [formatterName]="responseType" cdkFocusInitial [attr.minlength]="minLength" [attr.maxlength]="maxLength"
+                [readonly]="readOnly" [attr.type]="isNumericField() ? 'tel' : 'text'" [keyboardLayout]="keyboardLayout"
+                [value]="responseText" autoSelectOnFocus>
             <mat-placeholder>{{placeholderText}}</mat-placeholder>
-            <mat-hint class="prompt-hint" align="start" responsive-class>{{hintText}}</mat-hint>
-            <mat-error class="prompt-error">
-                <app-show-errors [control]="promptFormGroup.controls['promptInputControl']" [additionalValidationMessages]="validationMessages"></app-show-errors>
+            <mat-hint class="text-sm" align="start">{{hintText}}</mat-hint>
+            <mat-error class="text-sm">
+                <app-show-errors [control]="promptFormGroup.controls['promptInputControl']"
+                    [additionalValidationMessages]="validationMessages"></app-show-errors>
             </mat-error>
         </mat-form-field>
-            <mat-form-field fxFlexFill *ngSwitchCase="responseType==='Weight'" ngClass="text-lg">
-                <button *ngIf="isScanAllowed(); else iconBlock" type="button" mat-button matPrefix mat-icon-button (click)="onScan()">
-                    <mat-icon svgIcon="barcode"></mat-icon>
-                </button> 
-                <ng-template #iconBlock>
-                    <app-icon matPrefix iconClass="material-icons md primary" [iconName]="promptIcon"></app-icon>
-                </ng-template>
-                <input matInput [errorStateMatcher]="errorMatcher" [formControlName]="'promptInputControl'" [formatterName]="responseType" cdkFocusInitial
-                       [attr.minlength]="minLength" [attr.maxlength]="maxLength" [readonly]="readOnly" [attr.type]="isNumericField() ? 'tel' : 'text'"
-                       [keyboardLayout]="keyboardLayout" [value]="responseText" autoSelectOnFocus>
-                <mat-placeholder>{{placeholderText}}</mat-placeholder>
-                <mat-hint class="text-sm" align="start">{{hintText}}</mat-hint>
-                <mat-error class="text-sm">
-                    <app-show-errors [control]="promptFormGroup.controls['promptInputControl']" [additionalValidationMessages]="validationMessages"></app-show-errors>
-                </mat-error>
-            </mat-form-field>
 
         <mat-form-field fxFlexFill *ngSwitchCase="responseType==='TextArea'" ngClass="prompt-textarea" responsive-class>
-            <textarea matInput [rows]="5" [cols]="40" [formControlName]="'promptInputControl'" cdkFocusInitial style="font-size:18px"
-                [attr.minlength]="minLength" [attr.maxlength]="maxLength" [readonly]="readOnly" [attr.type]="isNumericField() ? 'tel' : 'text'"
-                autoSelectOnFocus responsive-class>
+            <textarea matInput [rows]="5" [cols]="40" [formControlName]="'promptInputControl'" cdkFocusInitial
+                style="font-size:18px" [attr.minlength]="minLength" [attr.maxlength]="maxLength" [readonly]="readOnly"
+                [attr.type]="isNumericField() ? 'tel' : 'text'" autoSelectOnFocus responsive-class>
                 </textarea>
-                <mat-placeholder *ngIf="placeholderText" >{{placeholderText}}</mat-placeholder>
-                <mat-placeholder *ngIf="!placeholderText">Comments</mat-placeholder>
-                <mat-hint class="prompt-hint" align="start" responsive-class>{{hintText}}</mat-hint>
-                <mat-error class="prompt-error">
-                    <app-show-errors [control]="promptFormGroup.controls['promptInputControl']" [additionalValidationMessages]="validationMessages"></app-show-errors>
-                </mat-error>
+            <mat-placeholder *ngIf="placeholderText">{{placeholderText}}</mat-placeholder>
+            <mat-placeholder *ngIf="!placeholderText">Comments</mat-placeholder>
+            <mat-hint class="prompt-hint" align="start" responsive-class>{{hintText}}</mat-hint>
+            <mat-error class="prompt-error">
+                <app-show-errors [control]="promptFormGroup.controls['promptInputControl']"
+                    [additionalValidationMessages]="validationMessages"></app-show-errors>
+            </mat-error>
         </mat-form-field>
 
-        <mat-slide-toggle *ngSwitchCase="responseType==='ONOFF'" [formControlName]="'promptInputControl'"  (click)="onCheck()" color="primary" ngClass="text-lg">
+        <mat-slide-toggle *ngSwitchCase="responseType==='ONOFF'" [formControlName]="'promptInputControl'"
+            (click)="onCheck()" color="primary" ngClass="text-lg">
             {{placeholderText}} {{responseText}}
         </mat-slide-toggle>
 
         <mat-form-field fxFlexFill *ngSwitchCase="isPassword()" ngClass="prompt-password" responsive-class>
-            <app-icon matPrefix iconClass="material-icons md primary" [iconName]="promptIcon" responsive-class></app-icon>
-            <input matInput [formControlName]="'promptInputControl'" cdkFocusInitial autoSelectOnFocus class="prompt-input"
-                type="password" [formatterName]="responseType"  [attr.minlength]="minLength" [attr.maxlength]="maxLength" responsive-class>
+            <app-icon matPrefix iconClass="material-icons md primary" [iconName]="promptIcon" responsive-class>
+            </app-icon>
+            <input matInput [formControlName]="'promptInputControl'" cdkFocusInitial autoSelectOnFocus
+                class="prompt-input" type="password" [formatterName]="responseType" [attr.minlength]="minLength"
+                [attr.maxlength]="maxLength" responsive-class>
             <mat-placeholder>{{placeholderText}}</mat-placeholder>
             <mat-hint class="prompt-hint" align="start" responsive-class>{{hintText}}</mat-hint>
             <mat-error class="prompt-error">
-                <app-show-errors [control]="promptFormGroup.controls['promptInputControl']" [additionalValidationMessages]="validationMessages"></app-show-errors>
+                <app-show-errors [control]="promptFormGroup.controls['promptInputControl']"
+                    [additionalValidationMessages]="validationMessages"></app-show-errors>
             </mat-error>
         </mat-form-field>
     </ng-container>
 
     <ng-template #dateField>
         <ng-container>
-            <app-dynamic-date-form-field [controlName]="'promptInputControl'" [hiddenControl]="'promptInputHiddenDateControl'" [form]="promptFormGroup"
-            [type]="responseType" [(value)]="responseText" [placeholder]="placeholderText" [isPrompt]=true [hintText]="hintText"></app-dynamic-date-form-field>
+            <app-dynamic-date-form-field [controlName]="'promptInputControl'"
+                [hiddenControl]="'promptInputHiddenDateControl'" [form]="promptFormGroup" [type]="responseType"
+                [(value)]="responseText" [placeholder]="placeholderText" [isPrompt]=true [hintText]="hintText">
+            </app-dynamic-date-form-field>
             <mat-error class="text-sm">
-                <app-show-errors [control]="promptFormGroup.controls['promptInputControl']" [additionalValidationMessages]="validationMessages"></app-show-errors>
+                <app-show-errors [control]="promptFormGroup.controls['promptInputControl']"
+                    [additionalValidationMessages]="validationMessages"></app-show-errors>
             </mat-error>
         </ng-container>
     </ng-template>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/prompt-input/prompt-input.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/prompt-input/prompt-input.component.scss
@@ -75,3 +75,9 @@ app-icon {
   width: 100%;
   flex-grow: 1;
 }
+
+.barcode-scanner {
+  width: 100%;
+  background: blue;
+  min-height: 200px;
+}

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/prompt-input/prompt-input.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/prompt-input/prompt-input.component.scss
@@ -77,7 +77,7 @@ app-icon {
 }
 
 .barcode-scanner {
+  display: grid;
   width: 100%;
-  background: blue;
   min-height: 200px;
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/prompt-input/prompt-input.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/prompt-input/prompt-input.component.scss
@@ -5,6 +5,8 @@
 .prompt-input {
   @extend %text-lg;
 
+  min-width: unset;
+
   &.mobile {
     font-size: $text-md-mobile;
   }
@@ -41,4 +43,35 @@ app-icon {
   @at-root app-prompt-input .tablet .mat-form-field-label {
     font-size: $text-lg-mobile;
   }
+}
+
+.input-container {
+  display: flex;
+  flex-direction: row;
+}
+
+.input-container > app-primary-button {
+  align-self: start;
+  min-height: 64px;
+  margin-top: 26px;
+  margin-left: 8px;
+
+  .barcode-icon {
+    padding-bottom: 5px;
+  }
+
+  &.tablet {
+    min-height: 48px;
+    margin-top: 20px;
+  }
+
+  &.mobile {
+    align-self: unset;
+    margin-top: 8px;
+  }
+}
+
+.grow {
+  width: 100%;
+  flex-grow: 1;
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/prompt-input/prompt-input.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/prompt-input/prompt-input.component.ts
@@ -5,7 +5,6 @@ import { ErrorStateMatcher } from '@angular/material';
 import { BarcodeScanner } from '../../../core/platform-plugins/barcode-scanners/barcode-scanner.service';
 import { ScanData } from '../../../core/platform-plugins/barcode-scanners/scanner';
 import { ActionService } from '../../../core/actions/action.service';
-import { IActionItem } from '../../../core/actions/action-item.interface';
 
 @Component({
     selector: 'app-prompt-input',

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/prompt-input/prompt-input.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/prompt-input/prompt-input.component.ts
@@ -96,8 +96,7 @@ export class PromptInputComponent implements OnInit, OnDestroy {
     }
 
     isScanAllowed(): boolean {
-        return this.scanEnabled &&
-            ['numerictext', 'alphanumerictext'].indexOf(this.responseType.toLowerCase()) >= 0;
+        return this.scanEnabled && (this.responseType && ['numerictext', 'alphanumerictext'].indexOf(this.responseType.toLowerCase()) >= 0);
     }
 
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.component.html
@@ -15,7 +15,7 @@
                                       [keyboardPreference]="screenData.keyboardPreference" [scanEnabled]="screenData.scanEnabled"
                                       [validationMessages]="screenData.validationMessages"
                                       [readOnly]="!screenData.editable"
-                                      [scanActionName]="screenData.scan.scanActionName">
+                                      [scanActionName]="screenData.scan?.scanActionName">
                     </app-prompt-input>
                     <app-instructions *ngIf="instructions" [instructions]="instructions" [instructionsSize]="'text-sm'"></app-instructions>
                     <div #optionsRef>
@@ -59,7 +59,7 @@
                                       [minLength]="screenData.minLength" [maxLength]="screenData.maxLength" [promptFormGroup]="promptFormGroup"
                                       [validationMessages]="screenData.validationMessages"
                                       [keyboardPreference]="screenData.keyboardPreference" [scanEnabled]="screenData.scanEnabled" [readOnly]="!screenData.editable"
-                                      [scanActionName]="screenData.scan.scanActionName">
+                                      [scanActionName]="screenData.scan?.scanActionName">
                     </app-prompt-input>
                     <app-instructions *ngIf="instructions" [instructions]="instructions" [instructionsSize]="'text-sm'"></app-instructions>
                     <div #optionsRef>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.component.html
@@ -14,7 +14,8 @@
                                       [maxLength]="screenData.maxLength" [promptFormGroup]="promptFormGroup"
                                       [keyboardPreference]="screenData.keyboardPreference" [scanEnabled]="screenData.scanEnabled"
                                       [validationMessages]="screenData.validationMessages"
-                                      [readOnly]="!screenData.editable">
+                                      [readOnly]="!screenData.editable"
+                                      [scanActionName]="screenData.scan.scanActionName">
                     </app-prompt-input>
                     <app-instructions *ngIf="instructions" [instructions]="instructions" [instructionsSize]="'text-sm'"></app-instructions>
                     <div #optionsRef>
@@ -57,7 +58,8 @@
                                       [promptIcon]="screenData.promptIcon" [responseText]="screenData.responseText" [hintText]="screenData.hintText"
                                       [minLength]="screenData.minLength" [maxLength]="screenData.maxLength" [promptFormGroup]="promptFormGroup"
                                       [validationMessages]="screenData.validationMessages"
-                                      [keyboardPreference]="screenData.keyboardPreference" [scanEnabled]="screenData.scanEnabled" [readOnly]="!screenData.editable">
+                                      [keyboardPreference]="screenData.keyboardPreference" [scanEnabled]="screenData.scanEnabled" [readOnly]="!screenData.editable"
+                                      [scanActionName]="screenData.scan.scanActionName">
                     </app-prompt-input>
                     <app-instructions *ngIf="instructions" [instructions]="instructions" [instructionsSize]="'text-sm'"></app-instructions>
                     <div #optionsRef>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.component.ts
@@ -6,7 +6,6 @@ import { IActionItem } from '../../../core/actions/action-item.interface';
 import { PromptFormPartInterface } from './prompt-form-part.interface';
 import {Configuration} from '../../../configuration/configuration';
 import {merge} from 'rxjs';
-import { ScanInterface } from '../scan-part/scan-part.interface';
 
 @Component({
     selector: 'app-prompt-form-part',

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.component.ts
@@ -6,6 +6,7 @@ import { IActionItem } from '../../../core/actions/action-item.interface';
 import { PromptFormPartInterface } from './prompt-form-part.interface';
 import {Configuration} from '../../../configuration/configuration';
 import {merge} from 'rxjs';
+import { ScanInterface } from '../scan-part/scan-part.interface';
 
 @Component({
     selector: 'app-prompt-form-part',

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.interface.ts
@@ -27,5 +27,5 @@ export interface PromptFormPartInterface {
     validationMessages: Map<string, string>;
     promptPosition: PromptPosition;
     info: DisplayProperty[];
-    scan: ScanInterface;
+    scan?: ScanInterface;
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.interface.ts
@@ -1,9 +1,9 @@
 import { FieldInputType } from '../../../core/interfaces/field-input-type.enum';
 import { IActionItem } from '../../../core/actions/action-item.interface';
 import { Validator } from '@angular/forms';
-import { IForm } from '../../../core/interfaces/form.interface';
 import { PromptPosition } from './prompt-position.enum';
 import { DisplayProperty } from '../../components/display-property/display-property.interface';
+import { ScanInterface } from '../scan-part/scan-part.interface';
 
 export interface PromptFormPartInterface {
     type: string;
@@ -27,4 +27,5 @@ export interface PromptFormPartInterface {
     validationMessages: Map<string, string>;
     promptPosition: PromptPosition;
     info: DisplayProperty[];
+    scan: ScanInterface;
 }


### PR DESCRIPTION
### Summary
Modernized image scanner support for prompt screens/dialogs. This updates the old plugin support for barcode input for scanners to allow for image scanners like Scandit to be shown.

### Screenshots
![Scanner](https://user-images.githubusercontent.com/2295721/110502164-30714700-80b8-11eb-9eae-c708602ddfd2.png)

