### PR TITLE
Add several mobile specific changes to screens

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/options/options-screen-dialog.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/options/options-screen-dialog.component.scss
@@ -11,7 +11,7 @@
         display: grid;
         justify-self: center;
         align-content: center;
-        width:100%;
+        width: auto;
         @extend %page-spaced-content; 
     
         .options-image {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/sale.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/sale.component.scss
@@ -9,6 +9,7 @@
     height: 100%;
     .sale-outer {
         display: grid;
+        grid-template-rows: 1fr auto;
         min-height:100px;
 
         .sale-body {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/selection-list/selection-list-screen-dialog.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/selection-list/selection-list-screen-dialog.component.html
@@ -10,7 +10,8 @@
                         [configuration]="listConfig" [defaultSelect]="screen.defaultSelect"
                         [selectedItemList]="selectedItems"
                         [selectedItem]="selectedItem"
-                        (selectedItemChange)="onItemChange($event)" (selectedItemListChange)="onItemListChange($event)">
+                        (selectedItemChange)="onItemChange($event)" (selectedItemListChange)="onItemListChange($event)"
+                        class="item-list">
                         <ng-template let-item>
                             <div #items gdAreas="img info" gdColumns="auto 2fr" [ngClass]="{'muted-color' : !item.enabled}">
                                 <div gdArea="img">
@@ -20,10 +21,10 @@
                                 <div gdArea="info">
                                     <div fxShow fxHide.xs="true" fxHide.lg="false" *ngIf="item.title" class="text-sm" [innerHtml]="item.title | markdownFormatter"></div>
                                     <div fxHide fxHide.xs="false" fxHide.lg="true" *ngIf="item.title" class="text-md" [innerHtml]="item.title | markdownFormatter"></div>
-                                    <div *ngIf="item.properties" fxLayout="row wrap" fxLayoutAlign="space-between">
+                                    <div *ngIf="item.properties" fxLayoutAlign="space-between">
                                         <div *ngFor="let property of item.properties">
-                                            <div *ngIf="property.label" class="text-sm item-property-label">{{property.label}}</div>
-                                            <p class="text-sm item-property-line" *ngFor="let line of property.lines">{{line}}</p>
+                                            <div *ngIf="property.label" class="item-property-label">{{property.label}}</div>
+                                            <p class="item-property-line" *ngFor="let line of property.lines">{{line}}</p>
                                         </div>
                                     </div>
                                 </div>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/selection-list/selection-list-screen-dialog.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/selection-list/selection-list-screen-dialog.component.scss
@@ -1,4 +1,5 @@
 @import "../../styles/variables/spacing";
+@import "../../styles/mixins/typography";
 
 .selection-list-outer {
     display:grid;
@@ -18,6 +19,22 @@
         &.mobile {
             .dialog-content {
                 max-height: 300px;
+                ::ng-deep .item-list .selection-list {
+                      padding: 2px;
+                      margin:8px 0px;
+                }
+
+                .item-property-label {
+                    font-weight: bold;
+                    font-size:$text-xs-mobile*.9;
+                }
+
+                .item-property-line {
+                    margin-top:3px;
+                    margin-right:5px;
+                    margin-bottom:2px;
+                    font-size:$text-xs-mobile*.9;
+                }
             }
         }
         &.tablet {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/kebab-button/kebab-button.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/kebab-button/kebab-button.component.ts
@@ -8,6 +8,8 @@ import {Configuration} from '../../../configuration/configuration';
 import {KebabMenuComponent} from '../kebab-menu/kebab-menu.component';
 import {FocusService} from '../../../core/focus/focus.service';
 import {IActionItem} from '../../../core/actions/action-item.interface';
+import {MediaBreakpoints, OpenposMediaService} from "../../../core/media/openpos-media.service";
+import {Observable} from "rxjs";
 
 @Component({
     selector: 'app-kebab-button',
@@ -29,6 +31,8 @@ export class KebabButtonComponent implements OnDestroy {
     iconClass;
 
     dialogRef: MatDialogRef<KebabMenuComponent>;
+    isMobile: Observable<boolean>;
+    kebabWidth: string;
 
     @Input()
     set keyBinding(key: string) {
@@ -54,7 +58,23 @@ export class KebabButtonComponent implements OnDestroy {
 
     protected subscription: Subscription;
 
-    constructor(protected dialog: MatDialog, protected keyPresses: KeyPressProvider, protected focusService: FocusService, protected actionService: ActionService) {
+    constructor(protected dialog: MatDialog, protected keyPresses: KeyPressProvider, protected focusService: FocusService, protected media: OpenposMediaService, protected actionService: ActionService) {
+        this.isMobile = media.observe(new Map([
+            [MediaBreakpoints.MOBILE_PORTRAIT, true],
+            [MediaBreakpoints.MOBILE_LANDSCAPE, true],
+            [MediaBreakpoints.TABLET_PORTRAIT, true],
+            [MediaBreakpoints.TABLET_LANDSCAPE, false],
+            [MediaBreakpoints.DESKTOP_PORTRAIT, false],
+            [MediaBreakpoints.DESKTOP_LANDSCAPE, false]
+        ]));
+
+        this.isMobile.subscribe(mobile => {
+            if (mobile) {
+                this.kebabWidth = '100vw';
+            } else {
+                this.kebabWidth = '35vw';
+            }
+        });
     }
 
     ngOnDestroy(): void {
@@ -79,7 +99,7 @@ export class KebabButtonComponent implements OnDestroy {
                     autoFocus: false,
                     restoreFocus: false
                 },
-                width: '35vw',
+                width: this.kebabWidth,
                 autoFocus: false
             });
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/option-button/option-button.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/option-button/option-button.component.scss
@@ -84,6 +84,7 @@
 
     &.mobile {
         .mat-button-wrapper {
+            grid-template-columns: 16px 1fr 16px;
             display: grid !important;
             column-gap: 4px;
         }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/mobile-loyalty-part/mobile-loyalty-part.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/mobile-loyalty-part/mobile-loyalty-part.component.scss
@@ -5,8 +5,6 @@
     padding: 8px 16px !important;
 
     .mat-button-wrapper {
-        grid-template-columns: 30% 70%;
-        display: grid;
         margin: 0px;
     }
 }
@@ -45,8 +43,6 @@
     width: 100%;
 
     .mat-button-wrapper {
-        grid-template-columns: auto 1fr;
-        display: grid;
         margin: 0px;
         line-height: normal;
     }
@@ -54,7 +50,7 @@
 
 .mobile-loyalty-customer-name {
     display: grid;
-    justify-self: end;
+    justify-self: center;
 }
 
 .mobile-loyalty-image {
@@ -65,10 +61,10 @@
 
 .mobile-loyalty-name {
     @extend %text-sm;
-    justify-self: end;
+    justify-self: center;
 }
 
 .mobile-loyalty-id {
     @extend %text-sm;
-    justify-self: end;
+    justify-self: center;
 }


### PR DESCRIPTION
### Issues Fixed
 - [4927](https://petcoalm.atlassian.net/browse/PDPOS-4927) (indirectly)

### Summary
A few updates to the mobile styling of the `selection-list-screen-dialog` component, `options-list` components, the sale screen, and kebab menus to make the screens more easily readable on mobile devices. These styling changes are mostly relegated to text size, margin, padding, and spacing adjustments. Changes have been tested on both mobile and desktop views - desktop views should be unchanged (specifically kebab menus like the item options dialog).

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/39058176/113604935-f5f5be00-9613-11eb-868a-ba46f20cd0f4.png)

After:
![image](https://user-images.githubusercontent.com/39058176/113604889-e5454800-9613-11eb-9f98-32528ecd5551.png)

----

Before: 
![image](https://user-images.githubusercontent.com/39058176/113745930-c1493b80-96d3-11eb-9a98-bfe5b16ec3c2.png)

After: 
![image](https://user-images.githubusercontent.com/39058176/113746000-d2924800-96d3-11eb-9d8b-d5b266b191d3.png)

----

Before: 
![image](https://user-images.githubusercontent.com/39058176/113746165-ff465f80-96d3-11eb-96bb-20e7b5137185.png)

After:
![image](https://user-images.githubusercontent.com/39058176/113746197-0a00f480-96d4-11eb-92bf-193b3a1dbb4f.png)

----

Before:
![image](https://user-images.githubusercontent.com/39058176/113751776-446d9000-96da-11eb-9188-7d42ded844af.png)

After:
![image](https://user-images.githubusercontent.com/39058176/113752054-8c8cb280-96da-11eb-8c25-a1529533b1fe.png)
