### PR TITLE
Should always return implementation match for endpoint overrides

### DIFF
--- a/openpos-service/src/main/java/org/jumpmind/pos/service/EndpointInvoker.java
+++ b/openpos-service/src/main/java/org/jumpmind/pos/service/EndpointInvoker.java
@@ -194,23 +194,14 @@ public class EndpointInvoker implements InvocationHandler {
 
     protected Object findBestEndpointOverrideMatch(String path, String implementation, Collection<Object> endpointOverrides) {
         Object bestMatch = null;
-        List<SimpleEntry<Object,EndpointOverride>> pathMatchedOverrides = endpointOverrides.stream()
-                .map(o -> new SimpleEntry<>(o, ClassUtils.resolveAnnotation(EndpointOverride.class, o)))
+        List<SimpleEntry<Object, EndpointOverride>> pathMatchedOverrides = endpointOverrides.stream()
+                .map(o -> new SimpleEntry<Object, EndpointOverride>(o, ClassUtils.resolveAnnotation(EndpointOverride.class, o)))
                 .filter(entry -> entry.getValue().path().equals(path)
                 ).collect(Collectors.toList());
 
         if (pathMatchedOverrides.size() > 0) {
-            List<SimpleEntry<Object, EndpointOverride>> implMatchedOverrides;
-            if(pathMatchedOverrides.stream().anyMatch(entry -> entry.getValue().implementation().equals(implementation))) {
-                implMatchedOverrides = pathMatchedOverrides.stream()
-                        .filter(entry -> entry.getValue().implementation().equals(implementation))
-                        .collect(Collectors.toList());
-            }  else {
-                implMatchedOverrides = pathMatchedOverrides.stream()
-                        .filter(entry -> entry.getValue().implementation().equals(Endpoint.IMPLEMENTATION_DEFAULT))
-                        .collect(Collectors.toList());
-            }
-
+            List<SimpleEntry<Object, EndpointOverride>> implMatchedOverrides = pathMatchedOverrides.stream()
+                    .filter(entry -> entry.getValue().implementation().equals(implementation)).collect(Collectors.toList());
             if (implMatchedOverrides.size() > 1) {
                 throw new IllegalStateException(
                         String.format("Found %d EndpointOverrides having path '%s' and implementation '%s'. Expected only one.",
@@ -339,7 +330,7 @@ public class EndpointInvoker implements InvocationHandler {
                     }
                 }
             }
-            log.debug("{}.{}() {}",
+            log.info("{}.{}() {}",
                     method.getDeclaringClass().getSimpleName(),
                     method.getName(),
                     implementation == null || Endpoint.IMPLEMENTATION_DEFAULT.equals(implementation) ? "" : implementation + " implementation");


### PR DESCRIPTION
### Summary
Should always return implementation match for endpoint overrides