### PR TITLE
WebKit Item Image

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/item-card/item-card.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/item-card/item-card.component.html
@@ -1,12 +1,11 @@
 <mat-card class="item-card" [class]="item.lineItemType | lowercase" [ngClass]="{'mat-elevation-z5':hover, 'mat-elevation-z1':!hover}">
     <mat-card-content class="item-content">
-        <app-image
-                   responsive-class
+        <app-image responsive-class
                    *ngIf="item.imageUrl && !item.svgImage"
                    class="item-card-image"
                    [imageUrl]="item.imageUrl | imageUrl"
                    [altText]="item.description"
-                   [ngClass]="{'collapsed': !expanded}">
+                   [class.collapsed]="!expanded">
         </app-image>
         <app-icon *ngIf="item.imageUrl && item.svgImage" [iconName]="item.imageUrl"
             [iconClass]="expanded ? 'material-icons mat-128' : 'material-icons mat-48'" [ngClass]="{'collapsed': !expanded}">

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/item-card/item-card.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/item-card/item-card.component.scss
@@ -17,15 +17,18 @@
 
         .item-card-image {
             grid-area: 1/1/1/1;
+            width: 220px;
             height: 275px;
             padding-right: 16px;
 
             &.tablet {
                 height: 150px;
+                width: 100px;
             }
 
             &.mobile {
-                height: 50px;
+                height: 60px;
+                width: 60px;
             }
         }
 
@@ -35,7 +38,8 @@
         }
 
         .item-card-image.collapsed {
-            height: 50px;
+            width: 60px;
+            height: 60px;
         }
 
         .left-side {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/mobile-item/mobile-item.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/mobile-item/mobile-item.component.scss
@@ -12,20 +12,24 @@
 
         .item-card-image {
             grid-area: 1/1/1/1;
+            width: 220px;
             height: 275px;
             padding-right:16px;
         
             &.tablet {
                 height: 150px;
+                width: 100px;
             }
         
             &.mobile {
-                height: 50px;
+                height: 60px;
+                width: 60px;
             }
         }
 
         .item-card-image.collapsed {
-            height: 50px;
+            width: 60px;
+            height: 60px;
         }
 
         .left-side {


### PR DESCRIPTION
### Issues Fixed
PCOM-1845

### Summary
Safari/WebKit has trouble re-sizing the item images to fill the container's space. The only thing I could get to work was to fix the sizes of the images containers. The effect is pretty consistent now which I think is an improvement, but it has the side effect that if an image has a different aspect ratio, there could be some empty space that I can't really do anything about.
