### PR TITLE
Customer details membership configuration

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/customer-details-dialog/customer-details-dialog.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/customer-details-dialog/customer-details-dialog.component.html
@@ -34,14 +34,16 @@
             </div>
         </div>
     </app-content-card>
-    <div class="tabs" [ngClass]="{'tabs': true, 'mobile': (isMobile | async)}" responsive-class>
+    <div *ngIf="(isMobile | async) || (!(isMobile | async) && (screen.rewardTabEnabled || screen.rewardHistoryTabEnabled))"
+         class="tabs" [ngClass]="{'tabs': true, 'mobile': (isMobile | async)}" responsive-class>
         <mat-tab-group mat-align-tabs="start" animationDuration="0ms">
             <mat-tab class="contactTab" [label]="screen.contactLabel" *ngIf="isMobile | async">
                 <mat-card class="customer-details muted-color">
                     <app-customer-information [customer]="screen.customer"></app-customer-information>
                 </mat-card>
             </mat-tab>
-            <mat-tab class="rewardsTab" [label]="getRewardsLabel()">
+            <mat-tab *ngIf="screen.rewardTabEnabled"
+                    class="rewardsTab" [label]="getRewardsLabel()">
                 <mat-card [ngClass]="{'rewardsContent': true, 'no-promotions': !(screen.customer.rewards && screen.customer.rewards.length)}">
                     <div *ngIf="(screen.customer.rewards && screen.customer.rewards.length)" >
                         <div *ngFor="let reward of screen.customer.rewards" class="line">
@@ -53,7 +55,8 @@
                     </div>
                 </mat-card>
             </mat-tab>
-            <mat-tab class="rewardsHistoryTab" [label]="screen.rewardHistoryLabel">
+            <mat-tab *ngIf="screen.rewardHistoryTabEnabled"
+                    class="rewardsHistoryTab" [label]="screen.rewardHistoryLabel">
                 <mat-card [ngClass]="{'rewardsHistoryContent': true, 'no-promotions': !(screen.customer.rewardHistory && screen.customer.rewardHistory.length)}">
                     <div *ngIf="(screen.customer.rewardHistory && screen.customer.rewardHistory.length)" >
                         <div *ngFor="let reward of screen.customer.rewardHistory" class="line">

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/customer-details-dialog/customer-details-dialog.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/customer-details-dialog/customer-details-dialog.component.html
@@ -75,6 +75,7 @@
     <app-secondary-button responsive-class
                           class="unlink"
                           *ngIf="screen.unlinkButton"
+                          [disabled]="!screen.unlinkButton?.enabled"
                           [actionItem]="screen.unlinkButton"
                           (actionClick)="doAction(screen.unlinkButton)"
                           (click)="doAction(screen.unlinkButton)">
@@ -83,6 +84,7 @@
     <app-secondary-button responsive-class
                           class="edit"
                           *ngIf="screen.editButton"
+                          [disabled]="!screen.editButton?.enabled"
                           [actionItem]="screen.editButton"
                           (actionClick)="doAction(screen.editButton)"
                           (click)="doAction(screen.editButton)">
@@ -91,6 +93,7 @@
     <app-primary-button responsive-class
                         class="done"
                         *ngIf="screen.doneButton"
+                        [disabled]="!screen.doneButton?.enabled"
                         [actionItem]="screen.doneButton"
                         (actionClick)="doAction(screen.doneButton)"
                         (click)="doAction(screen.doneButton)">

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/customer-details-dialog/customer-details-dialog.component.spec.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/customer-details-dialog/customer-details-dialog.component.spec.ts
@@ -73,7 +73,10 @@ describe('CustomerDetailsDialog', () => {
       }).compileComponents();
       fixture = TestBed.createComponent(CustomerDetailsDialogComponent);
       component = fixture.componentInstance;
-      component.screen = { customer } as CustomerDetailsDialogInterface;
+      component.screen = { customer,
+        rewardTabEnabled: true,
+        rewardHistoryTabEnabled: true
+      } as CustomerDetailsDialogInterface;
       fixture.detectChanges();
     });
 
