### PR TITLE
Fixed styling of sales-total-panel

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
@@ -101,6 +101,7 @@ app-scandit-native {
         "buttons";
     grid-template-rows: 0 min-content minmax(0, 1fr) min-content;
     grid-template-columns: minmax(0, 1fr);
+    display: grid;
     align-self: stretch;
     justify-self: stretch;
     margin: 0;


### PR DESCRIPTION
### Summary
Cherry pick #1152 to fix some styling in the central app transaction details screen.