### PR TITLE
Multiple item counts

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/return/_return-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/return/_return-theme.scss
@@ -2,7 +2,7 @@
     $app-primary: mat-color(map-get($theme, returns));
     $app-accent: mat-color(map-get($theme, accent));
     $app-warn: mat-color(map-get($theme, warn));
-    
+
     $contrast: mat-color(map-get($theme, returns), default-contrast);
     $dark: map-get($mat-grey, 600);
 
@@ -25,7 +25,7 @@
                 }
             }
 
-            .item-count {
+            .item-counts {
                 background-color:$app-primary;
                 color:$contrast;
             }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel-theme.scss
@@ -10,7 +10,7 @@
         }
     }
 
-    .item-count {
+    .item-counts {
         background-color: $item-count-background;
     }
 
@@ -25,7 +25,7 @@
             border-color: $disabled-border;
         }
     }
-    
+
     .sale-total-total {
         border-color: $border;
     }
@@ -44,7 +44,7 @@
             @extend %text-sm;
             .mat-button-wrapper {
                 display: grid;
-                
+
                 div {
                     line-height: normal;
                 }
@@ -68,11 +68,11 @@
             @extend %text-sm;
             .mat-button-wrapper {
                 display: grid;
-                
+
                 div {
                     line-height: normal;
                 }
-            }    
+            }
         }
 
         .sale-total-employee-sale-name {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.html
@@ -61,12 +61,14 @@
                 {{screenData.statusMessage}}
             </app-stamp>
         </div>
-        <div *ngIf="screenData.itemCount" class="item-count">
-            <div *ngIf="screenData.itemCount.amount" responsive-class class="item-count-amount">
-                {{screenData.itemCount.amount}}
-            </div>
-            <div *ngIf="screenData.itemCount.name" responsive-class class="item-count-name">
-                <span *ngIf="screenData.itemCount.amount">&nbsp;</span>{{screenData.itemCount.name}}
+        <div class="item-counts">
+            <div *ngFor="let itemCount of screenData.itemCounts" class="item-count">
+                <div *ngIf="itemCount.amount" responsive-class class="item-count-amount">
+                    {{itemCount.amount}}
+                </div>
+                <div *ngIf="itemCount.name" responsive-class class="item-count-name">
+                    <span *ngIf="itemCount.amount">&nbsp;</span>{{itemCount.name}}
+                </div>
             </div>
         </div>
         <div class="sale-total-content" responsive-class>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.html
@@ -61,7 +61,7 @@
                 {{screenData.statusMessage}}
             </app-stamp>
         </div>
-        <div class="item-counts">
+        <div *ngIf="screenData.itemCounts" class="item-counts">
             <div *ngFor="let itemCount of screenData.itemCounts" class="item-count">
                 <div *ngIf="itemCount.amount" responsive-class class="item-count-amount">
                     {{itemCount.amount}}

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
@@ -83,15 +83,13 @@ app-scandit-native {
     grid-area: item-counts;
     display: flex;
     flex-direction: column;
-    margin-top: 12px;
-    margin-bottom: 12px;
+    padding: 8px 0;
     .item-count {
         display: flex;
         height: fit-content;
         justify-content: center;
         align-items: center;
-        padding-top: 4px;
-        padding-bottom: 4px;
+        padding: 4px 0;
     }
 }
 .status-stamp {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
@@ -79,14 +79,20 @@ app-scandit-native {
     background: red;
 }
 
-.item-count {
-    grid-area: item-count;
+.item-counts {
+    grid-area: item-counts;
     display: flex;
-    height: fit-content;
-    padding-top: 12px;
-    padding-bottom: 12px;
-    justify-content: center;
-    align-items: center;
+    flex-direction: column;
+    margin-top: 12px;
+    margin-bottom: 12px;
+    .item-count {
+        display: flex;
+        height: fit-content;
+        justify-content: center;
+        align-items: center;
+        padding-top: 4px;
+        padding-bottom: 4px;
+    }
 }
 .status-stamp {
     grid-area: status-stamp;
@@ -100,7 +106,7 @@ app-scandit-native {
 .sale-total-background {
     grid-template-areas:
         "status-stamp"
-        "item-count"
+        "item-counts"
         "content"
         "buttons";
     grid-template-rows: 0 min-content minmax(0, 1fr) min-content;

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.interface.ts
@@ -6,7 +6,7 @@ import {Membership} from "../membership-display/memebership-display.interface";
 export interface SaleTotalPanelInterface extends IAbstractScreen {
     totals: ITotal[];
     grandTotal: ITotal;
-    itemCount: ITotal;
+    itemCounts: ITotal[];
     checkoutButton: IActionItem;
     helpButton: IActionItem;
     logoutButton: IActionItem;

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/ReturnUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/ReturnUIMessage.java
@@ -19,7 +19,7 @@ public class ReturnUIMessage extends UIMessage {
 
     private List<Total> totals;
     private Total grandTotal;
-    private Total itemCount;
+    private List<Total> itemCounts;
 
     private List<TransactionReceipt> receipts = new ArrayList<>();
 
@@ -56,5 +56,12 @@ public class ReturnUIMessage extends UIMessage {
             this.receipts = new ArrayList<>();
         }
         this.receipts.add(receipt);
+    }
+
+    public void addItemCount(Total total) {
+        if (itemCounts == null) {
+            itemCounts = new ArrayList<>();
+        }
+        itemCounts.add(total);
     }
 }

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/SaleUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/SaleUIMessage.java
@@ -20,8 +20,8 @@ public class SaleUIMessage extends UIMessage {
 
     private List<Total> totals;
     private Total grandTotal;
-    private Total itemCount;
-    
+    private List<Total> itemCounts;
+
 
     private List<OrderSummary> orders;
     private ActionItem removeOrderAction;
@@ -79,8 +79,14 @@ public class SaleUIMessage extends UIMessage {
         this.taxExemptCertificateDetail = new AdditionalLabel(label, value);
     }
 
-    public void setItemCount(String name, String amount) {
-        this.setItemCount(new Total(name, amount));
+    public void addItemCount(Total total) {
+        if (itemCounts == null) {
+            itemCounts = new ArrayList<>();
+        }
+        itemCounts.add(total);
     }
-    
+
+    public void addItemCount(String name, String amount) {
+        addItemCount(new Total(name, amount));
+    }
 }


### PR DESCRIPTION
AE has a desire to split out the number of order items and sell items in a transaction. Adding support to the openpos framework to allow multiple item counts.

### Summary
Adding support for multiple item counts on the totals panel.

