### PR TITLE
Add privacy restriction functionality to customer-search-results.

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/customer-search-result-dialog/customer-search-result-dialog.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/customer-search-result-dialog/customer-search-result-dialog.interface.ts
@@ -9,5 +9,5 @@ export interface ICustomerDetails extends SelectableItemInterface{
     email: string,
     address: {line1: string, line2: string, city: string, state: string, postalCode: string}
     memberships: Membership[],
-    privacyRestricted: string
+    privacyRestrictedMessage: string
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/customer-search-result-dialog/customer-search-result-dialog.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/customer-search-result-dialog/customer-search-result-dialog.interface.ts
@@ -1,22 +1,13 @@
-import {IAbstractScreen} from "../../core/interfaces/abstract-screen.interface";
-import {IActionItem} from "../../core/actions/action-item.interface";
 import {Membership} from "../../shared/screen-parts/membership-display/memebership-display.interface";
 import {SelectableItemInterface} from "../selection-list/selectable-item.interface";
 
-export interface CustomerSearchResultDialogInterface extends IAbstractScreen {
-    instructions: String;
-    selectButton: IActionItem;
-    viewButton: IActionItem;
-    results: ICustomerDetails[]
-}
 
 export interface ICustomerDetails extends SelectableItemInterface{
-    selected: boolean;
-    enabled: boolean;
     name: string,
     loyaltyNumber: string,
     phoneNumber: string,
     email: string,
     address: {line1: string, line2: string, city: string, state: string, postalCode: string}
-    memberships: Membership[]
+    memberships: Membership[],
+    privacyRestricted: string
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/display-customer-lookup/display-customer-lookup.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/display-customer-lookup/display-customer-lookup.component.html
@@ -3,14 +3,14 @@
         <span class="customer-name text-md">{{customer.name}}</span>
         <span class="customer-loyaltyNumber muted-color">{{customer.loyaltyNumber}}</span>
     </div>
-    <div class="privacy muted-color" *ngIf="customer.privacyRestricted">
-        {{customer.privacyRestricted}}
+    <div class="privacy muted-color" *ngIf="customer.privacyRestrictedMessage">
+        {{customer.privacyRestrictedMessage}}
     </div>
-    <div class="customer-email-phone muted-color" *ngIf="!customer.privacyRestricted">
+    <div class="customer-email-phone muted-color" *ngIf="!customer.privacyRestrictedMessage">
         <div class="customer-email">{{customer.email}}</div>
         <div class="customer-phoneNumber">{{customer.phoneNumber | phone}}</div>
     </div>
-    <div class="customer-address muted-color" *ngIf="!customer.privacyRestricted">
+    <div class="customer-address muted-color" *ngIf="!customer.privacyRestrictedMessage">
         <div class="customer-line1">{{customer.address.line1}}</div>
         <div class="customer-line2" *ngIf="customer.address.line2">{{customer.address.line2}}</div>
         <div class="customer-cityStateZip">
@@ -19,7 +19,7 @@
             <span *ngIf="customer.address.postalCode">{{customer.address.postalCode}}</span>
         </div>
     </div>
-    <div class="customer-memberships" *ngIf="!customer.privacyRestricted">
+    <div class="customer-memberships" *ngIf="!customer.privacyRestrictedMessage">
         <div *ngFor="let membership of customer.memberships">
             <app-membership-display [membership]="membership"></app-membership-display>
         </div>
@@ -28,12 +28,12 @@
 <div *ngIf="(isMobile | async)" class="mobile-customer-details text-sm">
     <div class="customer-info-left">
         <div class="customer-name text-md">{{customer.name}}</div>
-        <div class="privacy muted-color" *ngIf="customer.privacyRestricted">{{customer.privacyRestricted}}</div>
+        <div class="privacy muted-color" *ngIf="customer.privacyRestrictedMessage">{{customer.privacyRestrictedMessage}}</div>
         <div class="customer-loyaltyNumber muted-color">{{customer.loyaltyNumber}}</div>
-        <div class="customer-email muted-color"*ngIf="!customer.privacyRestricted">{{customer.email}}&nbsp;</div>
-        <div class="customer-phoneNumber muted-color"*ngIf="!customer.privacyRestricted">{{customer.phoneNumber | phone}}</div>
+        <div class="customer-email muted-color"*ngIf="!customer.privacyRestrictedMessage">{{customer.email}}&nbsp;</div>
+        <div class="customer-phoneNumber muted-color"*ngIf="!customer.privacyRestrictedMessage">{{customer.phoneNumber | phone}}</div>
     </div>
-    <div class="customer-info-right customer-memberships muted-color" *ngIf="!customer.privacyRestricted">
+    <div class="customer-info-right customer-memberships muted-color" *ngIf="!customer.privacyRestrictedMessage">
         <div *ngFor="let membership of customer.memberships" class="text-sm">
             <app-membership-display [membership]="membership"></app-membership-display>
         </div>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/display-customer-lookup/display-customer-lookup.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/display-customer-lookup/display-customer-lookup.component.html
@@ -1,16 +1,16 @@
-<div class="text-sm privacy" *ngIf="customer.privacyRestricted">
-    {{customer.privacyRestricted}}
-</div>
 <div *ngIf="!(isMobile | async)" class="customer-details text-sm">
     <div class="customer-name-loyaltyNumber">
         <span class="customer-name text-md">{{customer.name}}</span>
         <span class="customer-loyaltyNumber muted-color">{{customer.loyaltyNumber}}</span>
     </div>
-    <div class="customer-email-phone muted-color">
-        <div class="customer-email">{{customer.email}}&nbsp;</div>
+    <div class="privacy muted-color" *ngIf="customer.privacyRestricted">
+        {{customer.privacyRestricted}}
+    </div>
+    <div class="customer-email-phone muted-color" *ngIf="!customer.privacyRestricted">
+        <div class="customer-email">{{customer.email}}</div>
         <div class="customer-phoneNumber">{{customer.phoneNumber | phone}}</div>
     </div>
-    <div class="customer-address muted-color">
+    <div class="customer-address muted-color" *ngIf="!customer.privacyRestricted">
         <div class="customer-line1">{{customer.address.line1}}</div>
         <div class="customer-line2" *ngIf="customer.address.line2">{{customer.address.line2}}</div>
         <div class="customer-cityStateZip">
@@ -19,7 +19,7 @@
             <span *ngIf="customer.address.postalCode">{{customer.address.postalCode}}</span>
         </div>
     </div>
-    <div class="customer-memberships">
+    <div class="customer-memberships" *ngIf="!customer.privacyRestricted">
         <div *ngFor="let membership of customer.memberships">
             <app-membership-display [membership]="membership"></app-membership-display>
         </div>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/display-customer-lookup/display-customer-lookup.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/display-customer-lookup/display-customer-lookup.component.html
@@ -1,3 +1,6 @@
+<div class="text-sm privacy" *ngIf="customer.privacyRestricted">
+    {{customer.privacyRestricted}}
+</div>
 <div *ngIf="!(isMobile | async)" class="customer-details text-sm">
     <div class="customer-name-loyaltyNumber">
         <span class="customer-name text-md">{{customer.name}}</span>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/display-customer-lookup/display-customer-lookup.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/display-customer-lookup/display-customer-lookup.component.html
@@ -28,11 +28,12 @@
 <div *ngIf="(isMobile | async)" class="mobile-customer-details text-sm">
     <div class="customer-info-left">
         <div class="customer-name text-md">{{customer.name}}</div>
+        <div class="privacy muted-color" *ngIf="customer.privacyRestricted">{{customer.privacyRestricted}}</div>
         <div class="customer-loyaltyNumber muted-color">{{customer.loyaltyNumber}}</div>
-        <div class="customer-email muted-color">{{customer.email}}&nbsp;</div>
-        <div class="customer-phoneNumber muted-color">{{customer.phoneNumber | phone}}</div>
+        <div class="customer-email muted-color"*ngIf="!customer.privacyRestricted">{{customer.email}}&nbsp;</div>
+        <div class="customer-phoneNumber muted-color"*ngIf="!customer.privacyRestricted">{{customer.phoneNumber | phone}}</div>
     </div>
-    <div class="customer-info-right customer-memberships muted-color">
+    <div class="customer-info-right customer-memberships muted-color" *ngIf="!customer.privacyRestricted">
         <div *ngFor="let membership of customer.memberships" class="text-sm">
             <app-membership-display [membership]="membership"></app-membership-display>
         </div>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/display-customer-lookup/display-customer-lookup.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/display-customer-lookup/display-customer-lookup.component.scss
@@ -1,8 +1,3 @@
-.privacy{
-  padding-top: 1em;
-  padding-left:1em;
-}
-
 .customer-details{
   display: grid;
   padding: .5em;
@@ -18,9 +13,21 @@
     padding-bottom: .5em;
   }
   .customer-email-phone{
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: 1em 1em;
+    gap: 0px 0px;
+    grid-template-areas:
+    "email"
+    "phone";
+
     .customer-email{
+      grid-area: email;
       text-overflow: ellipsis;
       overflow: hidden;
+    }
+    .customer-phoneNumber{
+      grid-area: phone;
     }
   }
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/display-customer-lookup/display-customer-lookup.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/display-customer-lookup/display-customer-lookup.component.scss
@@ -1,3 +1,8 @@
+.privacy{
+  padding-top: 1em;
+  padding-left:1em;
+}
+
 .customer-details{
   display: grid;
   padding: .5em;

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/display-customer-lookup/display-customer-lookup.component.spec.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/display-customer-lookup/display-customer-lookup.component.spec.ts
@@ -31,8 +31,7 @@ describe('DisplayCustomerLookupComponent', () => {
             } as Membership,{
                 id: '2', name: 'testGroup2', member: true
             } as Membership
-        ],
-        privacyRestricted: 'testRestricted'
+        ]
 
     } as ICustomerDetails;
 
@@ -91,6 +90,8 @@ describe('DisplayCustomerLookupComponent', () => {
                 expect(membershipDisplayComponents.length).toBe(testCustomer.memberships.length);
             });
             it('should display privacy message when privacy is restricted.', function () {
+                testCustomer.privacyRestricted = "test";
+                fixture.detectChanges();
                 const privacyDiv = fixture.debugElement.query(By.css(".privacy"));
                 expect(privacyDiv).toBeDefined()
                 expect(privacyDiv.nativeElement.textContent).toContain(testCustomer.privacyRestricted);
@@ -133,19 +134,25 @@ describe('DisplayCustomerLookupComponent', () => {
                 validateText(fixture, '.customer-name', testCustomer.name);
             });
             it('should display customer loyalty number', function () {
+                testCustomer.privacyRestricted = null;
                 validateText(fixture, '.customer-loyaltyNumber', testCustomer.loyaltyNumber);
             });
             it('should display customer email address', function () {
+                testCustomer.privacyRestricted = null;
                 validateText(fixture, '.customer-email', testCustomer.email);
             });
             it('should display customer phone number', function () {
+                testCustomer.privacyRestricted = null;
                 validateText(fixture, '.customer-phoneNumber', "(614) 234-5678");
             });
             it('should display all memberships as badges', function () {
+                testCustomer.privacyRestricted = null;
                 const membershipDisplayComponents = fixture.debugElement.queryAll(By.css('app-membership-display'));
                 expect(membershipDisplayComponents.length).toBe(testCustomer.memberships.length);
             });
             it('should display privacy message when privacy is restricted.', function () {
+                testCustomer.privacyRestricted = "test";
+                fixture.detectChanges();
                 const privacyDiv = fixture.debugElement.query(By.css(".privacy"));
                 expect(privacyDiv).toBeDefined()
                 expect(privacyDiv.nativeElement.textContent).toContain(testCustomer.privacyRestricted);

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/display-customer-lookup/display-customer-lookup.component.spec.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/display-customer-lookup/display-customer-lookup.component.spec.ts
@@ -31,7 +31,8 @@ describe('DisplayCustomerLookupComponent', () => {
             } as Membership,{
                 id: '2', name: 'testGroup2', member: true
             } as Membership
-        ]
+        ],
+        privacyRestricted: 'testRestricted'
 
     } as ICustomerDetails;
 
@@ -89,6 +90,11 @@ describe('DisplayCustomerLookupComponent', () => {
                 const membershipDisplayComponents = fixture.debugElement.queryAll(By.css('app-membership-display'));
                 expect(membershipDisplayComponents.length).toBe(testCustomer.memberships.length);
             });
+            it('should display privacy message when privacy is restricted.', function () {
+                const privacyDiv = fixture.debugElement.query(By.css(".privacy"));
+                expect(privacyDiv).toBeDefined()
+                expect(privacyDiv.nativeElement.textContent).toContain(testCustomer.privacyRestricted);
+            });
         });
     });
 
