### PR TITLE
Added loyaltyIDLabel field for returns that is expected by UI

### DIFF
--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/ReturnUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/ReturnUIMessage.java
@@ -28,6 +28,7 @@ public class ReturnUIMessage extends UIMessage {
     private ActionItem linkedCustomerButton;
     private ActionItem linkedEmployeeButton;
     private ActionItem removeReceiptAction;
+    private String loyaltyIDLabel;
 
     private boolean transactionActive = false;
 


### PR DESCRIPTION
### Issues Fixed
Loyalty ID label was missing in the returns screen

### Summary
The same field is used in the sale screen and was missing at the returns screen.

### Screenshots
Before the fix at the left and after it at the right.
<img width="349" alt="Before" src="https://user-images.githubusercontent.com/74003404/114717542-30630780-9d46-11eb-94e7-a1080208bab3.png"> <img width="347" alt="After" src="https://user-images.githubusercontent.com/74003404/114717556-348f2500-9d46-11eb-90df-d83dbbbe581d.png">