### PR TITLE
Update UI for linked customer button on Sale page.

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/membership-display/membership-display.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/membership-display/membership-display.component.scss
@@ -3,7 +3,7 @@
 mat-chip {
   text-transform: uppercase;
   padding-right: 2em;
-  padding-left: 1em;
+  padding-left: 2em;
   &.tablet-portrait {
     font-size: $text-sm;
   }
@@ -13,6 +13,7 @@ mat-chip {
   }
   app-icon{
     margin-right: .5em;
+    margin-left: -.5em;
   }
 }
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.html
@@ -36,22 +36,22 @@
                         </div>
                     <div class="icon"><app-icon [iconName]="screenData.profileIcon" [iconClass]="(isMobile | async) ? null: 'material-icons mat-36'"></app-icon></div>
                     <div class="memberships">
-                        <div *ngIf="screenData.customerMissingInfoEnabled && screenData.customerMissingInfo" class="customer-missing-info">
+                        <div *ngIf="isMissingCustomerInfo()" class="customer-missing-info">
                             <app-warn-button responsive-class>
                                 <app-icon [iconName]="screenData.customerMissingInfoIcon"
                                           [iconClass]="'material-icons mat-24'"></app-icon>
                                 <span class="text">{{screenData.customerMissingInfoLabel}}</span>
                             </app-warn-button>
                         </div>
-                        <span *ngIf="!screenData.membershipEnabled" class="loyaltyId">
+                        <span *ngIf="!screenData.membershipEnabled && !isMissingCustomerInfo()" class="loyaltyId">
                             {{screenData.loyaltyIDLabel}}: {{screenData.customer.id}}
                         </span>
-                        <div *ngIf="screenData.membershipEnabled">
+                        <div *ngIf="screenData.membershipEnabled && !isMissingCustomerInfo()">
                             <div *ngFor="let membership of screenData.memberships">
                                 <app-membership-display (clickEvent)="doAction(screenData.linkedCustomerButton)" [membership]="membership"></app-membership-display>
                             </div>
                             <div *ngIf="!(screenData.memberships && screenData.memberships.length)">
-                                <span>
+                                <span class="noMembershipsFound">
                                     {{screenData.noMembershipsFoundLabel}}
                                 </span>
                             </div>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
@@ -44,8 +44,8 @@
                 grid-template-rows: auto 1fr;
                 gap: 0px 0px;
                 grid-template-areas:
-                    "Name Name"
-                    "Icon Memberships";
+                    "Icon Name"
+                    "Memberships Memberships";
                 .name {
                     grid-area: Name;
                     .customer-name {
@@ -61,6 +61,16 @@
                 }
                 .memberships {
                     grid-area: Memberships;
+                    display: flex;
+                    flex-direction: row;
+                    div{
+                        display: flex;
+                        flex-wrap: wrap;
+                        app-membership-display{
+                            margin: .2em .2em;
+                        }
+                    }
+
                     .customer-missing-info {
                         margin-bottom: 4px;
                         app-warn-button {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.spec.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.spec.ts
@@ -257,6 +257,23 @@ describe('SaleTotalPanelComponent', () => {
                                     validateIcon(fixture, '.customer-missing-info app-icon', component.screenData.customerMissingInfoIcon);
                                     validateText(fixture, '.customer-missing-info .text', component.screenData.customerMissingInfoLabel);
                                 });
+                                it('dose not show the customer memberships', function () {
+                                    component.screenData.membershipEnabled = true;
+                                    component.screenData.memberships = [
+                                        { id: '123', name: 'membership1', member: true},
+                                        { id: '124', name: 'membership2', member: false},
+                                        { id: '125', name: 'membership3', member: false}
+                                    ];
+                                    fixture.detectChanges();
+                                    validateDoesNotExist(fixture, 'app-membership-display');
+                                    component.screenData.membershipEnabled = false;
+                                    component.screenData.memberships = [];
+                                    fixture.detectChanges();
+
+                                });
+                                it('dose not show the no memberships label', function () {
+                                    validateDoesNotExist(fixture, '.noMembershipsFound')
+                                });
                             });
 
                             describe('when customerMissingInfo is false', () => {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.ts
@@ -54,4 +54,8 @@ export class SaleTotalPanelComponent extends ScreenPartComponent<SaleTotalPanelI
     public doMenuItemAction(menuItem: IActionItem) {
         this.doAction(menuItem);
     }
+
+    public isMissingCustomerInfo() {
+        return this.screenData.customerMissingInfoEnabled && this.screenData.customerMissingInfo
+    }
 }


### PR DESCRIPTION
### Summary
A number of different change have made it into this feature.
- Moved avatar icon to first line before the customers name. 
- Membership chips now display horizontally and wrap.
- Membership chip css altered to make chips with no checkmark have symmetrical padding.
- When missing customer information tab is showing customer membership information no long shows.
- Added testing for changes sale-total-panel component.

### Screenshots

With memberships.
![Screen Shot 2021-04-06 at 3 13 03 PM](https://user-images.githubusercontent.com/16402926/113768212-95d34a80-96ed-11eb-8f62-ab443f9ac3f2.png)

With missing customer information.
![Screen Shot 2021-04-06 at 3 35 29 PM](https://user-images.githubusercontent.com/16402926/113768438-d8952280-96ed-11eb-9716-c59351caab34.png)