@@ -184,9 +187,6 @@ describe('CustomerDetailsDialog', () => {
         });
       })
       describe('tabs', () => {
-        it('does not have the mobile class', () => {
-
-        });
         it('displays the tabs section', () => {
           const tabsElement = fixture.debugElement.query(By.css('.tabs'));
           expect(tabsElement.nativeElement).toBeDefined();
@@ -353,7 +353,10 @@ describe('CustomerDetailsDialog', () => {
       }).compileComponents();
       fixture = TestBed.createComponent(CustomerDetailsDialogComponent);
       component = fixture.componentInstance;
-      component.screen = { customer } as CustomerDetailsDialogInterface;
+      component.screen = { customer,
+        rewardTabEnabled: true,
+        rewardHistoryTabEnabled: true
+      } as CustomerDetailsDialogInterface;
       fixture.detectChanges();
     });
     describe('template', () => {
@@ -361,6 +364,13 @@ describe('CustomerDetailsDialog', () => {
         it('has the mobile class', () => {
           const tabsElement = fixture.debugElement.query(By.css('.tabs'));
           expect(tabsElement.nativeElement.classList).toContain('mobile');
+        });
+
+        it('always shows the tab section', () => {
+          component.screen.rewardTabEnabled = false;
+          component.screen.rewardHistoryTabEnabled = false;
+          fixture.detectChanges();
+          validateExist(fixture, '.tabs');
         });
       });
     });
@@ -387,7 +397,10 @@ describe('CustomerDetailsDialog', () => {
       }).compileComponents();
       fixture = TestBed.createComponent(CustomerDetailsDialogComponent);
       component = fixture.componentInstance;
-      component.screen = { customer } as CustomerDetailsDialogInterface;
+      component.screen = { customer,
+        rewardTabEnabled: true,
+        rewardHistoryTabEnabled: true
+      } as CustomerDetailsDialogInterface;
       fixture.detectChanges();
     });
     describe('template', () => {
@@ -395,6 +408,27 @@ describe('CustomerDetailsDialog', () => {
         it('does not has the mobile class', () => {
           const tabsElement = fixture.debugElement.query(By.css('.tabs'));
           expect(tabsElement.nativeElement.classList).not.toContain('mobile');
+        });
+
+        it('does not shows the tab section when both rewardTabEnabled and rewardHistoryTab are false', () => {
+          component.screen.rewardTabEnabled = false;
+          component.screen.rewardHistoryTabEnabled = false;
+          fixture.detectChanges();
+          validateDoesNotExist(fixture, '.tabs');
+        });
+
+        it('it shows when rewardTabEnabled is true', () => {
+          component.screen.rewardTabEnabled = true;
+          component.screen.rewardHistoryTabEnabled = false;
+          fixture.detectChanges();
+          validateExist(fixture, '.tabs');
+        });
+
+        it('it shows when rewardHistoryTabEnabled is true', () => {
+          component.screen.rewardTabEnabled = false;
+          component.screen.rewardHistoryTabEnabled = true;
+          fixture.detectChanges();
+          validateExist(fixture, '.tabs');
         });
       });
     });

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/customer-details-dialog/customer-details-dialog.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/customer-details-dialog/customer-details-dialog.interface.ts
@@ -13,7 +13,9 @@ export interface CustomerDetailsDialogInterface extends IAbstractScreen {
     doneButton: IActionItem;
     contactLabel: string;
     rewardsLabel: string;
+    rewardTabEnabled: boolean;
     rewardHistoryLabel: string;
+    rewardHistoryTabEnabled: boolean;
     noPromotionsText: string;
     noMembershipsFoundLabel: string;
 

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/CustomerDetailsUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/CustomerDetailsUIMessage.java
@@ -17,6 +17,9 @@ public class CustomerDetailsUIMessage extends UIMessage {
     private UICustomerDetailsItem customer;
 
     private Boolean membershipEnabled;
+    private Boolean rewardTabEnabled;
+    private Boolean rewardHistoryTabEnabled;
+
     private String membershipLabel;
     private String contactLabel;
     private String noPromotionsText;


### PR DESCRIPTION
### Summary
Moved configuration location for membership details and added new properties to control the displaying of reward details and reward history details on the customer details dialog.

### Screenshots
openpos.customer.membership.rewardTab.enabled: false
openpos.customer.membership.rewardHistoryTab.enabled: false
![image](https://user-images.githubusercontent.com/2406987/112327126-897dd500-8c8b-11eb-90d2-e4b5f2c7f842.png)

openpos.customer.membership.rewardTab.enabled: true
openpos.customer.membership.rewardHistoryTab.enabled: true
![image](https://user-images.githubusercontent.com/2406987/112326375-d9a86780-8c8a-11eb-98eb-b50b9a4b83d4.png)

openpos.customer.membership.rewardTab.enabled: true
openpos.customer.membership.rewardHistoryTab.enabled: false
![image](https://user-images.githubusercontent.com/2406987/112327475-d8c40580-8c8b-11eb-80c1-92d1e81e90d1.png)

openpos.customer.membership.rewardTab.enabled: false
openpos.customer.membership.rewardHistoryTab.enabled: true
![image](https://user-images.githubusercontent.com/2406987/112326774-3146d300-8c8b-11eb-9344-cadf04c68e44.png)

When button is configured to be disabled
![image](https://user-images.githubusercontent.com/2406987/112328407-acf54f80-8c8c-11eb-93fd-0c731b9bfa80.png)
