### PR TITLE
Create AddressUIMessage that AutoCompleteAddressUIMessage extends from. PCOM-2289

### DIFF
--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/AddressUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/AddressUIMessage.java
@@ -18,7 +18,6 @@ public class AddressUIMessage extends DynamicFormUIMessage {
     private StatusStripPart statusStrip = new StatusStripPart();
 
     public AddressUIMessage() {
-        setScreenType(UIMessageType.DYNAMIC_FORM);
         ActionItem submitButton = new ActionItem("Next", "Next", IconType.Forward);
         submitButton.setKeybind(KeyConstants.KEY_ENTER);
         setSubmitButton(submitButton);

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/AddressUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/AddressUIMessage.java
@@ -24,10 +24,8 @@ public class AddressUIMessage extends DynamicFormUIMessage {
     }
 
     public AddressUIMessage(String screenType) {
+        this();
         setScreenType(screenType);
-        ActionItem submitButton = new ActionItem("Next", "Next", IconType.Forward);
-        submitButton.setKeybind(KeyConstants.KEY_ENTER);
-        setSubmitButton(submitButton);
     }
 
     public void addDefaultAddressFields() {
@@ -39,6 +37,16 @@ public class AddressUIMessage extends DynamicFormUIMessage {
         this.getForm().addTextField("country", "Country", "", true);
     }
 
+    public void addDefaultAddressFields(String streetAddress, String addressLine2, String locality, String state, String postalCode, String country) {
+        this.getForm().addTextField("streetAddress", "Street Address", streetAddress, true);
+        this.getForm().addTextField("addressLine2", "Address Line 2", addressLine2, false);
+        this.getForm().addTextField("locality", "City", locality, true);
+        this.getForm().addTextField("state", "State", state, true);
+        this.getForm().addTextField("postalCode", "Postal Code", postalCode, true);
+        this.getForm().addTextField("country", "Country", country, true);
+    }
+
+
     public void addAddressFieldsWithComboState(List<String> states) {
         this.getForm().addTextField("streetAddress", "Street Address", "", true);
         this.getForm().addTextField("addressLine2", "Address Line 2", "", false);
@@ -46,6 +54,15 @@ public class AddressUIMessage extends DynamicFormUIMessage {
         this.getForm().addComboBox("state", "State", states, true);
         this.getForm().addTextField("postalCode", "Postal Code", "", true);
         this.getForm().addTextField("country", "Country", "", true);
+    }
+
+    public void addAddressFieldsWithComboState(List<String> states, String streetAddress, String addressLine2, String locality, String state, String postalCode, String country) {
+        this.getForm().addTextField("streetAddress", "Street Address", streetAddress, true);
+        this.getForm().addTextField("addressLine2", "Address Line 2", addressLine2, false);
+        this.getForm().addTextField("locality", "City", locality, true);
+        this.getForm().addComboBox("state", "State", state, states, true);
+        this.getForm().addTextField("postalCode", "Postal Code", postalCode, true);
+        this.getForm().addTextField("country", "Country", country, true);
     }
 
     public BaconStripPart getBaconStrip() {

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/AddressUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/AddressUIMessage.java
@@ -1,0 +1,68 @@
+package org.jumpmind.pos.core.ui.message;
+
+import org.jumpmind.pos.core.ui.ActionItem;
+import org.jumpmind.pos.core.ui.IconType;
+import org.jumpmind.pos.core.ui.KeyConstants;
+import org.jumpmind.pos.core.ui.messagepart.BaconStripPart;
+import org.jumpmind.pos.core.ui.messagepart.StatusStripPart;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AddressUIMessage extends DynamicFormUIMessage {
+
+    private static final long serialVersionUID = 1L;
+
+    private BaconStripPart baconStrip = new BaconStripPart();
+    private List<ActionItem> sausageLinks = new ArrayList<>();
+    private StatusStripPart statusStrip = new StatusStripPart();
+
+    public AddressUIMessage() {
+        setScreenType(UIMessageType.DYNAMIC_FORM);
+        ActionItem submitButton = new ActionItem("Next", "Next", IconType.Forward);
+        submitButton.setKeybind(KeyConstants.KEY_ENTER);
+        setSubmitButton(submitButton);
+    }
+
+    public void addDefaultAddressFields() {
+        this.getForm().addTextField("streetAddress", "Street Address", "", true);
+        this.getForm().addTextField("addressLine2", "Address Line 2", "", false);
+        this.getForm().addTextField("locality", "City", "", true);
+        this.getForm().addTextField("state", "State", "", true);
+        this.getForm().addTextField("postalCode", "Postal Code", "", true);
+        this.getForm().addTextField("country", "Country", "", true);
+    }
+
+    public void addAddressFieldsWithComboState(List<String> states) {
+        this.getForm().addTextField("streetAddress", "Street Address", "", true);
+        this.getForm().addTextField("addressLine2", "Address Line 2", "", false);
+        this.getForm().addTextField("locality", "City", "", true);
+        this.getForm().addComboBox("state", "State", states, true);
+        this.getForm().addTextField("postalCode", "Postal Code", "", true);
+        this.getForm().addTextField("country", "Country", "", true);
+    }
+
+    public BaconStripPart getBaconStrip() {
+        return baconStrip;
+    }
+
+    public void setBaconStrip(BaconStripPart baconStrip) {
+        this.baconStrip = baconStrip;
+    }
+
+    public List<ActionItem> getSausageLinks() {
+        return sausageLinks;
+    }
+
+    public void setSausageLinks(List<ActionItem> sausageLinks) {
+        this.sausageLinks = sausageLinks;
+    }
+
+    public StatusStripPart getStatusStrip() {
+        return statusStrip;
+    }
+
+    public void setStatusStrip(StatusStripPart statusStrip) {
+        this.statusStrip = statusStrip;
+    }
+}

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/AddressUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/AddressUIMessage.java
@@ -24,6 +24,13 @@ public class AddressUIMessage extends DynamicFormUIMessage {
         setSubmitButton(submitButton);
     }
 
+    public AddressUIMessage(String screenType) {
+        setScreenType(screenType);
+        ActionItem submitButton = new ActionItem("Next", "Next", IconType.Forward);
+        submitButton.setKeybind(KeyConstants.KEY_ENTER);
+        setSubmitButton(submitButton);
+    }
+
     public void addDefaultAddressFields() {
         this.getForm().addTextField("streetAddress", "Street Address", "", true);
         this.getForm().addTextField("addressLine2", "Address Line 2", "", false);

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/AutoCompleteAddressUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/AutoCompleteAddressUIMessage.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 
-public class AutoCompleteAddressUIMessage extends DynamicFormUIMessage implements IHasAutoCompleteAddress {
+public class AutoCompleteAddressUIMessage extends AddressUIMessage implements IHasAutoCompleteAddress {
 
     private static final long serialVersionUID = 1L;
 

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/AutoCompleteAddressUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/AutoCompleteAddressUIMessage.java
@@ -13,59 +13,7 @@ import java.util.List;
 
 public class AutoCompleteAddressUIMessage extends AddressUIMessage implements IHasAutoCompleteAddress {
 
-    private static final long serialVersionUID = 1L;
-
-    private BaconStripPart baconStrip = new BaconStripPart();
-    private List<ActionItem> sausageLinks = new ArrayList<>();
-    private StatusStripPart statusStrip = new StatusStripPart();
-
     public AutoCompleteAddressUIMessage() {
-        setScreenType(UIMessageType.AUTO_COMPLETE_ADDRESS);
-        ActionItem submitButton = new ActionItem("Next", "Next", IconType.Forward);
-        submitButton.setKeybind(KeyConstants.KEY_ENTER);
-        setSubmitButton(submitButton);
+        super(UIMessageType.AUTO_COMPLETE_ADDRESS);
     }
-
-    public void addDefaultAddressFields() {
-        this.getForm().addTextField("streetAddress", "Street Address", "", true);
-        this.getForm().addTextField("addressLine2", "Address Line 2", "", false);
-        this.getForm().addTextField("locality", "City", "", true);
-        this.getForm().addTextField("state", "State", "", true);
-        this.getForm().addTextField("postalCode", "Postal Code", "", true);
-        this.getForm().addTextField("country", "Country", "", true);
-    }
-
-    public void addAddressFieldsWithComboState(List<String> states) {
-        this.getForm().addTextField("streetAddress", "Street Address", "", true);
-        this.getForm().addTextField("addressLine2", "Address Line 2", "", false);
-        this.getForm().addTextField("locality", "City", "", true);
-        this.getForm().addComboBox("state", "State", states, true);
-        this.getForm().addTextField("postalCode", "Postal Code", "", true);
-        this.getForm().addTextField("country", "Country", "", true);
-    }
-
-    public BaconStripPart getBaconStrip() {
-        return baconStrip;
-    }
-
-    public void setBaconStrip(BaconStripPart baconStrip) {
-        this.baconStrip = baconStrip;
-    }
-
-    public List<ActionItem> getSausageLinks() {
-        return sausageLinks;
-    }
-
-    public void setSausageLinks(List<ActionItem> sausageLinks) {
-        this.sausageLinks = sausageLinks;
-    }
-
-    public StatusStripPart getStatusStrip() {
-        return statusStrip;
-    }
-
-    public void setStatusStrip(StatusStripPart statusStrip) {
-        this.statusStrip = statusStrip;
-    }
-
 }


### PR DESCRIPTION
### Summary
Abstract the properties of AutoCompleteAddressUIMessage to a generic AddressUIMessage that will not implement the IHasAutoComplete interface. This change will allow for address forms that do not utilize the google api auto complete functionality.