### PR TITLE
Tag names are now forced to uppercase

### DIFF
--- a/openpos-devices/src/main/java/org/jumpmind/pos/devices/model/DeviceModel.java
+++ b/openpos-devices/src/main/java/org/jumpmind/pos/devices/model/DeviceModel.java
@@ -83,12 +83,12 @@ public class DeviceModel extends AbstractModel implements ITaggedModel {
 
     @Override
     public String getTagValue(String tagName) {
-        return tags.get(tagName);
+        return tags.get(tagName.toUpperCase());
     }
 
     @Override
     public void setTagValue(String tagName, String tagValue) {
-        tags.put(tagName, tagValue);
+        tags.put(tagName.toUpperCase(), tagValue);
     }
 
     @Override

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AbstractTaggedModel.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AbstractTaggedModel.java
@@ -28,12 +28,12 @@ abstract public class AbstractTaggedModel extends AbstractModel implements ITagg
 
     @Override
     public String getTagValue(String tagName) {
-        return tags.get(tagName);
+        return tags.get(tagName.toUpperCase());
     }
 
     @Override
     public void setTagValue(String tagName, String tagValue) {
-        tags.put(tagName, tagValue);
+        tags.put(tagName.toUpperCase(), tagValue);
     }
 
     @Override


### PR DESCRIPTION
### Issues Fixed
- [5009](https://petcoalm.atlassian.net/browse/PDPOS-5009)

### Summary
When starting the server, sometimes the tag names could end up being lower case in some parts of the code, but uppercase in others, depending on both the database used and the configuration. Specifically, there was an issue in the save() function in DBSession.java where setTagValues() would pre-emptively set a tag name to uppercase and use that uppercase as a key to bind a tag value to, but loadValues() right after it would not set the tag name to uppercase, and would try to use the lower case version of the tag name as a key to reference the just-set value. This would cause some database functions to incorrectly report tag values as empty, when really they were just using the wrong key.
