### PR TITLE
Exceptions on XML responses

### DIFF
--- a/openpos-util/src/main/java/org/jumpmind/pos/util/web/ConfiguredRestTemplate.java
+++ b/openpos-util/src/main/java/org/jumpmind/pos/util/web/ConfiguredRestTemplate.java
@@ -21,7 +21,10 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.security.cert.X509Certificate;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Slf4j
 public class ConfiguredRestTemplate extends RestTemplate {

--- a/openpos-util/src/main/java/org/jumpmind/pos/util/web/ConfiguredRestTemplate.java
+++ b/openpos-util/src/main/java/org/jumpmind/pos/util/web/ConfiguredRestTemplate.java
@@ -21,16 +21,13 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @Slf4j
 public class ConfiguredRestTemplate extends RestTemplate {
 
     ObjectMapper mapper;
-    
+
     private Map<String, String> additionalHeaders;
 
     static BufferingClientHttpRequestFactory build(int timeout) {
@@ -67,18 +64,13 @@ public class ConfiguredRestTemplate extends RestTemplate {
             @Override
             public boolean canRead(java.lang.Class<?> clazz,
                                    org.springframework.http.MediaType mediaType) {
-                return true;
+                return super.canRead(mediaType);
             }
             @Override
             public boolean canRead(java.lang.reflect.Type type,
                                    java.lang.Class<?> contextClass,
                                    org.springframework.http.MediaType mediaType) {
-                return true;
-            }
-            @Override
-            protected boolean canRead(
-                    org.springframework.http.MediaType mediaType) {
-                return true;
+                return super.canRead(mediaType);
             }
         });
         List<ClientHttpRequestInterceptor> interceptors = new ArrayList<>();
@@ -111,7 +103,7 @@ public class ConfiguredRestTemplate extends RestTemplate {
         });
 
     }
-    
+
     public void addHeader(String name, String value){
         if( additionalHeaders == null){
             additionalHeaders = new HashMap<>();
@@ -147,11 +139,11 @@ public class ConfiguredRestTemplate extends RestTemplate {
     public HttpHeaders buildHeaders() {
         HttpHeaders headers = new HttpHeaders();
         headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
-        
+
         if( additionalHeaders != null){
             additionalHeaders.forEach((s, s2) -> headers.set(s, s2));
         }
-        
+
         return headers;
     }
 


### PR DESCRIPTION
### Summary 
The previous commit #1244 was always allowing Jackson to handle the deserialization of messages. For AEO the email service returns XML with a correct MediaType of application/xml. Jackson was trying to handle this message instead of delegating to the XML deserializer. Changing these overrides to only use the jackson message converter if the message is of the appropriate media type.

```
org.springframework.web.client.RestClientException: Error while extracting response for type [class java.lang.String] and content type [application/xml;charset=utf-8]; nested exception is org.springframework.http.converter.HttpMessageNotReadableException: JSON parse error: Unexpected character ('<' (code 60)): expected a valid value (JSON String, Number, Array, Object or token 'null', 'true' or 'false'); nested exception is com.fasterxml.jackson.core.JsonParseException: Unexpected character ('<' (code 60)): expected a valid value (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
 at [Source: (ByteArrayInputStream); line: 1, column: 2]
	at org.springframework.web.client.HttpMessageConverterExtractor.extractData(HttpMessageConverterExtractor.java:120)
	at org.springframework.web.client.RestTemplate$ResponseEntityResponseExtractor.extractData(RestTemplate.java:998)
	at org.springframework.web.client.RestTemplate$ResponseEntityResponseExtractor.extractData(RestTemplate.java:981)
	at org.springframework.web.client.RestTemplate.doExecute(RestTemplate.java:741)
	at org.springframework.web.client.RestTemplate.execute(RestTemplate.java:674)
	at org.springframework.web.client.RestTemplate.exchange(RestTemplate.java:583)
	at org.jumpmind.pos.util.web.ConfiguredRestTemplate.execute(ConfiguredRestTemplate.java:131)
	at org.jumpmind.pos.document.EmailClient.emailReceipt(EmailClient.java:42)
	at org.jumpmind.pos.document.EmailClient$$FastClassBySpringCGLIB$$afab592.invoke(<generated>)
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218)
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:687)
	at org.jumpmind.pos.document.EmailClient$$EnhancerBySpringCGLIB$$f7ece1a7.emailReceipt(<generated>)
	at org.jumpmind.pos.document.service.AeoEmailReceiptEndpoint.emailReceipt(AeoEmailReceiptEndpoint.java:82)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.jumpmind.pos.service.strategy.LocalOnlyStrategy.invoke(LocalOnlyStrategy.java:35)
	at org.jumpmind.pos.service.EndpointInvoker.invoke(EndpointInvoker.java:250)
	at com.sun.proxy.$Proxy140.emailReceipt(Unknown Source)
	at org.jumpmind.pos.document.service.EmailReceiptQueueWorker.doWork(EmailReceiptQueueWorker.java:32)
	at org.jumpmind.pos.sales.service.trans.ProcessWorkQueueEndpoint.lambda$processWorkQueue$0(ProcessWorkQueueEndpoint.java:42)
	at java.util.ArrayList.forEach(ArrayList.java:1257)
	at org.jumpmind.pos.sales.service.trans.ProcessWorkQueueEndpoint.processWorkQueue(ProcessWorkQueueEndpoint.java:36)
	at sun.reflect.GeneratedMethodAccessor127.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.jumpmind.pos.service.strategy.LocalOnlyStrategy.invoke(LocalOnlyStrategy.java:35)
	at org.jumpmind.pos.service.EndpointInvoker.invoke(EndpointInvoker.java:250)
	at com.sun.proxy.$Proxy137.processWorkQueue(Unknown Source)
	at org.jumpmind.pos.app.jobs.ProcessWorkQueueJob.execute(ProcessWorkQueueJob.java:16)
	at org.jumpmind.pos.context.service.JobManager$JobRunner.run(JobManager.java:215)
	at org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54)```