### PR TITLE
Bugfix/gs1 not accepted on last day valid expiration date bug

### DIFF
--- a/openpos-util/src/main/java/org/jumpmind/pos/coupons/GS1Coupon.java
+++ b/openpos-util/src/main/java/org/jumpmind/pos/coupons/GS1Coupon.java
@@ -2,6 +2,7 @@ package org.jumpmind.pos.coupons;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.Date;
 
 public class GS1Coupon {
@@ -131,7 +132,13 @@ public class GS1Coupon {
                     case 3:
                         // Expiry date
                         String date = gs1Databar.substring(i, i + 6);
-                        expirationDate = new SimpleDateFormat("yyMMdd").parse(date);
+                        Date parsedDate = new SimpleDateFormat("yyMMdd").parse(date);
+                        Calendar calendar = Calendar.getInstance();
+                        calendar.setTime(parsedDate);
+                        calendar.set(Calendar.HOUR_OF_DAY, 23);
+                        calendar.set(Calendar.MINUTE, 59);
+                        calendar.set(Calendar.SECOND, 59);
+                        expirationDate  = calendar.getTime();
                         i += 6;
                         break;
 

--- a/openpos-util/src/test/java/org/jumpmind/pos/coupons/GS1CouponTest.java
+++ b/openpos-util/src/test/java/org/jumpmind/pos/coupons/GS1CouponTest.java
@@ -16,7 +16,7 @@ public class GS1CouponTest {
         assertEquals(1, coupon.getPrimaryPurchaseRequirement());
         assertEquals(0, coupon.getSecondaryPurchaseRequirement());
         assertEquals(0, coupon.getTertiaryPurchaseRequirement());
-        assertEquals(new SimpleDateFormat("yyyy-MM-dd").parse("2019-03-03"), coupon.getExpirationDate());        
+        assertEquals(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2019-03-03 23:59:59"), coupon.getExpirationDate());
     }
     
     @Test
@@ -27,7 +27,7 @@ public class GS1CouponTest {
         assertEquals(1, coupon.getPrimaryPurchaseRequirement());
         assertEquals(0, coupon.getSecondaryPurchaseRequirement());
         assertEquals(0, coupon.getTertiaryPurchaseRequirement());
-        assertEquals(new SimpleDateFormat("yyyy-MM-dd").parse("2019-02-17"), coupon.getExpirationDate());
+        assertEquals(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2019-02-17 23:59:59"), coupon.getExpirationDate());
         System.out.println(coupon.toString());
         
     }


### PR DESCRIPTION
### Issues Fixed
[PDPOS-5330](https://petcoalm.atlassian.net/browse/PDPOS-5330)

### Summary
make sure that the expiration date for GS1Coupon is set to the parsed date with the hours/min/seconds set to 23:59:59 so that the GS1 will still be accepted for the last day

