### PR TITLE
Support mutable longs in the persistence layer

### DIFF
--- a/openpos-util/src/main/java/org/jumpmind/pos/util/ReflectUtils.java
+++ b/openpos-util/src/main/java/org/jumpmind/pos/util/ReflectUtils.java
@@ -1,6 +1,7 @@
 package org.jumpmind.pos.util;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.mutable.MutableLong;
 import org.apache.commons.lang3.time.DateUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,8 +20,6 @@ import static org.apache.commons.beanutils.BeanUtils.copyProperty;
 
 @Slf4j
 public class ReflectUtils {
-
-    static final Logger log = LoggerFactory.getLogger(ReflectUtils.class);
 
     public static void setProperty(Field field, Object target, Object value) {
         value = messageNulls(field, value);
@@ -69,6 +68,8 @@ public class ReflectUtils {
             value = ((Number) value).intValue();
         } else if (field.getType().equals(BigDecimal.class) && value instanceof Number) {
             value = new BigDecimal(value.toString());
+        } else if ((field.getType().equals(MutableLong.class) || field.getType().equals(Long.class)) && value instanceof Number) {
+            value = ((Number) value).longValue();
         } else if ((field.getType().equals(Boolean.class) || field.getType().equals(boolean.class))
                 && (value instanceof Number)) {
             Number number = (Number) value;


### PR DESCRIPTION
### Summary
Support mutable longs in the persistence layer.

The symptom was this:

2021-04-08T20:48:42.521943783Zorg.jumpmind.pos.persist.PersistException: Failed to execute query. Name: selectMaxJobNumber result class: class org.apache.commons.lang3.mutable.MutableLong Parameters: null at org.jumpmind.pos.persist.DBSession.query(DBSession.java:313) at org.jumpmind.pos.persist.DBSession.query(DBSession.java:255) at org.jumpmind.pos.persist.DBSession.query(DBSession.java:235) at org.jumpmind.pos.vertex.service.RunIntegrationEndpoint.getNextJobNumber(RunIntegrationEndpoint.java:147) at org.jumpmind.pos.vertex.service.RunIntegrationEndpoint.buildJobStatuses(RunIntegrationEndpoint.java:155) at org.jumpmind.pos.vertex.service.RunIntegrationEndpoint.runIntegration(RunIntegrationEndpoint.java:61) at org.jumpmind.pos.vertex.service.RunIntegrationEndpoint$$FastClassBySpringCGLIB$$f26bc43.invoke(<generated>) at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218) at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:771) at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163) at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:749) at org.springframework.aop.interceptor.AsyncExecutionInterceptor.lambda$invoke$0(AsyncExecutionInterceptor.java:115) at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264) at java.base/java.lang.Thread.run(Thread.java:832) Caused by: org.jumpmind.pos.persist.PersistException: Failed to execute sql: select max(job_number) as value from vertex_job_step_status at org.jumpmind.pos.persist.DBSession.queryInternal(DBSession.java:697) at org.jumpmind.pos.persist.DBSession.query(DBSession.java:310) ... 13 common frames omitted Caused by: org.jumpmind.pos.util.ReflectionException: Failed to set field 'value' on target '0' to value '1' at org.jumpmind.pos.util.ReflectUtils.setProperty(ReflectUtils.java:42) at org.jumpmind.pos.util.ReflectUtils.setProperty(ReflectUtils.java:93) at org.jumpmind.pos.util.ReflectUtils.setProperty(ReflectUtils.java:86) at org.jumpmind.pos.persist.DBSession.mapNonModel(DBSession.java:845) at org.jumpmind.pos.persist.DBSession.queryInternal(DBSession.java:685) ... 14 common frames omitted Caused by: java.lang.IllegalArgumentException: Can not set long field org.apache.commons.lang3.mutable.MutableLong.value to java.math.BigDecimal at java.base/jdk.internal.reflect.UnsafeFieldAccessorImpl.throwSetIllegalArgumentException(UnsafeFieldAccessorImpl.java:167) at java.base/jdk.internal.reflect.UnsafeFieldAccessorImpl.throwSetIllegalArgumentException(UnsafeFieldAccessorImpl.java:171) at java.base/jdk.internal.reflect.UnsafeLongFieldAccessorImpl.set(UnsafeLongFieldAccessorImpl.java:102) at java.base/java.lang.reflect.Field.set(Field.java:778) at org.jumpmind.pos.util.ReflectUtils.setProperty(ReflectUtils.java:31) ... 18 common frames omitted
