### PR TITLE
Loyalty Member Name and Member ID get cut off

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.html
@@ -28,12 +28,12 @@
             <div class="button-wrapper">
                 <div class="grid-container">
                     <div class="name">
-                        <div class="customer-name">
+                        <div responsive-class class="customer-name">
                             {{screenData.customer.name}}
                             <span *ngIf="keybindsEnabled(screenData.linkedCustomerButton)"
-                                  class="muted-color loyalty-keybind">{{screenData.linkedCustomerButton.keybindDisplayName}}</span></div>
+                                  class="muted-color loyalty-keybind">{{screenData.linkedCustomerButton.keybindDisplayName}}</span>
                         </div>
-
+                    </div>
                     <div class="icon"><app-icon [iconName]="'account_circle'" [iconClass]="(isMobile | async) ? null: 'material-icons mat-36'"></app-icon></div>
                     <div class="memberships"><span>{{screenData.loyaltyIDLabel}}: {{screenData.customer.id}}</span></div>
                 </div>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
@@ -46,7 +46,7 @@
                 .name {
                     grid-area: Name;
                     .customer-name {
-                        font-size: 24px;
+                        font-size: 1.5vw;
                         .loyalty-keybind {
                             margin-left: 10px;
                         }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
@@ -46,7 +46,7 @@
                 .name {
                     grid-area: Name;
                     .customer-name {
-                        font-size: 1.5vw;
+                        @extend %text-md;
                         .loyalty-keybind {
                             margin-left: 10px;
                         }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
@@ -46,7 +46,8 @@
                 .name {
                     grid-area: Name;
                     .customer-name {
-                        overflow: auto;
+                        overflow: hidden;
+                        white-space: normal;
                         @extend %text-sm;
                         .loyalty-keybind {
                             margin-left: 10px;

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
@@ -46,7 +46,8 @@
                 .name {
                     grid-area: Name;
                     .customer-name {
-                        @extend %text-md;
+                        overflow: auto;
+                        @extend %text-sm;
                         .loyalty-keybind {
                             margin-left: 10px;
                         }


### PR DESCRIPTION
JMC Mobile - Loyalty Member Name and Member ID get cut off
We always had font size 24px. In browser we can see that the text does not fit.
On a mobile device, the surname is just truncated.
![1938_problem](https://user-images.githubusercontent.com/77682108/110795566-a8d63480-827f-11eb-805d-a55e21cbf24b.gif)
Suggestion - use dynamic font size for loyalty button.
![1938_fixed](https://user-images.githubusercontent.com/77682108/110795789-e8048580-827f-11eb-89ec-84ba71ed7ced.gif)
