### PR TITLE
Better logging for jackson serialization failures.  Exception gets swallowed.

### DIFF
--- a/openpos-util/src/main/java/org/jumpmind/pos/util/web/ConfiguredRestTemplate.java
+++ b/openpos-util/src/main/java/org/jumpmind/pos/util/web/ConfiguredRestTemplate.java
@@ -62,7 +62,25 @@ public class ConfiguredRestTemplate extends RestTemplate {
     public ConfiguredRestTemplate(int timeout) {
         super(build(timeout));
         this.mapper = DefaultObjectMapper.build();
-        getMessageConverters().add(0, new MappingJackson2HttpMessageConverter(this.mapper));
+        getMessageConverters().add(0, new MappingJackson2HttpMessageConverter(this.mapper) {
+
+            @Override
+            public boolean canRead(java.lang.Class<?> clazz,
+                                   org.springframework.http.MediaType mediaType) {
+                return true;
+            }
+            @Override
+            public boolean canRead(java.lang.reflect.Type type,
+                                   java.lang.Class<?> contextClass,
+                                   org.springframework.http.MediaType mediaType) {
+                return true;
+            }
+            @Override
+            protected boolean canRead(
+                    org.springframework.http.MediaType mediaType) {
+                return true;
+            }
+        });
         List<ClientHttpRequestInterceptor> interceptors = new ArrayList<>();
         interceptors.add(new LoggingRequestInterceptor());
         setInterceptors(interceptors);


### PR DESCRIPTION
### Summary
Better logging for jackson serialization failures.  Exception gets swallowed.

Was getting: Could not extract response. no suitable HttpMessageConverter found
Now we see the actual serialization error.
