### PR TITLE
Set beforeCancel to null when done with work

### DIFF
--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/AsyncExecutor.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/AsyncExecutor.java
@@ -67,6 +67,8 @@ public class AsyncExecutor {
                 } else if (handleCancel != null) {
                     handleCancel.accept(null);
                 }
+            } finally {
+                this.beforeCancel = null;
             }
         });
     }


### PR DESCRIPTION
### Summary
When logging out the state manager is reinitialized which causes all the async executors to be canceled. Since the beforeCancel runnable was never reset after the executing the async work it would run on logout when there was really nothing to cancel.