@@ -114,7 +120,7 @@ describe('DisplayCustomerLookupComponent', () => {
             component = fixture.componentInstance;
             component.customer = testCustomer;
             component.isMobile = new Observable<boolean>(subscriber => {
-                subscriber.next(false);
+                subscriber.next(true);
             });
             fixture.detectChanges();
         });
@@ -138,6 +144,11 @@ describe('DisplayCustomerLookupComponent', () => {
             it('should display all memberships as badges', function () {
                 const membershipDisplayComponents = fixture.debugElement.queryAll(By.css('app-membership-display'));
                 expect(membershipDisplayComponents.length).toBe(testCustomer.memberships.length);
+            });
+            it('should display privacy message when privacy is restricted.', function () {
+                const privacyDiv = fixture.debugElement.query(By.css(".privacy"));
+                expect(privacyDiv).toBeDefined()
+                expect(privacyDiv.nativeElement.textContent).toContain(testCustomer.privacyRestricted);
             });
         });
     });

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/display-customer-lookup/display-customer-lookup.component.spec.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/display-customer-lookup/display-customer-lookup.component.spec.ts
@@ -63,6 +63,9 @@ describe('DisplayCustomerLookupComponent', () => {
         });
 
         describe('template', () => {
+            beforeEach(() => {
+                testCustomer.privacyRestrictedMessage = null;
+            });
             it('should display customer name', function () {
                 validateText(fixture, '.customer-name', testCustomer.name);
             });
@@ -90,11 +93,11 @@ describe('DisplayCustomerLookupComponent', () => {
                 expect(membershipDisplayComponents.length).toBe(testCustomer.memberships.length);
             });
             it('should display privacy message when privacy is restricted.', function () {
-                testCustomer.privacyRestricted = "test";
+                testCustomer.privacyRestrictedMessage = 'test';
                 fixture.detectChanges();
-                const privacyDiv = fixture.debugElement.query(By.css(".privacy"));
+                const privacyDiv = fixture.debugElement.query(By.css('.privacy'));
                 expect(privacyDiv).toBeDefined()
-                expect(privacyDiv.nativeElement.textContent).toContain(testCustomer.privacyRestricted);
+                expect(privacyDiv.nativeElement.textContent).toContain(testCustomer.privacyRestrictedMessage);
             });
         });
     });
