### PR TITLE
Use DB platform to prefix all table attributes with shadow table prefix

### DIFF
--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/DatabaseSchema.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/DatabaseSchema.java
@@ -80,13 +80,21 @@ public class DatabaseSchema {
                 table.setName(tableName.substring(0, tableName.length() - 1));
             }
         }
+        if(shadowTables.size() > 0 && shadowTablesConfig != null) {
+            prefixShadowTables();
 
-        for (ModelClassMetaData shadowMeta : shadowTables.values())  {
-            db.addTable(shadowMeta.getShadowTable());
-            log.info("Adding shadow table, regular table name {}, shadow table name {}", getTableName(tablePrefix, shadowMeta.getTable().getName()), shadowMeta.getShadowTable().getName());
+            for (ModelClassMetaData shadowMeta : shadowTables.values()) {
+                db.addTable(shadowMeta.getShadowTable());
+                log.info("Adding shadow table, regular table name {}, shadow table name {}", getTableName(tablePrefix, shadowMeta.getTable().getName()), shadowMeta.getShadowTable().getName());
+            }
         }
-
         return db;
+    }
+
+    private void prefixShadowTables() {
+        Database shadowDatabase = new Database();
+        shadowDatabase.addTables(shadowTables.values().stream().map(ModelClassMetaData::getShadowTable).collect(Collectors.toList()));
+        platform.prefixDatabase(String.format("%s_%s", shadowTablesConfig.getTablePrefix(), tablePrefix ), shadowDatabase);
     }
 
     public Table getTable(Class<?> entityClass, Class<?> superClass) {

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/ModelClassMetaData.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/ModelClassMetaData.java
@@ -74,10 +74,7 @@ public class ModelClassMetaData {
     }
 
     public void setShadowTable(String shadowPrefix, String modulePrefix)  {
-        Table shadowTable = table.copy();
-        shadowTable.setName((shadowPrefix + "_" + modulePrefix + "_" + table.getName()).toUpperCase());
-
-        this.shadowTable = shadowTable;
+        this.shadowTable = table.copy();
         this.shadowPrefix = shadowPrefix;
         this.modulePrefix = modulePrefix;
     }


### PR DESCRIPTION
### Summary
Adding training mode table indices was causing conflicts with some older indices that were not prefixed with the module name. Updated to ensure that all attributes for shadow tables are prefixed correctly using the DB platform specified.
