### PR TITLE
Modify DateUtils parse date logic and added unit tests

### DIFF
--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AugmenterHelper.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/model/AugmenterHelper.java
@@ -96,7 +96,7 @@ public class AugmenterHelper {
             int counter = 1;
             for (AugmenterConfig config : configs) {
                 for (AugmenterModel augmenter : config.getAugmenters()) {
-                    String columnValue = augmentedModel.getAugmentValue(augmenter.getName());
+                    String columnValue = augmentedModel != null ? augmentedModel.getAugmentValue(augmenter.getName()) : null;
                     if (columnValue != null) {
                         String columnName = config.getPrefix() + augmenter.getName();
                         String columnNameKey = String.format("augment%dColumnName", counter);

--- a/openpos-service/src/main/java/org/jumpmind/pos/service/util/DateUtils.java
+++ b/openpos-service/src/main/java/org/jumpmind/pos/service/util/DateUtils.java
@@ -18,62 +18,61 @@ public final class DateUtils {
     private static final String ISO_DATE_TIME_SECONDS = "yyyy-MM-dd HH:mm:ss";
     private static final String ISO_DATE_TIME_SECONDS_T = "yyyy-MM-dd'T'HH:mm:ss";
     private static final String ISO_DATE = "yyyy-MM-dd";
-    
+
+    public static final String SAFE_NULL_STR_VALUE = "null";
+
     private DateUtils() {
     }
-    
-    private static String[] FORMATS = new String[] {
+
+    private static final String[] FORMATS = new String[] {
             ISO_DATE_TIME_MILLIS,
             ISO_DATE_TIME_MILLIS_T,
             ISO_DATE_TIME_SECONDS,
             ISO_DATE_TIME_SECONDS_T,
             ISO_DATE
     };
-    
+
     public static Date parseDateTimeISO(String date) {
-        if (!StringUtils.isEmpty(date)) {
-            Exception originalException = null;
-            for (String format : FORMATS) {
-                if (date.length() == format.length() || date.length() == format.length()-2) {                    
-                    SimpleDateFormat dateFormat = new SimpleDateFormat(format);
-                    try {
-                        return dateFormat.parse(date);
-                    } catch (ParseException ex) {
-                        originalException = ex;
-                    }
+        if (StringUtils.isEmpty(date)) {
+            return null;
+        }
+        Exception originalException = null;
+        for (String format : FORMATS) {
+            if (date.length() == format.length() || date.length() == format.length() - 2 || date.length() == format.length() + 4) {
+                SimpleDateFormat dateFormat = new SimpleDateFormat(format);
+                try {
+                    return dateFormat.parse(date);
+                } catch (ParseException ex) {
+                    originalException = ex;
                 }
             }
-            if (originalException != null) {
-                throw new PosServerException("Failed to parse date as ISO format: '" + date + "'", originalException);                
-            } else {                
-                throw new PosServerException("Failed to parse date as ISO format: '" + date + "'");
-            }
+        }
+        if (originalException != null) {
+            throw new PosServerException("Failed to parse date as ISO format: '" + date + "'", originalException);
         } else {
-            return null;            
+            throw new PosServerException("Failed to parse date as ISO format: '" + date + "'");
         }
     }
-    
+
     public static String formatDateTimeISO(Date date) {
         if (date != null) {
-            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+            SimpleDateFormat dateFormat = new SimpleDateFormat(ISO_DATE_TIME_SECONDS);
             return dateFormat.format(date);
-        } else {
-            return "null";            
         }
+        return SAFE_NULL_STR_VALUE;
     }
 
     public static long daysBetween(Date date1, Date date2) {
-        Calendar cal1 = Calendar.getInstance(); 
+        Calendar cal1 = Calendar.getInstance();
         cal1.setTime(date1);
-        Calendar cal2 = Calendar.getInstance(); 
+        Calendar cal2 = Calendar.getInstance();
         cal2.setTime(date2);
-        
-        long diffDays = (cal2.getTimeInMillis()-cal1.getTimeInMillis()) / (24 * 60 * 60 * 1000);
-        return diffDays;
+
+        return (cal2.getTimeInMillis() - cal1.getTimeInMillis()) / (24 * 60 * 60 * 1000);
     }
 
     public static String changeFormat(String value, String existingFormat, String newFormat) {
-        if(StringUtils.isBlank(value)) {
+        if (StringUtils.isBlank(value)) {
             return value;
         }
 

--- a/openpos-service/src/test/java/org/jumpmind/pos/service/util/DateUtilsTest.java
+++ b/openpos-service/src/test/java/org/jumpmind/pos/service/util/DateUtilsTest.java
@@ -1,0 +1,110 @@
+package org.jumpmind.pos.service.util;
+
+import org.jumpmind.pos.service.PosServerException;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+
+public class DateUtilsTest {
+
+    private final Date MOCKED_DATE = org.apache.commons.lang3.time.DateUtils.truncate(new GregorianCalendar(1996, Calendar.JULY, 8, 12, 15, 45).getTime(), Calendar.SECOND);
+    private final Date MOCKED_DATE_PLUS_DAY = org.apache.commons.lang3.time.DateUtils.truncate(new GregorianCalendar(1996, Calendar.JULY, 7, 12, 15, 45).getTime(), Calendar.SECOND);
+
+    @Rule
+    public final ExpectedException EXPECTED_EX = ExpectedException.none();
+
+    @Test
+    public void testParseISODateParseException() {
+        EXPECTED_EX.expect(PosServerException.class);
+        DateUtils.parseDateTimeISO("1996-07-08T12:99:999.618");
+    }
+
+    @Test
+    public void testParseISOIncorrectDateParseException() {
+        EXPECTED_EX.expect(PosServerException.class);
+        DateUtils.parseDateTimeISO("ABCD-07-08 12:15:45.618");
+    }
+
+    @Test
+    public void testParseISONull() {
+        Assert.assertNull(DateUtils.parseDateTimeISO(""));
+    }
+
+    @Test
+    public void testParseISODateTimeMillis() {
+        Date result = truncateParsedDateForComparing(DateUtils.parseDateTimeISO("1996-07-08 12:15:45.618"));
+        Assert.assertEquals(MOCKED_DATE, result);
+    }
+
+    @Test
+    public void testParseISODateTimeMillisT() {
+        Date result = truncateParsedDateForComparing(DateUtils.parseDateTimeISO("1996-07-08T12:15:45.618"));
+        Assert.assertEquals(MOCKED_DATE, result);
+    }
+
+    @Test
+    public void testParseISODateTimeMillisTNotInUTC() {
+        Date result = truncateParsedDateForComparing(DateUtils.parseDateTimeISO("1996-07-08T12:15:45.618-04:00"));
+        Assert.assertEquals(MOCKED_DATE, result);
+    }
+
+    @Test
+    public void testParseISODateTimeSeconds() {
+        Date result = truncateParsedDateForComparing(DateUtils.parseDateTimeISO("1996-07-08 12:15:45"));
+        Assert.assertEquals(MOCKED_DATE, result);
+    }
+
+    @Test
+    public void testParseISODateTimeSecondsT() {
+        Date result = truncateParsedDateForComparing(DateUtils.parseDateTimeISO("1996-07-08T12:15:45"));
+        Assert.assertEquals(MOCKED_DATE, result);
+    }
+
+    @Test
+    public void testFormatDateTimeISO() {
+        String result = DateUtils.formatDateTimeISO(MOCKED_DATE);
+        Assert.assertEquals("1996-07-08 12:15:45", result);
+    }
+
+    @Test
+    public void testFormatDateTimeISONull() {
+        String result = DateUtils.formatDateTimeISO(null);
+        Assert.assertEquals(DateUtils.SAFE_NULL_STR_VALUE, result);
+    }
+
+    @Test
+    public void testDaysBetween() {
+        long daysBetween = DateUtils.daysBetween(MOCKED_DATE_PLUS_DAY, MOCKED_DATE);
+        Assert.assertEquals(1, daysBetween);
+    }
+
+    @Test
+    public void testChangeFormat() {
+        String result = DateUtils.changeFormat("1996-07-08T12:15:45.618", "yyyy-MM-dd'T'HH:mm:ss.SSS", "MM/dd/yyyy");
+        Assert.assertEquals("07/08/1996", result);
+    }
+
+    @Test
+    public void testChangeFormatBlank() {
+        String result = DateUtils.changeFormat("", "", "");
+        Assert.assertEquals("", result);
+    }
+
+    @Test
+    public void testChangeFormatParseException() {
+        String INCORRECT_FORMATTED_DATE = "1996-07-08T12:95:459.9999";
+        String result = DateUtils.changeFormat(INCORRECT_FORMATTED_DATE, "yyyy-MM-dd HH:mm:ss.SSS", "MM/dd/yyyy");
+        Assert.assertEquals(INCORRECT_FORMATTED_DATE, result);
+    }
+
+    private Date truncateParsedDateForComparing(Date parsedDate) {
+        return org.apache.commons.lang3.time.DateUtils.truncate(parsedDate, Calendar.SECOND);
+    }
+
+}


### PR DESCRIPTION
We receive a date, for example, "2020-09-16T11:41:48.117-04:00".
It can be parsed using the existing pattern: ISO_DATE_TIME_MILLIS_T = "yyyy-MM-dd'T'HH:mm:ss.SSS"
But it didn't happen due to the condition in DateUtils#parseDateTimeISO
Therefore, a new condition was added there:
date.length () == format.length () + 4
All other changes are just pretty safe code refactoring and test coverage so that changes can be made more safely in the future.
And also check condition augmented model for null.