@@ -130,32 +133,31 @@ describe('DisplayCustomerLookupComponent', () => {
         });
 
         describe('template', () => {
+            beforeEach(() => {
+                testCustomer.privacyRestrictedMessage = null;
+            });
             it('should display customer name', function () {
                 validateText(fixture, '.customer-name', testCustomer.name);
             });
             it('should display customer loyalty number', function () {
-                testCustomer.privacyRestricted = null;
                 validateText(fixture, '.customer-loyaltyNumber', testCustomer.loyaltyNumber);
             });
             it('should display customer email address', function () {
-                testCustomer.privacyRestricted = null;
                 validateText(fixture, '.customer-email', testCustomer.email);
             });
             it('should display customer phone number', function () {
-                testCustomer.privacyRestricted = null;
                 validateText(fixture, '.customer-phoneNumber', "(614) 234-5678");
             });
             it('should display all memberships as badges', function () {
-                testCustomer.privacyRestricted = null;
                 const membershipDisplayComponents = fixture.debugElement.queryAll(By.css('app-membership-display'));
                 expect(membershipDisplayComponents.length).toBe(testCustomer.memberships.length);
             });
             it('should display privacy message when privacy is restricted.', function () {
-                testCustomer.privacyRestricted = "test";
+                testCustomer.privacyRestrictedMessage = 'test';
                 fixture.detectChanges();
-                const privacyDiv = fixture.debugElement.query(By.css(".privacy"));
+                const privacyDiv = fixture.debugElement.query(By.css('.privacy'));
                 expect(privacyDiv).toBeDefined()
-                expect(privacyDiv.nativeElement.textContent).toContain(testCustomer.privacyRestricted);
+                expect(privacyDiv.nativeElement.textContent).toContain(testCustomer.privacyRestrictedMessage);
             });
         });
     });

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/UICustomerDetailsItem.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/UICustomerDetailsItem.java
@@ -10,6 +10,7 @@ import java.util.List;
 public class UICustomerDetailsItem extends SelectableItem implements Serializable {
     private static final long serialVersionUID = 1L;
 
+    private String privacyRestricted;
     private String name;
     private String loyaltyNumber;
     private String email;

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/UICustomerDetailsItem.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/UICustomerDetailsItem.java
@@ -10,7 +10,7 @@ import java.util.List;
 public class UICustomerDetailsItem extends SelectableItem implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    private String privacyRestricted;
+    private String privacyRestrictedMessage;
     private String name;
     private String loyaltyNumber;
     private String email;


### PR DESCRIPTION
### Summary
When a customer is flagged as having Privacy Restrictions search results will no longer display any information, other than the name of the customer and a messages of "Privacy Restricted" as well as being  not selectable. No customer information other than name is passed to the font-end either.

### Screenshots
Single customer

HP Engage
![image](https://user-images.githubusercontent.com/16402926/113025590-1de9ab00-9156-11eb-9b54-f3f8f97b385d.png)

ELO POS
![image](https://user-images.githubusercontent.com/16402926/113025618-25a94f80-9156-11eb-9afd-dbeeb5b01647.png)

IPad
![image](https://user-images.githubusercontent.com/16402926/113025641-2c37c700-9156-11eb-91fe-d7b4f7ede53e.png)

Multiple customers

HP Engage
![image](https://user-images.githubusercontent.com/16402926/113025888-71f48f80-9156-11eb-9c03-24c66d335d67.png)

ELO POS
![image](https://user-images.githubusercontent.com/16402926/113025921-7caf2480-9156-11eb-882d-830c201606c0.png)

IPad
![image](https://user-images.githubusercontent.com/16402926/113026044-a1a39780-9156-11eb-89e7-9cee72b93c91.png)