### PR TITLE
Make timers on sale screen appear without delay

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/status-strip/status-strip.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/status-strip/status-strip.component.ts
@@ -2,7 +2,7 @@ import {map} from 'rxjs/operators';
 import { ScreenPartComponent } from '../screen-part';
 import { StatusStripInterface } from './status-strip.interface';
 import { MatDialog } from '@angular/material';
-import {interval, of, timer} from 'rxjs';
+import { timer } from 'rxjs';
 import { Component, Injector } from '@angular/core';
 import { ScreenPart } from '../../decorators/screen-part.decorator';
 @ScreenPart({
@@ -15,8 +15,8 @@ import { ScreenPart } from '../../decorators/screen-part.decorator';
 })
 export class StatusStripComponent extends ScreenPartComponent<StatusStripInterface> {
 
-    date = interval(1000).pipe( map( () => Date.now()));
-    timer = interval(1000).pipe(map( () => {
+    date = timer(0, 1000).pipe(map( () => Date.now()));
+    timer = timer(0, 1000).pipe(map( () => {
         if ( this.screenData.timestampBegin ) {
         const timestampBegin = this.screenData.timestampBegin;
         return ((new Date()).getTime() - timestampBegin) / 1000;


### PR DESCRIPTION
### Summary
Make timers on the sale screen appear without delay