### PR TITLE
Fix Error on Customer Components When Customer Has No Address

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/customer-information/customer-information.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/customer-information/customer-information.component.html
@@ -9,7 +9,7 @@
 </div>
 <div class="details-row address" responsive-class>
     <app-icon [iconName]="screenData.locationIcon" [iconClass]="'material-icons mat-18'"></app-icon>
-    <div class="address-details">
+    <div class="address-details" *ngIf="customer.address">
         <div *ngIf="customer.address.line1" class="line1">{{customer.address.line1}}</div>
         <div *ngIf="customer.address.line2" class="line2">{{customer.address.line2}}</div>
         <div class="line3">

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/display-customer-lookup/display-customer-lookup.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/display-customer-lookup/display-customer-lookup.component.html
@@ -11,9 +11,9 @@
         <div class="customer-phoneNumber">{{customer.phoneNumber | phone}}</div>
     </div>
     <div class="customer-address muted-color" *ngIf="!customer.privacyRestrictedMessage">
-        <div class="customer-line1">{{customer.address.line1}}</div>
-        <div class="customer-line2" *ngIf="customer.address.line2">{{customer.address.line2}}</div>
-        <div class="customer-cityStateZip">
+        <div class="customer-line1" *ngIf="customer.address && customer.address.line1">{{customer.address.line1}}</div>
+        <div class="customer-line2" *ngIf="customer.address && customer.address.line2">{{customer.address.line2}}</div>
+        <div class="customer-cityStateZip" *ngIf="customer.address">
             <span *ngIf="customer.address.city">{{customer.address.city}}, </span>
             <span *ngIf="customer.address.state">{{customer.address.state}} </span>
             <span *ngIf="customer.address.postalCode">{{customer.address.postalCode}}</span>


### PR DESCRIPTION
### Summary
I added a check to make sure a customer has an address before showing the address fields. This scenario happens when I tested my recent changes for regression in PR [#3317](https://github.com/JumpMind/commerce/pull/3317) that dealt with accommodation customers.

I'm not sure if this actually a realistic scenario, or if it might have happened because of incomplete test data. Either way, I figured it wouldn't hurt to have the check and decided I might as well put up a PR for the check.
