### PR TITLE
Match default implementations for endpoint overrides (#1181)

### DIFF
--- a/openpos-service/src/main/java/org/jumpmind/pos/service/EndpointInvoker.java
+++ b/openpos-service/src/main/java/org/jumpmind/pos/service/EndpointInvoker.java
@@ -156,7 +156,7 @@ public class EndpointInvoker implements InvocationHandler {
             }
             else {
                 implMatchedOverrides = pathMatchedOverrides.stream()
-                        .filter(entry -> entry.getValue().implementation().equals(Endpoint.IMPLEMENTATION_DEFAULT))
+                        .filter(entry -> entry.getValue().implementation().equals("default"))
                         .collect(Collectors.toList());
             }
 


### PR DESCRIPTION
### Summary
Match override endpoints with matching implementation or "default"

This was addressing an issue where the controller implementation was defined in the yml and the base endpoint was overridden, but the endpoint implementation didn't match the yml implmentation:

```
# application-corp.yml
openpos:
...
  services:
    returnsmgmt_1_1:
       implementation: appriss

@Endpoint(path="/returnsmgmt/version/1_1/search")
@EndpointOverride(path="/returnsmgmt/version/1_1/search")
```
In this scenario, the EndpointInvoker matched the RestController with the original endpoint instead of the EndpointOverride. The