### PR TITLE
Add support for training mode in DML queries

### DIFF
--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/DBSession.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/DBSession.java
@@ -54,12 +54,12 @@ public class DBSession {
     private TypedProperties sessionContext;
     private NamedParameterJdbcTemplate jdbcTemplate;
     private QueryTemplates queryTemplates;
-    private Map<String, DmlTemplate> dmlTemplates;
+    private DmlTemplates dmlTemplates;
     private TagHelper tagHelper;
     private AugmenterHelper augmenterHelper;
 
     public DBSession(String catalogName, String schemaName, DatabaseSchema databaseSchema, IDatabasePlatform databasePlatform,
-                     TypedProperties sessionContext, QueryTemplates queryTemplates, Map<String, DmlTemplate> dmlTemplates,
+                     TypedProperties sessionContext, QueryTemplates queryTemplates, DmlTemplates dmlTemplates,
                      TagHelper tagHelper, AugmenterHelper augmenterHelper) {
         super();
         this.dmlTemplates = dmlTemplates;
@@ -206,7 +206,7 @@ public class DBSession {
     }
 
     public int executeDml(String namedDml, Object... params) {
-        DmlTemplate template = dmlTemplates.get(namedDml);
+        DmlTemplate template = this.getDmlTemplate(namedDml);
         if (template != null && isNotBlank(template.getDml())) {
             params = Arrays.stream(params).
                     map(p -> p instanceof Boolean ? (((Boolean) p ? 1 : 0)) : p).
@@ -319,6 +319,9 @@ public class DBSession {
         return wrapper;
     }
 
+    protected DmlTemplate getDmlTemplate(String templateName) {
+        return this.dmlTemplates.getDmlTemplate(databaseSchema.getDeviceMode(), templateName);
+    }
     @SuppressWarnings("unchecked")
     protected <T> QueryTemplate getQueryTemplate(Query<T> query) {
         QueryTemplate queryTemplate = new QueryTemplate();

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/AbstractSqlTemplates.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/AbstractSqlTemplates.java
@@ -1,0 +1,39 @@
+package org.jumpmind.pos.persist.impl;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jumpmind.db.sql.InvalidSqlException;
+
+import java.util.List;
+
+public abstract class AbstractSqlTemplates {
+
+    public abstract void replaceModelClassNamesWithTableNames(DatabaseSchema dbSchema, List<Class<?>> modelClassList, boolean validateTablesInQueries);
+    protected abstract String getTemplateSuffix();
+
+    protected String replaceClassModelNameInSqlText(String sqlText, String modelClassName, String tableName)  {
+        if ((sqlText != null) && StringUtils.indexOf(sqlText, modelClassName) >= 0)  {
+            return sqlText.replaceAll("\\b" + modelClassName + "\\b", tableName);
+        }
+
+        return sqlText;
+    }
+
+    protected void scanSqlTextForLiteralTableName(String sqlText, String textType, String templateName, String regularTableName, String shadowTableName, String modulePrefix, String modelClassName)  {
+        if (sqlText != null) {
+            boolean textContainsRegularName = sqlText.matches(".*\\b" + regularTableName + "\\b.*");
+            boolean textContainsShadowName = false;
+            if (!regularTableName.equals(shadowTableName)) {
+                textContainsShadowName = sqlText.matches(".*\\b" + shadowTableName + "\\b.*");
+            }
+
+            if (textContainsRegularName || textContainsShadowName) {
+                throw new InvalidSqlException("SQL " + (StringUtils.isNotBlank(textType) ? textType + " " : "") + "contains literal table name " +
+                        (textContainsRegularName ? regularTableName : shadowTableName) + " in query " + templateName +
+                        " in file " + modulePrefix.toLowerCase() + getTemplateSuffix() + ". Replace it with the corresponding model class name " +
+                        modelClassName + " instead."
+                );
+            }
+        }
+    }
+
+}

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/DmlTemplate.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/DmlTemplate.java
@@ -1,6 +1,8 @@
 package org.jumpmind.pos.persist.impl;
 
-public class DmlTemplate {
+import org.jumpmind.pos.persist.PersistException;
+
+public class DmlTemplate implements Cloneable {
 
     String name;
     String dml;
@@ -20,5 +22,13 @@ public class DmlTemplate {
     public String getName() {
         return name;
     }
-    
+
+    public DmlTemplate copy() {
+        try {
+            return (DmlTemplate)this.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new PersistException(e);
+        }
+    }
+
 }

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/DmlTemplates.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/DmlTemplates.java
@@ -1,16 +1,104 @@
 package org.jumpmind.pos.persist.impl;
 
+import org.jumpmind.db.model.Table;
+
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
-public class DmlTemplates {
+public class DmlTemplates extends AbstractSqlTemplates {
 
-    List<DmlTemplate> dmls;
-    
+    Map<String, Map<String, DmlTemplate>> dmlsByDeviceMode = new HashMap<>();
+
+    public DmlTemplates() {
+    }
+
     public void setDmls(List<DmlTemplate> dmls) {
-        this.dmls = dmls;
+        setDmls("default", dmls);
     }
-    
+
+    public void setDmls(String deviceMode, List<DmlTemplate> dmls) {
+        getDmlTemplateMapForDeviceMode(deviceMode).clear();
+        dmlsByDeviceMode.put(deviceMode, buildDmlTemplatesByNameMap(dmls));
+    }
+
+    public List<DmlTemplate> getDmls(String deviceMode) {
+        List<DmlTemplate> templateList = new ArrayList<>(getDmlTemplateMapForDeviceMode(deviceMode).values());
+        return templateList;
+    }
+
     public List<DmlTemplate> getDmls() {
-        return dmls;
+        return getDmls("default");
     }
+
+    public void addDmls(List<DmlTemplate> dmls) {
+        addDmls("default", dmls);
+    }
+
+    public void addDmls(String deviceMode, List<DmlTemplate> dmls) {
+        dmlsByDeviceMode.put(deviceMode, buildDmlTemplatesByNameMap(dmls));
+    }
+
+    public DmlTemplate getDmlTemplate(String deviceMode, String templateName) {
+        return getDmlTemplateMapForDeviceMode(deviceMode).get(templateName);
+    }
+
+    @Override
+    public void replaceModelClassNamesWithTableNames(DatabaseSchema dbSchema, List<Class<?>> modelClassList, boolean validateTablesInQueries) {
+        for (String deviceMode : dmlsByDeviceMode.keySet()) {
+            Map<String, DmlTemplate> dmlTemplateMap = dmlsByDeviceMode.get(deviceMode);
+            for (DmlTemplate template : dmlTemplateMap.values()) {
+                for (Class<?> modelClass : modelClassList) {
+                    String modelClassName = modelClass.getSimpleName();
+
+                    Table regularTable = dbSchema.getTableForDeviceMode("default", modelClass, modelClass);
+                    Table shadowTable = dbSchema.getTableForDeviceMode("training", modelClass, modelClass);
+
+                    if (regularTable == null)  {
+                        //  For whatever reason, we could not find a table associated with the given model class.
+                        continue;
+
+                    } else if (shadowTable == null)  {
+                        shadowTable = regularTable;
+                    }
+
+                    String regularTableName = regularTable.getName();
+                    String shadowTableName = shadowTable.getName();
+
+                    if (validateTablesInQueries) {
+                        scanSqlTextForLiteralTableName(template.getDml(), "", template.getName(), regularTableName, shadowTableName, dbSchema.getTablePrefix(), modelClassName);
+                    }
+
+                    //  In the case below, we always want the model class, NOT its superclass.
+                    String tableName = (deviceMode.equals("training") ? shadowTableName : regularTableName);
+
+                    template.setDml(replaceClassModelNameInSqlText(template.getDml(), modelClassName, tableName));
+                }
+            }
+        }
+    }
+
+    @Override
+    protected String getTemplateSuffix() {
+        return "-dml.yml";
+    }
+
+    private Map<String, DmlTemplate> buildDmlTemplatesByNameMap(List<DmlTemplate> templateList) {
+        Map<String, DmlTemplate> dmlTemplatesMap = new HashMap<>();
+        if (templateList != null) {
+            for (DmlTemplate t : templateList)  {
+                dmlTemplatesMap.put(t.getName(), t.copy());
+            }
+        }
+        return dmlTemplatesMap;
+    }
+
+    private Map<String, DmlTemplate> getDmlTemplateMapForDeviceMode(String deviceMode)  {
+        //  Normalize the Device Mode. Currently only "training" and "default" are supported.
+        deviceMode = (deviceMode == null ? "default" : (deviceMode.equalsIgnoreCase("training") ? "training" : "default"));
+        Map<String, DmlTemplate> queryMap = dmlsByDeviceMode.get(deviceMode);
+        return (queryMap == null ? new HashMap<>() : queryMap);
+    }
+
 }

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/QueryTemplates.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/QueryTemplates.java
@@ -1,12 +1,10 @@
 package org.jumpmind.pos.persist.impl;
 
-import org.apache.commons.lang3.StringUtils;
 import org.jumpmind.db.model.Table;
-import org.jumpmind.db.sql.InvalidSqlException;
 
 import java.util.*;
 
-public class QueryTemplates {
+public class QueryTemplates extends AbstractSqlTemplates {
     Map<String, Map<String, QueryTemplate>> queriesByDeviceMode = new HashMap<>();
 
     public QueryTemplates() {
@@ -51,8 +49,14 @@ public class QueryTemplates {
         return getQueryTemplateMapForDeviceMode(deviceMode).get(queryName);
     }
 
+    @Override
+    protected String getTemplateSuffix() {
+        return "-query.yml";
+    }
+
     //  SQL parsing.
 
+    @Override
     public void replaceModelClassNamesWithTableNames(DatabaseSchema dbSchema, List<Class<?>> modelClassList, boolean validateTablesInQueries) {
         for (String deviceMode : queriesByDeviceMode.keySet()) {
             Map<String, QueryTemplate> queryMap = queriesByDeviceMode.get(deviceMode);
@@ -101,32 +105,6 @@ public class QueryTemplates {
                         template.setOptionalWhereClauses(newOptionalWhereClauses);
                     }
                 }
-            }
-        }
-    }
-
-    private String replaceClassModelNameInSqlText(String sqlText, String modelClassName, String tableName)  {
-        if ((sqlText != null) && StringUtils.indexOf(sqlText, modelClassName) >= 0)  {
-            return sqlText.replaceAll("\\b" + modelClassName + "\\b", tableName);
-        }
-
-        return sqlText;
-    }
-
-    private void scanSqlTextForLiteralTableName(String sqlText, String textType, String templateName, String regularTableName, String shadowTableName, String modulePrefix, String modelClassName)  {
-        if (sqlText != null) {
-            boolean textContainsRegularName = sqlText.matches(".*\\b" + regularTableName + "\\b.*");
-            boolean textContainsShadowName = false;
-            if (!regularTableName.equals(shadowTableName)) {
-                textContainsShadowName = sqlText.matches(".*\\b" + shadowTableName + "\\b.*");
-            }
-
-            if (textContainsRegularName || textContainsShadowName) {
-                throw new InvalidSqlException("SQL " + textType + " contains literal table name " +
-                    (textContainsRegularName ? regularTableName : shadowTableName) + " in query " + templateName +
-                    " in file " + modulePrefix.toLowerCase() + "-query.yml. Replace it with the corresponding model class name " +
-                    modelClassName + " instead."
-                );
             }
         }
     }

--- a/openpos-persist/src/test/java/org/jumpmind/pos/persist/DBSessionQueryConcurrentTest.java
+++ b/openpos-persist/src/test/java/org/jumpmind/pos/persist/DBSessionQueryConcurrentTest.java
@@ -3,8 +3,6 @@ package org.jumpmind.pos.persist;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.util.HashMap;
-import java.util.Map;
 
 import javax.sql.DataSource;
 
@@ -12,8 +10,8 @@ import org.jumpmind.db.model.Table;
 import org.jumpmind.db.platform.IDatabasePlatform;
 import org.jumpmind.pos.persist.cars.CarModel;
 import org.jumpmind.pos.persist.impl.DatabaseSchema;
-import org.jumpmind.pos.persist.impl.DmlTemplate;
 import org.jumpmind.pos.persist.impl.QueryTemplates;
+import org.jumpmind.pos.persist.impl.DmlTemplates;
 import org.jumpmind.pos.persist.model.AugmenterHelper;
 import org.jumpmind.pos.persist.model.TagHelper;
 import org.jumpmind.properties.TypedProperties;
@@ -59,8 +57,8 @@ public class DBSessionQueryConcurrentTest {
         Mockito.when(ps.executeQuery()).thenReturn(rs);
 
         QueryTemplates queryTemplates = new QueryTemplates();
-        Map<String, DmlTemplate> dmlTemplates = new HashMap<>();
-        
+        DmlTemplates dmlTemplates = new DmlTemplates();
+
         DBSession db = new DBSession("catalog", "schema", databaseSchema, databasePlatform, new TypedProperties(), queryTemplates, dmlTemplates, tagHelper, augmenterHelper);
         
         for (int i = 0; i < 1000; i++) {            


### PR DESCRIPTION
### Issues Fixed

**PDPOS-5307** (_[NGPOS][Training Mode] - Return Txn# in Training Mode is in sequence with Regular Mode txn# and Customer Receipt does NOT indicate Training Mode on return transaction receipt_)

### Summary
- Adds core support for necessary to fix training mode problems for any functional areas that use DML queries.  For example, updating the quantity available for return on a line item of an original transaction.
