### PR TITLE
Missing customer information indicator 

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/customer-information/customer-information.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/customer-information/customer-information.component.html
@@ -1,13 +1,13 @@
-<div class="details-row email" responsive-class>
+<div *ngIf="customer.email" class="details-row email" responsive-class>
     <app-icon [iconName]="screenData.emailIcon" [iconClass]="'material-icons mat-18'"></app-icon>{{customer.email}}
 </div>
-<div class="details-row phone-number" responsive-class>
+<div *ngIf="customer.phoneNumber" class="details-row phone-number" responsive-class>
     <app-icon [iconName]="screenData.phoneIcon" [iconClass]="'material-icons mat-18'"></app-icon>{{customer.phoneNumber | phone}}
 </div>
-<div class="details-row loyalty-number" responsive-class>
+<div *ngIf="customer.loyaltyNumber" class="details-row loyalty-number" responsive-class>
     <app-icon [iconName]="screenData.loyaltyNumberIcon" [iconClass]="'material-icons mat-18'"></app-icon>{{customer.loyaltyNumber}}
 </div>
-<div class="details-row address" responsive-class>
+<div *ngIf="customer.address" class="details-row address" responsive-class>
     <app-icon [iconName]="screenData.locationIcon" [iconClass]="'material-icons mat-18'"></app-icon>
     <div class="address-details" *ngIf="customer.address">
         <div *ngIf="customer.address.line1" class="line1">{{customer.address.line1}}</div>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/customer-information/customer-information.component.spec.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/customer-information/customer-information.component.spec.ts
@@ -83,10 +83,24 @@ describe('CustomerInformationComponent', () => {
             validateIcon(fixture, '.email app-icon', 'mail_outline');
         });
 
