### PR TITLE
Loyalty Member Name and Member ID get cut off - reopened fix

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
@@ -60,6 +60,9 @@
                     color: lightgray;
                 }
                 .memberships {
+                    overflow: hidden;
+                    white-space: normal;
+                    @extend %text-xs;
                     grid-area: Memberships;
                 }
             }


### PR DESCRIPTION
Bug #1183 has been reopened because I forgot that the same problem is repeated for the loyalty id. 
Now fixed...
![1939_reopened_fix](https://user-images.githubusercontent.com/77682108/111617486-d4ab6a00-87eb-11eb-91b9-73f2f4502bb2.gif)

