### PR TITLE
update tender-part to have row-gap be 16px for desktop-landscape and …

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/tender-part/tender-part.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/tender-part/tender-part.component.scss
@@ -7,11 +7,9 @@
     align-content: center;
     row-gap: 32px;
 
+    &.desktop-landscape,
+    &.tablet,
     &.mobile {
-        row-gap: 16px;
-    }
-
-    &.tablet {
         row-gap: 16px;
     }
 }
@@ -148,6 +146,7 @@
     justify-self: center;
     text-align: center;
     max-width: 50%;
+    margin: -16px 0;
 
     &.mobile {
         max-width: 75%;


### PR DESCRIPTION
### Issues Fixed
[PDPOS-5045](https://petcoalm.atlassian.net/browse/PDPOS-5045)

### Summary
After donation option was added to tender screen, we lost some space for the tender options which resulted in tender options overflowing for a resolution of 1366x768. Updated the tender-part to have row-gap be 16px for desktop-landscape and also trim down some of the space around the instructions

### Screenshots
Before:
<img width="1028" alt="Screen Shot 2021-04-15 at 3 59 51 PM" src="https://user-images.githubusercontent.com/6811136/114932242-42f04600-9e05-11eb-8505-6f64531294d2.png">

After (included screenshots of change different sized screens as well):
<img width="1028" alt="Screen Shot 2021-04-15 at 3 54 52 PM" src="https://user-images.githubusercontent.com/6811136/114932321-57344300-9e05-11eb-922d-e43e13498496.png">
<img width="1679" alt="Screen Shot 2021-04-15 at 4 01 32 PM" src="https://user-images.githubusercontent.com/6811136/114932334-5bf8f700-9e05-11eb-8746-164bc95deb82.png">
<img width="1124" alt="Screen Shot 2021-04-15 at 4 02 16 PM" src="https://user-images.githubusercontent.com/6811136/114932342-5f8c7e00-9e05-11eb-9b14-d26742c1d39f.png">
<img width="303" alt="Screen Shot 2021-04-15 at 4 03 27 PM" src="https://user-images.githubusercontent.com/6811136/114932381-6c10d680-9e05-11eb-81b3-250f66478829.png">
<img width="523" alt="Screen Shot 2021-04-15 at 4 03 49 PM" src="https://user-images.githubusercontent.com/6811136/114932392-70d58a80-9e05-11eb-85e9-c0141325e17d.png">

