### PR TITLE
Allow properties to be removed from the ClientContext (support for fixing sequence number duplication)

### DIFF
--- a/openpos-service/src/main/java/org/jumpmind/pos/service/EndpointInvoker.java
+++ b/openpos-service/src/main/java/org/jumpmind/pos/service/EndpointInvoker.java
@@ -339,7 +339,7 @@ public class EndpointInvoker implements InvocationHandler {
                     annotation == null || annotation.implementation().equals(Endpoint.IMPLEMENTATION_DEFAULT) ?
                             "" : annotation.implementation() + " implementation");
             */
-            log.info("{}.{}() {}",
+            log.debug("{}.{}() {}",
                     method.getDeclaringClass().getSimpleName(),
                     method.getName(),
                     implementation == null || Endpoint.IMPLEMENTATION_DEFAULT.equals(implementation) ? "" : implementation + " implementation");

--- a/openpos-util/src/main/java/org/jumpmind/pos/util/clientcontext/ClientContext.java
+++ b/openpos-util/src/main/java/org/jumpmind/pos/util/clientcontext/ClientContext.java
@@ -58,6 +58,17 @@ public class ClientContext {
         return props.get(name);
     }
 
+    /**
+     * Removes the given property from the ClientContext
+     * @param name The name of the property to remove.
+     */
+    public void remove(String name) {
+        Map<String, String> props = propertiesMap.get();
+        if (props != null && name != null) {
+            props.remove(name);
+        }
+    }
+
     public Set<String> getPropertyNames() {
         Map<String, String> props = propertiesMap.get();
 


### PR DESCRIPTION
### Issues Fixed
PDPOS-4786

### Summary
Openpos supporting changes for providing a solution for preventing duplicate sequence numbers during service calls between commerce instances.

- Turn down logging on service calls.
- Allow properties to be removed from the ClientContext