### PR TITLE
Fix scenario where action will hang when inheriting action handler from base state

### DIFF
--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/ActionHandlerImpl.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/ActionHandlerImpl.java
@@ -54,7 +54,7 @@ public class ActionHandlerImpl {
     public boolean handleAnyAction(IStateManager stateManager, Object state, Action action) {
         // Get list of @BeforeAction methods in the state and execute them first
         beforeActionService.executeBeforeActionMethods(stateManager, state, action);
-        
+
         Method anyActionMethod = helper.getAnyActionMethod(state);
         if (anyActionMethod != null) {
             helper.invokeActionMethod(stateManager, state, action, anyActionMethod);
@@ -78,9 +78,9 @@ public class ActionHandlerImpl {
         for (StackTraceElement stackFrame : stackTrace) {
             Class<?> currentClass = helper.getClassFrom(stackFrame);
             if (currentClass != null && !Modifier.isAbstract(currentClass.getModifiers()) && FlowUtil.isState(currentClass)
-                    && currentClass != state.getClass()) {
+                    && !currentClass.isAssignableFrom(state.getClass())) {
                 return false;
-            } else if (stackFrame.getClassName().equals(state.getClass().getName())) {
+            } else if (currentClass.isAssignableFrom(state.getClass())) {
                 return true;
             }
 
@@ -88,8 +88,8 @@ public class ActionHandlerImpl {
 
         return false;
     }
-    
- 
+
+
     public IBeforeActionService getBeforeActionService() {
         return beforeActionService;
     }

--- a/openpos-flow/src/test/java/org/jumpmind/pos/core/flow/StateManagerTest.java
+++ b/openpos-flow/src/test/java/org/jumpmind/pos/core/flow/StateManagerTest.java
@@ -141,7 +141,7 @@ public class StateManagerTest {
                 .withTransition("SetVariables", SetVariablesState.class)
                 .withTransition("UnsetVariables", UnsetVariablesState.class)
                 .withTransition("CheckVariables", CheckVariablesState.class)
-                .withTransition("CheckOverrideState", TestStates.OverrideState.class)
+                .withTransition("CheckOverrideState", TestStates.OverrideSimpleState.class)
                 .build()
         );
         config.add(FlowBuilder.addState(SetVariablesState.class).withTransition("UnsetVariables", UnsetVariablesState.class).build());
@@ -890,8 +890,8 @@ public class StateManagerTest {
         stateManagerInit();
         assertEquals(HomeState.class, stateManager.getCurrentState().getClass());
         doAction("CheckOverrideState");
-        TestStates.OverrideState overrideState = (TestStates.OverrideState) stateManager.getCurrentState();
-        assertEquals(TestStates.OverrideState.class, overrideState.getClass());
+        TestStates.OverrideSimpleState overrideState = (TestStates.OverrideSimpleState) stateManager.getCurrentState();
+        assertEquals(TestStates.OverrideSimpleState.class, overrideState.getClass());
         doAction("Something");
         assertEquals(overrideState.message, "Override state message");
     }

--- a/openpos-flow/src/test/java/org/jumpmind/pos/core/flow/StateManagerTest.java
+++ b/openpos-flow/src/test/java/org/jumpmind/pos/core/flow/StateManagerTest.java
@@ -66,13 +66,13 @@ public class StateManagerTest {
 
     @InjectMocks
     Injector injector;
- 
+
     @Mock
     private ScreenService screenService;
 
     @Mock
     private IMessageService messageService;
-    
+
     @Mock
     private IErrorHandler errorHandler;
 
@@ -92,12 +92,12 @@ public class StateManagerTest {
                 FlowBuilder.addState(CustomerSignupState.class).withTransition("CustomerSignedup", CompleteState.class)
                 .withTransition("Back", CompleteState.class)
                 .build());
-        
+
         FlowConfig testFlowScopeFlow2 = new FlowConfig();
         testFlowScopeFlow2.setInitialState(FlowBuilder.addState(SubStateFlowScopePropogation2.class)
                 .withTransition("Back", CompleteState.class)
                 .build());
-        
+
         FlowConfig testFlowScopeFlow = new FlowConfig();
         testFlowScopeFlow.setInitialState(FlowBuilder.addState(SubStateFlowScopePropogation1.class)
                 .withTransition("Back", CompleteState.class)
@@ -114,7 +114,7 @@ public class StateManagerTest {
         customerFlow.addGlobalTransitionOrActionHandler("Help", HelpState.class);
         customerFlow.addGlobalSubTransition("CustomerSignup", customerSignupFlow);
         customerFlow.add(FlowBuilder.addState(HelpState.class).withTransition("Back", CustomerState.class).build());
-        
+
         FlowConfig multiReturnActionSubFlow = new FlowConfig();
         multiReturnActionSubFlow.setInitialState(FlowBuilder.addState(MultiReturnActionInitialState.class).build());
 
@@ -141,6 +141,7 @@ public class StateManagerTest {
                 .withTransition("SetVariables", SetVariablesState.class)
                 .withTransition("UnsetVariables", UnsetVariablesState.class)
                 .withTransition("CheckVariables", CheckVariablesState.class)
+                .withTransition("CheckOverrideState", TestStates.OverrideState.class)
                 .build()
         );
         config.add(FlowBuilder.addState(SetVariablesState.class).withTransition("UnsetVariables", UnsetVariablesState.class).build());
@@ -157,7 +158,7 @@ public class StateManagerTest {
                 .withTransition("MultiReturnAction1", MultiReturnAction1State.class)
                 .withTransition("MultiReturnAction2", MultiReturnAction2State.class)
                 .build());
-        
+
 
 
         config.addGlobalTransitionOrActionHandler("Help", HelpState.class);
@@ -205,23 +206,23 @@ public class StateManagerTest {
     @Test
     public void testSubStateTransitionBackToAnotherState() {
         stateManagerInit();
-        
+
         HomeState homeState = (HomeState) stateManager.getCurrentState();
         homeState.departGeneralCalled = false;
         homeState.departToSubflowCalled = false;
         homeState.departStateCalled = false;
-        
+
         assertEquals(HomeState.class, homeState.getClass());
         assertTrue(homeState.arriveCalled);
         doAction("ToSubState1");
-        
+
         assertTrue(homeState.departGeneralCalled);
         assertTrue(homeState.departToSubflowCalled);
         assertFalse(homeState.departStateCalled);
-        
+
         assertEquals(ActionTestingState.class, stateManager.getCurrentState().getClass());
     }
-    
+
     @Test
     public void testSubStateTransitionBackToAnotherSubState() {
         stateManagerInit();
@@ -267,7 +268,7 @@ public class StateManagerTest {
         homeState.departGeneralCalled = false;
         homeState.departToSubflowCalled = false;
         homeState.departStateCalled = false;
-        
+
         assertEquals(HomeState.class, homeState.getClass());
         doAction("Sell");
         assertTrue(homeState.departGeneralCalled);
@@ -353,7 +354,7 @@ public class StateManagerTest {
         assertNull("stateManager.getScopeValue(\"selectedCustomer\")", stateManager.getScopeValue("selectedCustomer"));
         assertEquals(SellState.class, stateManager.getCurrentState().getClass());
     }
-    
+
     @Test
     public void testFlowScopePropogation() {
         stateManagerInit();
@@ -363,7 +364,7 @@ public class StateManagerTest {
         assertEquals(SubStateFlowScopePropogation1.class, stateManager.getCurrentState().getClass());
         doAction("SubStateFlowScopePropogation2Action");
         assertEquals(SubStateFlowScopePropogation2.class, stateManager.getCurrentState().getClass());
-        assertEquals("flowScopeValue1", stateManager.getScopeValue("flowScopeValue1"));        
+        assertEquals("flowScopeValue1", stateManager.getScopeValue("flowScopeValue1"));
         doAction("Back");
         assertEquals(SubStateFlowScopePropogation1.class, stateManager.getCurrentState().getClass());
         assertEquals("flowScopeValue1", stateManager.getScopeValue("flowScopeValue1"));
@@ -447,10 +448,10 @@ public class StateManagerTest {
         verify(errorHandler).handleError(eq(stateManager), exArgument.capture());
         assertEquals(FlowException.class, exArgument.getValue().getClass());
         assertTrue(exArgument.getValue().getMessage().contains("UnhandledAction"));
-        
+
     }
-    
-    
+
+
     @Test
     public void testInjectionFailure() {
         stateManagerInit();
@@ -489,7 +490,7 @@ public class StateManagerTest {
         assertEquals(FlowException.class, exArgument.getValue().getClass());
         assertTrue(exArgument.getValue().getMessage().contains("inject"));
     }
-    
+
     @Test
     public void testOptionalInjections() {
         stateManagerInit();
@@ -573,7 +574,7 @@ public class StateManagerTest {
         class Invoked { boolean invoked = false; }
         final Invoked i = new Invoked();
         Runnable r = () -> i.invoked = true;
-        
+
         assertFalse(i.invoked);
         doAction(new Action("SomeGlobalAction", r));
         assertEquals(HomeState.class, stateManager.getCurrentState().getClass());
@@ -621,7 +622,7 @@ public class StateManagerTest {
         assertEquals(NullPointerException.class, exArgument.getValue().getCause().getCause().getClass());
         assertTrue( exArgument.getValue().getCause().getCause().getMessage().contains("Global"));
     }
-    
+
     @Test
     public void testTransitionProceed() {
         stateManagerInit();
@@ -669,7 +670,7 @@ public class StateManagerTest {
         this.testStackOverflow();
         verify(errorHandler, atLeastOnce()).handleError(eq(stateManager), isA(FlowException.class));
     }
-    
+
     @Test
     public void testMultiSubFlowReturnActions1() {
         stateManagerInit();
@@ -681,7 +682,7 @@ public class StateManagerTest {
         doAction("MultiReturnAction1");
         assertEquals(MultiReturnAction1State.class, stateManager.getCurrentState().getClass());
     }
-    
+
     @Test
     public void testMultiSubFlowReturnActions2() {
         stateManagerInit();
@@ -693,7 +694,7 @@ public class StateManagerTest {
         doAction("MultiReturnAction2");
         assertEquals(MultiReturnAction2State.class, stateManager.getCurrentState().getClass());
     }
-    
+
     @Test
     public void testMultiSubFlowReturnActions1_NoFlowConfig() {
         stateManagerInit();
@@ -705,7 +706,7 @@ public class StateManagerTest {
         doAction("MultiReturnAction1");
         assertEquals(MultiReturnAction1State.class, stateManager.getCurrentState().getClass());
     }
-    
+
     @Test
     public void testMultiSubFlowReturnActions2_NoFlowConfig() {
         stateManagerInit();
@@ -717,7 +718,7 @@ public class StateManagerTest {
         doAction("MultiReturnAction2");
         assertEquals(MultiReturnAction2State.class, stateManager.getCurrentState().getClass());
     }
-    
+
 
     @Test
     public void testOnArriveThatThrowsException( ) {
@@ -744,25 +745,25 @@ public class StateManagerTest {
             stateManager.setErrorHandler(existingErrorHandler);
         }
     }
-    
+
     @Test
     public void testOnArriveThatThrowsException_WithErrorHandler( ) {
         ArgumentCaptor<Throwable> exArgument = ArgumentCaptor.forClass(Throwable.class);
-        
+
         stateManager.setErrorHandler(errorHandler);
         stateManagerInit();
         assertEquals(HomeState.class, stateManager.getCurrentState().getClass());
         doAction("TestExceptionOnArriveAction");
-        
+
         verify(errorHandler).handleError(eq(stateManager), exArgument.capture());
-        
+
         assertEquals(ExceptionOnArriveState.class, stateManager.getCurrentState().getClass());
         assertEquals(FlowException.class, exArgument.getValue().getClass());
         assertEquals(InvocationTargetException.class, exArgument.getValue().getCause().getClass());
         assertEquals(NullPointerException.class, exArgument.getValue().getCause().getCause().getClass());
         assertTrue(exArgument.getValue().getCause().getCause().getMessage().contains("arrive"));
     }
-    
+
     @Test
     public void testOnDepartThatThrowsException( ) {
         stateManagerInit();
@@ -789,13 +790,13 @@ public class StateManagerTest {
             stateManager.setErrorHandler(existingErrorHandler);
         }
     }
-    
+
     @Test
     public void testOnDepartThatThrowsException_WithErrorHandler( ) {
         ArgumentCaptor<Throwable> exArgument = ArgumentCaptor.forClass(Throwable.class);
-        
+
         stateManager.setErrorHandler(errorHandler);
-        
+
         stateManagerInit();
         assertEquals(HomeState.class, stateManager.getCurrentState().getClass());
         doAction("TestExceptionOnDepartAction");
@@ -856,7 +857,7 @@ public class StateManagerTest {
         }
 
     }
-    
+
     @Test
     public void testExceptionInActionHandler_WithErrorHandler( ) {
         ArgumentCaptor<Throwable> exArgument = ArgumentCaptor.forClass(Throwable.class);
@@ -868,7 +869,7 @@ public class StateManagerTest {
         assertEquals(ExceptionInActionHandlerState.class, stateManager.getCurrentState().getClass());
 
         doAction("ThrowsExceptionAction");
-        
+
         verify(errorHandler).handleError(eq(stateManager), exArgument.capture());
         assertEquals(FlowException.class, exArgument.getValue().getClass());
         assertEquals(InvocationTargetException.class, exArgument.getValue().getCause().getClass());
@@ -882,5 +883,16 @@ public class StateManagerTest {
         doAction("ToSubFlowWithActionActionHandlerForTerminatingState");
         doAction("TerminatingAction");
         assertTrue(stateManager.getScopeValue("actionHandlerCalled"));
+    }
+
+    @Test
+    public void testOverrideStateThatExtendsBaseState() {
+        stateManagerInit();
+        assertEquals(HomeState.class, stateManager.getCurrentState().getClass());
+        doAction("CheckOverrideState");
+        TestStates.OverrideState overrideState = (TestStates.OverrideState) stateManager.getCurrentState();
+        assertEquals(TestStates.OverrideState.class, overrideState.getClass());
+        doAction("Something");
+        assertEquals(overrideState.message, "Override state message");
     }
 }

--- a/openpos-flow/src/test/java/org/jumpmind/pos/core/flow/TestStates.java
+++ b/openpos-flow/src/test/java/org/jumpmind/pos/core/flow/TestStates.java
@@ -632,8 +632,8 @@ public class TestStates {
         }
     }
 
-    @StateOverride(originalState = TestStates.HomeState.class)
-    public static class OverrideState extends SimpleBaseState {
+    @StateOverride(originalState = TestStates.SimpleBaseState.class)
+    public static class OverrideSimpleState extends SimpleBaseState {
 
         @Override
         protected void doLogic() {

--- a/openpos-flow/src/test/java/org/jumpmind/pos/core/flow/TestStates.java
+++ b/openpos-flow/src/test/java/org/jumpmind/pos/core/flow/TestStates.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import lombok.extern.slf4j.Slf4j;
 import org.jumpmind.pos.server.model.Action;
 
 public class TestStates {
@@ -14,7 +15,7 @@ public class TestStates {
 
         @Out(scope = ScopeType.Conversation, required = false)
         private String optionalInjectionFullfiled = "optionalInjectionFullfiled";
-        
+
         boolean departToSubflowCalled = false;
         boolean departStateCalled = false;
         boolean departGeneralCalled = false;
@@ -32,26 +33,31 @@ public class TestStates {
         public void arrivedAtHome(Action action) {
             arriveCalled = true;
         }
-        
+
         @OnDepart
         public void depart(Action action) {
             departGeneralCalled = true;
-        }          
-        
+        }
+
         @OnDepart(toAnotherState=false)
         public void departToSubflow() {
             departToSubflowCalled = true;
         }
-        
+
         @OnDepart(toSubflow=false)
         public void departState(Action action) {
             departStateCalled = true;
             departAction = action;
         }
-        
+
         @ActionHandler
         protected void onReturn() {
-            
+
+        }
+
+        @ActionHandler
+        protected void onSell(Action action) {
+            stateManager.doAction(action);
         }
     }
 
@@ -166,32 +172,32 @@ public class TestStates {
     public static class SubStateFlowScopePropogation1 implements IState {
         @In(scope = ScopeType.Device)
         private IStateManager stateManager;
-        
+
         @Out(scope = ScopeType.Flow)
         private String flowScopeValue1;
-        
+
         @Override
         public void arrive(Action action) {
             flowScopeValue1 = "flowScopeValue1";
             //stateManager.doAction("SubStateFlowScopePropogation2Action");
         }
-        
+
         @ActionHandler
         public void onSubStateFlowScopePropogation2DONE(Action action) {
-            
+
         }
     }
-    
+
     public static class SubStateFlowScopePropogation2 implements IState {
         @In(scope = ScopeType.Device)
         private IStateManager stateManager;
-        
+
         @In(scope = ScopeType.Flow)
         private String flowScopeValue1; // should be inherited.
-        
+
         @Out(scope = ScopeType.Flow)
         private String flowScopeValue2;
-        
+
         @Override
         public void arrive(Action action) {
             flowScopeValue2 = "flowScopeValue2";
@@ -199,7 +205,7 @@ public class TestStates {
             //stateManager.doAction("SubStateFlowScopePropogation2DONE");
         }
     }
-    
+
     public static class SubStateReturnsWithTransitionState implements IState {
         @In(scope = ScopeType.Device)
         private IStateManager stateManager;
@@ -329,7 +335,7 @@ public class TestStates {
     public static class StackOverflowState extends AbstractStackOverflowState {
 
     }
-    
+
     public static class MultiReturnActionTestState implements IState {
         @In(scope = ScopeType.Device)
         private IStateManager stateManager;
@@ -337,29 +343,29 @@ public class TestStates {
         public void arrive(Action action) {
 
         }
-    }    
+    }
     public static class MultiReturnActionInitialState implements IState {
         @In(scope = ScopeType.Device)
         private IStateManager stateManager;
         @Override
         public void arrive(Action action) {
-            
+
         }
-    }    
+    }
     public static class MultiReturnAction1State implements IState {
         @In(scope = ScopeType.Device)
         private IStateManager stateManager;
         @Override
         public void arrive(Action action) {
-            
+
         }
-    }    
+    }
     public static class MultiReturnAction2State implements IState {
         @In(scope = ScopeType.Device)
         private IStateManager stateManager;
         @Override
         public void arrive(Action action) {
-            
+
         }
     }
     public static class SetVariablesState {
@@ -407,20 +413,20 @@ public class TestStates {
     }
 
     public static class StateWithBeforeActionMethod {
-        
+
         boolean onAction1Invoked = false;
         boolean beforeActionInvoked = false;
 
         @OnArrive
         public void arrive() {
         }
-        
+
         @ActionHandler
         public void onAction1(Action action) {
             assertTrue(this.beforeActionInvoked);
             this.onAction1Invoked = true;
         }
-        
+
         @BeforeAction
         public void onBeforeAnyAction(Action action) {
             assertFalse(this.beforeActionInvoked);
@@ -432,15 +438,15 @@ public class TestStates {
     }
 
     public static class StateWithBeforeActionMethodThatThrowsException extends StateWithBeforeActionMethod {
-        
+
         @BeforeAction
         @Override
         public void onBeforeAnyAction(Action action) {
-            throw new RuntimeException("Throwing this exception should halt execution of the action since default value of failOnException is true"); 
+            throw new RuntimeException("Throwing this exception should halt execution of the action since default value of failOnException is true");
         }
-        
+
     }
-    
+
     public static class StateWithMultipleBeforeActionMethods {
 
         boolean onAction1Invoked = false;
@@ -451,7 +457,7 @@ public class TestStates {
         @OnArrive
         public void arrive() {
         }
-        
+
         @ActionHandler
         public void onAction1(Action action) {
             assertTrue(this.beforeAction_AInvoked);
@@ -459,8 +465,8 @@ public class TestStates {
             assertTrue(this.beforeAction_CInvoked);
             this.onAction1Invoked = true;
         }
-        
-        
+
+
         @BeforeAction(order=2)
         public void onBeforeAnyAction_B(Action action) {
             assertEquals("Action1", action.getName());
@@ -470,7 +476,7 @@ public class TestStates {
             assertTrue(this.beforeAction_CInvoked);
             this.beforeAction_BInvoked = true;
         }
-        
+
         @BeforeAction(order=1)
         public void onBeforeAnyAction_A(Action action) {
             assertEquals("Action1", action.getName());
@@ -478,9 +484,9 @@ public class TestStates {
             assertFalse(this.beforeAction_AInvoked);
             assertFalse(this.beforeAction_BInvoked);
             assertTrue(this.beforeAction_CInvoked);
-            this.beforeAction_AInvoked = true;            
+            this.beforeAction_AInvoked = true;
         }
-        
+
         @BeforeAction(order=-1)
         public void onBeforeAnyAction_C(Action action) {
             assertEquals("Action1", action.getName());
@@ -488,11 +494,11 @@ public class TestStates {
             assertFalse(this.beforeAction_AInvoked);
             assertFalse(this.beforeAction_BInvoked);
             assertFalse(this.beforeAction_CInvoked);
-            this.beforeAction_CInvoked = true;                        
+            this.beforeAction_CInvoked = true;
         }
-        
+
     }
-    
+
     public static class StateWithMultipleBeforeActionAndFailOnExceptionIsFalse extends StateWithMultipleBeforeActionMethods {
         boolean beforeAction_DInvoked = false;
 
@@ -529,9 +535,9 @@ public class TestStates {
         }
 
     }
-    
+
     public static class GlobalActionHandler {
-        
+
         @OnGlobalAction
         public void onSomeGlobalAction(Action action) {
             Runnable r = action.getData();
@@ -541,14 +547,14 @@ public class TestStates {
     }
 
     public static class GlobalActionHandlerWithException {
-        
+
         @OnGlobalAction
         public void onSomeGlobalActionWithException(Action action) {
             assertEquals("SomeGlobalActionWithException", action.getName());
             throw new NullPointerException("Throwing NPE on Global Action");
         }
     }
-    
+
     public static class ExceptionOnArriveState {
         @OnArrive
         public void arrive(Action action) {
@@ -561,13 +567,13 @@ public class TestStates {
         @OnArrive
         public void arrive() {
         }
-        
+
         @OnDepart
         public void depart() {
             throw new NullPointerException("Raising exception on departure");
         }
     }
-    
+
     public static class ExceptionInActionHandlerState {
         @OnArrive
         public void arrive() {
@@ -604,5 +610,34 @@ public class TestStates {
 
         }
     }
-    
+
+    public static class SimpleBaseState {
+        @In(scope = ScopeType.Device)
+        private IStateManager stateManager;
+
+        public String message;
+
+        @OnArrive
+        public void arrive() {
+        }
+
+        protected void doLogic() {
+            this.message = "Base state message";
+        }
+
+        @ActionHandler
+        public void onSomething(Action action) {
+            doLogic();
+            stateManager.doAction(action);
+        }
+    }
+
+    @StateOverride(originalState = TestStates.HomeState.class)
+    public static class OverrideState extends SimpleBaseState {
+
+        @Override
+        protected void doLogic() {
+            this.message = "Override state message";
+        }
+    }
 }


### PR DESCRIPTION
### Summary
Found an issue that would hang the application when attempting to extend an existing state and use the ActionHandler defined in the SuperClass. Since at runtime the stack trace will have the actual class that is performing the action changed the isCalledFrom state method to check if the class is in the current state's hierarchy instead of doing an exact class comparison. 