### PR TITLE
Cherry Pick Training Mode Bug Fixes From Master

### DIFF
--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/DatabaseSchema.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/DatabaseSchema.java
@@ -34,6 +34,7 @@ import org.jumpmind.pos.util.model.ITypeCode;
 import org.jumpmind.pos.util.clientcontext.ClientContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.AnnotationConfigurationException;
 
 public class DatabaseSchema {
 
@@ -59,8 +60,8 @@ public class DatabaseSchema {
         this.entityExtensionClasses = entityExtensionClasses;
         this.augmenterHelper = augmenterHelper;
         if (clientContext == null)  {
-            log.error("ClientContext is null in {}, initialization error", this.getClass().getSimpleName());
-            //  TODO  Should this throw an exception instead?
+            log.error("Autowired ClientContext is null in {}: Initialization error", this.getClass().getSimpleName());
+            throw new AnnotationConfigurationException("Failed to autowire the ClientContext for database initialization, see AbstractRDBMSModule.clientContext");
         }
         this.clientContext = clientContext;
         this.shadowTablesConfig = shadowTablesConfig;


### PR DESCRIPTION
### Issues Fixed
Bring some of the last Training Mode changes/fixes made on master over to 1.10.

### Summary
Bring over these bug fixes from master:

1.  Add the ability for database modules to initialize their shadow table configurations. This is mostly useful for writing tests.
2. Throw an exception if the ClientContext is null during database initialization.
3. Add support for shadow tables to create tag and/or augmented columns when they are created. 

### Database Changes
None per se other than creating a shadow table with tag or augmented columns correctly.