### PR TITLE
Theme and sass variable updates for membership features

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/membership-display/_membership-display-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/membership-display/_membership-display-theme.scss
@@ -1,7 +1,7 @@
 @mixin membership-display-theme($theme) {
     $foreground: map-get($theme, foreground );
-    $membership-in-color: map-get($theme, membership-in-color );
-    $membership-in-background: map-get($theme, membership-in-background );
+    $openpos-membership-in-color: map-get($theme, openpos-membership-in-color );
+    $openpos-membership-in-background: map-get($theme, openpos-membership-in-background );
 
     .membership-chips {
         mat-chip.not-in {
@@ -11,8 +11,8 @@
         }
 
         mat-chip.in {
-            color: $membership-in-color !important;
-            background-color: $membership-in-background !important;
+            color: $openpos-membership-in-color !important;
+            background-color: $openpos-membership-in-background !important;
         }
     }
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel-theme.scss
@@ -30,9 +30,9 @@
     }
 
     .link-customer {
-        color: mat-color($theme, link-customer-color);
-        background-color: mat-color($theme, link-customer-background);
-        border-color: mat-color($theme, link-customer-background);
+        color: mat-color($theme, openpos-link-customer-color);
+        background-color: mat-color($theme, openpos-link-customer-background);
+        border-color: mat-color($theme, openpos-link-customer-background);
         border-style: solid;
         white-space: break-spaces;
         max-width: 100%;

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/themes/_bang-orange-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/themes/_bang-orange-theme.scss
@@ -5,7 +5,21 @@
     $openpos-app-accent :  mat-palette($mat-blue, 600, 600, 900);
     $openpos-app-warn : mat-palette($mat-red);
     $openpos-app-selected :  mat-palette($mat-green, 800, 600, 900);
-    $openpos-theme: openpos-theme-light($openpos-app-primary, $openpos-app-accent, $openpos-app-warn, $openpos-app-selected);
+
+    $link-customer-color: #ffffff;
+    $link-customer-background: #ff9800;
+
+    $membership-in-color: #ffffff;
+    $membership-in-background: #ff9800;
+
+    $addons: (
+            link-customer-color: $link-customer-color,
+            link-customer-background: $link-customer-background,
+            membership-in-color: $membership-in-color,
+            membership-in-background: $membership-in-background
+    );
+
+    $openpos-theme: openpos-theme-light($openpos-app-primary, $openpos-app-accent, $openpos-app-warn, $openpos-app-selected, $addons);
 
     .bang-orange-theme {
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/themes/_bang-orange-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/themes/_bang-orange-theme.scss
@@ -6,17 +6,17 @@
     $openpos-app-warn : mat-palette($mat-red);
     $openpos-app-selected :  mat-palette($mat-green, 800, 600, 900);
 
-    $link-customer-color: #ffffff;
-    $link-customer-background: #ff9800;
+    $openpos-link-customer-color: #ffffff;
+    $openpos-link-customer-background: #ff9800;
 
-    $membership-in-color: #ffffff;
-    $membership-in-background: #ff9800;
+    $openpos-membership-in-color: #ffffff;
+    $openpos-membership-in-background: #ff9800;
 
     $addons: (
-            link-customer-color: $link-customer-color,
-            link-customer-background: $link-customer-background,
-            membership-in-color: $membership-in-color,
-            membership-in-background: $membership-in-background
+            openpos-link-customer-color: $openpos-link-customer-color,
+            openpos-link-customer-background: $openpos-link-customer-background,
+            openpos-membership-in-color: $openpos-membership-in-color,
+            openpos-membership-in-background: $openpos-membership-in-background
     );
 
     $openpos-theme: openpos-theme-light($openpos-app-primary, $openpos-app-accent, $openpos-app-warn, $openpos-app-selected, $addons);

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/themes/_openpos-default-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/themes/_openpos-default-theme.scss
@@ -4,7 +4,20 @@
     $openpos-default-app-warn : mat-palette($mat-red);
     $openpos-default-app-selected : mat-palette($mat-green);
 
-    $openpos-default-theme: openpos-theme-light($openpos-default-app-primary, $openpos-default-app-accent, $openpos-default-app-warn, $openpos-default-app-selected);
+    $link-customer-color: #ffffff;
+    $link-customer-background: #296db6;
+
+    $membership-in-color: #ffffff;
+    $membership-in-background: #64834D;
+
+    $addons: (
+            link-customer-color: $link-customer-color,
+            link-customer-background: $link-customer-background,
+            membership-in-color: $membership-in-color,
+            membership-in-background: $membership-in-background
+    );
+
+    $openpos-default-theme: openpos-theme-light($openpos-default-app-primary, $openpos-default-app-accent, $openpos-default-app-warn, $openpos-default-app-selected, $addons);
 
     // Clients can extend this using
     //   @extend %openpos-default-theme-base;

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/themes/_openpos-default-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/themes/_openpos-default-theme.scss
@@ -4,17 +4,17 @@
     $openpos-default-app-warn : mat-palette($mat-red);
     $openpos-default-app-selected : mat-palette($mat-green);
 
-    $link-customer-color: #ffffff;
-    $link-customer-background: #296db6;
+    $openpos-link-customer-color: #ffffff;
+    $openpos-link-customer-background: #296db6;
 
-    $membership-in-color: #ffffff;
-    $membership-in-background: #64834D;
+    $openpos-membership-in-color: #ffffff;
+    $openpos-membership-in-background: #64834D;
 
     $addons: (
-            link-customer-color: $link-customer-color,
-            link-customer-background: $link-customer-background,
-            membership-in-color: $membership-in-color,
-            membership-in-background: $membership-in-background
+            openpos-link-customer-color: $openpos-link-customer-color,
+            openpos-link-customer-background: $openpos-link-customer-background,
+            openpos-membership-in-color: $openpos-membership-in-color,
+            openpos-membership-in-background: $openpos-membership-in-background
     );
 
     $openpos-default-theme: openpos-theme-light($openpos-default-app-primary, $openpos-default-app-accent, $openpos-default-app-warn, $openpos-default-app-selected, $addons);


### PR DESCRIPTION
### Summary
Renaming of sass variables to denote where it is used in a theme. Updated base themes have the variables wired up and with a default color that fits. (dark-blue being asked for by petco)

### Screenshots
**burl-theme**
![burl_them_linked](https://user-images.githubusercontent.com/2406987/114100528-6f9adf80-9892-11eb-8088-bb70fe197207.png)
![burl_theme_unlinked](https://user-images.githubusercontent.com/2406987/114100529-6f9adf80-9892-11eb-932b-5a2fdd0daac9.png)


**dark-blue-theme (petco requested)**
![dark_blue_theme_linked](https://user-images.githubusercontent.com/2406987/114100530-70337600-9892-11eb-9fc6-4c88bb77ad35.png)
![dark_blue_theme_unlinked](https://user-images.githubusercontent.com/2406987/114100531-70337600-9892-11eb-88eb-3c1cf22b5f64.png)


**default-theme**
![default_theme_linked](https://user-images.githubusercontent.com/2406987/114100532-70337600-9892-11eb-9d3f-4bd4e1d7adc2.png)
![default_theme_unlinked](https://user-images.githubusercontent.com/2406987/114100533-70337600-9892-11eb-9c6c-cca37271e7a7.png)


**openpos-default-theme**
![openpos_default_theme_linked](https://user-images.githubusercontent.com/2406987/114100534-70cc0c80-9892-11eb-9648-7c1751b966eb.png)
![openpos_default_theme_unlinked](https://user-images.githubusercontent.com/2406987/114100535-70cc0c80-9892-11eb-9879-808a3536618c.png)


**patriotic-bird-theme**
![patriotic_bird_theme_linked](https://user-images.githubusercontent.com/2406987/114100537-70cc0c80-9892-11eb-959b-8481b2bed9ee.png)
![patriotic_bird_theme_unlinked](https://user-images.githubusercontent.com/2406987/114100539-7164a300-9892-11eb-97b2-c17adc2d706f.png)



**patriotic-nest-theme**
![patriotic_nest_theme_linked](https://user-images.githubusercontent.com/2406987/114100540-7164a300-9892-11eb-84dc-508f632969e0.png)
![patriotic_nest_theme_unlinked](https://user-images.githubusercontent.com/2406987/114100541-7164a300-9892-11eb-937c-bebc427ac664.png)


**pets-theme**
![pats_theme_linked](https://user-images.githubusercontent.com/2406987/114100543-7164a300-9892-11eb-8c43-d221255299b7.png)
![pats_theme_unlinked](https://user-images.githubusercontent.com/2406987/114100544-71fd3980-9892-11eb-8355-040556a13787.png)


**training-theme**
![training_theme_linked](https://user-images.githubusercontent.com/2406987/114100545-71fd3980-9892-11eb-9297-04c94c31bb52.png)
![training_theme_unlinked](https://user-images.githubusercontent.com/2406987/114100547-71fd3980-9892-11eb-8b42-27d738d04036.png)


**bang-orange-theme**
![bang_orange_theme_linked](https://user-images.githubusercontent.com/2406987/114100513-6578e100-9892-11eb-8e20-b8821a79c834.png)
![bang_orange_theme_unlinked](https://user-images.githubusercontent.com/2406987/114100514-6578e100-9892-11eb-9eda-f35db28e8e51.png)