+        it('does not display the email when the user does not have one', () => {
+            component.customer.email = undefined;
+            fixture.detectChanges();
+
+            validateDoesNotExist(fixture, '.email');
+        });
+
         it('displays the customer phone number and icon', () => {
             const phonePipe: PhonePipe = new PhonePipe(TestBed.get(FormattersService));
             validateText(fixture, '.phone-number', phonePipe.transform(component.customer.phoneNumber));
             validateIcon(fixture, '.phone-number app-icon', 'phone');
+        });
+
+        it('does not display the customer phone when the user does not have one', () => {
+            component.customer.phoneNumber = undefined;
+            fixture.detectChanges();
+
+            validateDoesNotExist(fixture, '.phone-number');
         });
 
         it('displays the customer loyalty number and icon', () => {
@@ -94,7 +108,21 @@ describe('CustomerInformationComponent', () => {
             validateIcon(fixture, '.loyalty-number app-icon', 'account_heart');
         });
 
+        it('does not display the customer loyalty number when the user does not have one', () => {
+            component.customer.loyaltyNumber = undefined;
+            fixture.detectChanges();
+
+            validateDoesNotExist(fixture, '.loyalty-number');
+        });
+
         describe('customer address', () => {
+            it('does not display the customer loyalty number when the user does not have one', () => {
+                component.customer.address = undefined;
+                fixture.detectChanges();
+
+                validateDoesNotExist(fixture, '.address');
+            });
+
             it('displays the icon', () => {
                 validateIcon(fixture, '.address app-icon', 'place');
             });

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel-theme.scss
@@ -8,6 +8,21 @@
         .icon {
             color: map_get($foreground, icon);
         }
+        .memberships {
+            .customer-missing-info {
+                button {
+                    font-size: inherit;
+                    flex: inherit !important;
+                    overflow-x: hidden !important;
+                    white-space: pre-wrap !important;
+                    max-width: 100%;
+                    padding: 0px 10px;
+                    app-icon {
+                        padding-right: 10px;
+                    }
+                }
+            }
+        }
     }
 
     .item-counts {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.html
@@ -37,6 +37,13 @@
                     </div>
                     <div class="icon"><app-icon [iconName]="screenData.profileIcon" [iconClass]="(isMobile | async) ? null: 'material-icons mat-36'"></app-icon></div>
                     <div class="memberships">
+                        <div *ngIf="screenData.customerMissingInfoEnabled && screenData.customerMissingInfo" class="customer-missing-info">
+                            <app-warn-button responsive-class>
+                                <app-icon [iconName]="screenData.customerMissingInfoIcon"
+                                          [iconClass]="'material-icons mat-24'"></app-icon>
+                                <span class="text">{{screenData.customerMissingInfoLabel}}</span>
+                            </app-warn-button>
+                        </div>
                         <span *ngIf="!screenData.membershipEnabled" class="loyaltyId">
                             {{screenData.loyaltyIDLabel}}: {{screenData.customer.id}}
                         </span>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
@@ -66,6 +66,19 @@
                     white-space: normal;
                     @extend %text-xs;
                     grid-area: Memberships;
+                    .customer-missing-info {
+                        margin-bottom: 4px;
+                        app-warn-button {
+                            font-size: $text-sm;
+                            &.tablet-portrait {
+                                font-size: $text-sm;
+                            }
+
+                            &.mobile {
+                                font-size: $text-xs-mobile*1.25;
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.spec.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.spec.ts
@@ -15,7 +15,7 @@ import {IActionItem} from "../../../core/actions/action-item.interface";
 import {By} from "@angular/platform-browser";
 import {Configuration} from "../../../configuration/configuration";
 import {ImageUrlPipe} from "../../pipes/image-url.pipe";
-import {validateDoesNotExist, validateText} from "../../../utilites/test-utils";
+import {validateDoesNotExist, validateExist, validateIcon, validateText} from "../../../utilites/test-utils";
 
 class MockMatDialog {};
 class MockActionService {};
@@ -236,6 +236,51 @@ describe('SaleTotalPanelComponent', () => {
                             spyOn(component, 'keybindsEnabled').and.returnValue(false);
                             fixture.detectChanges();
                             validateDoesNotExist(fixture, '.sale-total-header .linked-customer-summary .loyalty-keybind');
+                        });
+
+                        describe('when customerMissingInfoEnabled is true', () => {
+                            beforeEach(() => {
+                                component.screenData.customerMissingInfoEnabled = true;
+                                fixture.detectChanges();
+                            });
+
+                            describe('when customerMissingInfo is true', () => {
+                                beforeEach(() => {
+                                    component.screenData.customerMissingInfo = true;
+                                    component.screenData.customerMissingInfoIcon = 'some icon';
+                                    component.screenData.customerMissingInfoLabel = 'some label';
+                                    fixture.detectChanges();
+                                });
+
+                                it('shows the customer missing info button', () => {
+                                    validateExist(fixture, '.customer-missing-info');
+                                    validateIcon(fixture, '.customer-missing-info app-icon', component.screenData.customerMissingInfoIcon);
+                                    validateText(fixture, '.customer-missing-info .text', component.screenData.customerMissingInfoLabel);
+                                });
+                            });
+
+                            describe('when customerMissingInfo is false', () => {
+                                beforeEach(() => {
+                                    component.screenData.customerMissingInfo = false;
+                                    component.screenData.customerMissingInfoIcon = 'some icon';
+                                    component.screenData.customerMissingInfoLabel = 'some label';
+                                    fixture.detectChanges();
+                                });
+                                it('does not show the customer missing info button', () => {
+                                    validateDoesNotExist(fixture, 'customer-missing-info');
+                                });
+                            });
+                        });
+
+                        describe('when customerMissingInfoEnabled is false', () => {
+                            beforeEach(() => {
+                                component.screenData.customerMissingInfoEnabled = false;
+                                fixture.detectChanges();
+                            });
+
+                            it('does not show the customer missing info button', () => {
+                                validateDoesNotExist(fixture, 'customer-missing-info');
+                            });
                         });
 
                         describe('when membershipEnabled is false', () => {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.interface.ts
@@ -25,4 +25,8 @@ export interface SaleTotalPanelInterface extends IAbstractScreen {
     noMembershipsFoundLabel: string;
     membershipEnabled: boolean;
     memberships: Membership[];
+    customerMissingInfoEnabled: boolean;
+    customerMissingInfo: boolean;
+    customerMissingInfoIcon: string;
+    customerMissingInfoLabel: string;
 }

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/SaleUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/SaleUIMessage.java
@@ -34,6 +34,10 @@ public class SaleUIMessage extends UIMessage {
     private String profileIcon;
     private List<UIMembership> memberships;
     private boolean membershipEnabled;
+    private boolean customerMissingInfoEnabled;
+    private boolean customerMissingInfo;
+    private String customerMissingInfoIcon;
+    private String customerMissingInfoLabel;
     private String checkMarkIcon;
     private String noMembershipsFoundLabel;
     private ActionItem mobileLoyaltyButton;


### PR DESCRIPTION
### Summary
Added an indicator to the loyalty button when a customer is linked to notify the user that the customer has required fields missing and that they should update the customer.

### Screenshots
openpos.customer.customerMissingInfo.enabled=true
openpos.customer.membership.enabled=true
customer missing information
![image](https://user-images.githubusercontent.com/2406987/113429743-081ef480-93a7-11eb-9c9e-d9ca2fd20ac4.png)

openpos.customer.customerMissingInfo.enabled=true
openpos.customer.membership.enabled=true
customer has all information
![image](https://user-images.githubusercontent.com/2406987/113429911-41576480-93a7-11eb-8da7-71eafb00ed75.png)

openpos.customer.customerMissingInfo.enabled=false 
openpos.customer.membership.enabled=true
customer missing information
![image](https://user-images.githubusercontent.com/2406987/113430150-aa3edc80-93a7-11eb-8797-93b086fc6585.png)

openpos.customer.customerMissingInfo.enabled=true 
openpos.customer.membership.enabled=true
customer has all information
![image](https://user-images.githubusercontent.com/2406987/113430187-b9be2580-93a7-11eb-835d-80edf9ac11d6.png)


openpos.customer.customerMissingInfo.enabled=true
openpos.customer.membership.enabled=false
customer missing information
![image](https://user-images.githubusercontent.com/2406987/113432069-b9735980-93aa-11eb-8f92-693c3502a15b.png)


openpos.customer.customerMissingInfo.enabled=true
openpos.customer.membership.enabled=false
customer has all information
![image](https://user-images.githubusercontent.com/2406987/113432113-cc862980-93aa-11eb-80c9-3b152188f066.png)



