### PR TITLE
Adding support for displaying card numbers for partial tender list

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/tender-part/tender-part.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/tender-part/tender-part.component.html
@@ -10,14 +10,15 @@
     class="tender-amounts-outer">
     <div *ngFor="let amount of screenData.amounts; let i = index;" responsive-class
         class="tender-amount-row tender-amount-outer" [ngClass]="{'void-tender-row' : amount.voidButton}">
-        <app-icon-button *ngIf="amount.voidButton" [iconName]="amount.voidButton.icon"
+        <app-icon-button class="tender-amount-void" *ngIf="amount.voidButton" [iconName]="amount.voidButton.icon"
             (buttonClick)="voidTender(amount, i)"></app-icon-button>
         <div class="tender-amount-name">{{amount.name}}</div>
+        <div class="tender-amount-card-number">{{amount.cardNumber}}</div>
         <div class="tender-amount">
             <app-currency-text [amountText]="amount.amount"></app-currency-text>
         </div>
     </div>
-    <div responsive-class class="tender-border-color tender-amount-row tender-remaining-balance-outer">
+    <div responsive-class class="tender-border-color tender-balance-row tender-remaining-balance-outer">
         <div class="tender-remaining-balance-name">{{screenData.amountDue.name}}</div>
         <div class="tender-remaining-balance">
             <app-currency-text [amountText]="screenData.amountDue.amount"></app-currency-text>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/tender-part/tender-part.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/tender-part/tender-part.component.scss
@@ -105,22 +105,55 @@
     @extend %text-md;
 }
 
-.tender-amount-row {
+.tender-balance-row {
     display: grid;
     grid-template-columns: auto auto;
     column-gap: 16px;
 }
 
+.tender-amount-row {
+    display: grid;
+    grid-template-columns: auto auto auto;
+    grid-template-areas: "name cardnumber amount";
+    column-gap: 16px;
+
+    &.mobile {
+        grid-template-columns: auto auto;
+        grid-template-areas:
+                "name amount"
+                "cardnumber cardnumber";
+    }
+}
+
 .void-tender-row {
-    grid-template-columns: auto 1fr 1fr;
+    grid-template-columns: auto 1fr 2fr 1fr;
+    grid-template-areas: "void name cardnumber amount";
+
+    &.mobile {
+        grid-template-columns: auto 1fr 1fr;
+        grid-template-areas:
+                "void name amount"
+                ". cardnumber cardnumber";
+    }
 }
 
 .tender-amount {
+    grid-area: amount;
     justify-self: end;
     align-self: center;
 }
 
+.tender-amount-void {
+    grid-area: void;
+}
+
+.tender-amount-card-number {
+    grid-area: cardnumber;
+    align-self: center;
+}
+
 .tender-amount-name {
+    grid-area: name;
     align-self: center;
 }
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/tender-part/tender.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/tender-part/tender.interface.ts
@@ -2,5 +2,6 @@ import { ITotal } from '../../../core/interfaces/total.interface';
 import { IActionItem } from '../../../core/actions/action-item.interface';
 
 export interface ITender extends ITotal {
+    cardNumber: string;
     voidButton: IActionItem;
 }

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/model/Tender.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/model/Tender.java
@@ -1,10 +1,16 @@
 package org.jumpmind.pos.core.model;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.jumpmind.pos.core.ui.ActionItem;
 
+@Getter
+@Setter
 public class Tender extends Total {
 
     private ActionItem voidButton;
+
+    private String cardNumber;
 
     public Tender(String name, String amount) {
         super(name, amount);
@@ -12,14 +18,6 @@ public class Tender extends Total {
 
     public Tender(String name, String amount, ActionItem voidButton) {
         super(name, amount);
-        this.voidButton = voidButton;
-    }
-
-    public ActionItem getVoidButton() {
-        return voidButton;
-    }
-
-    public void setVoidButton(ActionItem voidButton) {
         this.voidButton = voidButton;
     }
 }


### PR DESCRIPTION
### Summary
Support for displaying the card number on when performing partial tenders on the tender summary screen. There will be configuration in commerce to set which tender type codes this will apply to. For AEO will support gift cards and store credit.

### Screenshots
<img width="1676" alt="Screen Shot 2021-04-13 at 1 09 04 PM" src="https://user-images.githubusercontent.com/45565101/114592919-78f0c700-9c59-11eb-9d89-72fcbc77f8b0.png">

<img width="353" alt="Screen Shot 2021-04-13 at 1 10 09 PM" src="https://user-images.githubusercontent.com/45565101/114593024-9b82e000-9c59-11eb-9524-5021ab94d68e.png">



