### PR TITLE
Fix auto selected first option style

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/options-list/options-list.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/options-list/options-list.component.html
@@ -1,5 +1,9 @@
 <div *ngIf="screenData">
 
+    <mat-form-field class="options-input-invisible">
+        <input matInput cdkFocusInitial type="text" responsive-class/>
+    </mat-form-field>
+
     <div *ngIf="screenData && screenData.additionalButtons" class="options-buttons">
         <button mat-raised-button color="primary" responsive-class *ngFor="let button of screenData.additionalButtons"
             (click)="onOptionClick(button)" class="additional-options-buttons">

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/options-list/options-list.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/options-list/options-list.component.scss
@@ -19,3 +19,10 @@
         @extend %text-md;
     }
 }
+
+.options-input-invisible {
+    display: block;
+    visibility: hidden;
+    height: 0;
+    width: 0;
+}


### PR DESCRIPTION
We have prod-bug that after Post Void reason code appears auto selected. 
Actually, it's common problem, we have it in a lot of places where we have options-dialog.
Few problem places for example you can see in attachment.

My suggestion is the same as before I fixed this style for the X button at the top right of the pop-up windows:
Add hidden input with autofocus.
This solves the problem.
<img width="807" alt="Screen Shot 2021-03-10 at 9 55 11 PM" src="https://user-images.githubusercontent.com/77682108/110691416-c955ae80-81ed-11eb-8c18-7585b9c85b17.png">
