### PR TITLE
Bugfix/tender option flow off screen master

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/option-button/option-button.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/option-button/option-button.component.scss
@@ -80,6 +80,7 @@
 
 .option-right {
     min-width: 64px;
+    text-align: end;
 }
 
 ::ng-deep .option-item {
@@ -92,7 +93,7 @@
 
     &.mobile {
         .mat-button-wrapper {
-            grid-template-columns: 16px 1fr 16px;
+            grid-template-columns: 16px 1fr auto;
             display: grid !important;
             column-gap: 4px;
         }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/tender-part/tender-part.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/tender-part/tender-part.component.html
@@ -45,7 +45,8 @@
 </app-instructions>
 
 <app-options-list *ngIf="screenData.optionsList" (optionClick)="doAction($event)" responsive-class
-    class="tender-options" listSize="3" [overflowPanelClass]="'tender-options'" [overflowPanelWidth]="'75vw'">
+    class="tender-options" listSize="3" [overflowPanelClass]="'tender-options'"
+                  [optionListSizeClass]="'md'" [overflowPanelWidth]="'75vw'">
 </app-options-list>
 
 <img *ngIf="screenData.imageUrl" [src]="screenData.imageUrl | imageUrl" class="tender-payment-auth-image">

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/tender-part/tender-part.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/tender-part/tender-part.component.scss
@@ -7,11 +7,9 @@
     align-content: center;
     row-gap: 32px;
 
+    &.desktop-landscape,
+    &.tablet,
     &.mobile {
-        row-gap: 16px;
-    }
-
-    &.tablet {
         row-gap: 16px;
     }
 }
@@ -181,6 +179,7 @@
     justify-self: center;
     text-align: center;
     max-width: 50%;
+    margin: -16px 0;
 
     &.mobile {
         max-width: 75%;


### PR DESCRIPTION
### Issues Fixed
[PDPOS-5045](https://petcoalm.atlassian.net/browse/PDPOS-5045)

### Summary
After donation option was added to tender screen, we lost some space for the tender options which resulted in tender options overflowing for a resolution of 1366x768. Updated the tender-part to have row-gap be 16px for desktop-landscape and also trim down some of the space around the instructions

Additionally fix mobile screen text overflow on option buttons.

### Screenshots
Before:
<img width="1028" alt="Screen Shot 2021-04-15 at 3 59 51 PM" src="https://user-images.githubusercontent.com/6811136/114932242-42f04600-9e05-11eb-8505-6f64531294d2.png">
<img width="205" alt="Screen Shot 2021-04-16 at 9 53 56 AM" src="https://user-images.githubusercontent.com/6811136/115038818-e3924480-9e9d-11eb-9a30-a3c3349d6467.png">


After:
<img width="1680" alt="Screen Shot 2021-04-16 at 10 21 39 AM" src="https://user-images.githubusercontent.com/6811136/115038849-ebea7f80-9e9d-11eb-84f5-ad3ee2d99f7a.png">
<img width="685" alt="Screen Shot 2021-04-16 at 10 21 54 AM" src="https://user-images.githubusercontent.com/6811136/115038866-ef7e0680-9e9d-11eb-8525-0b655c4a39f4.png">
<img width="208" alt="Screen Shot 2021-04-16 at 10 22 06 AM" src="https://user-images.githubusercontent.com/6811136/115038890-f3118d80-9e9d-11eb-86fb-7b3f8da93b94.png">
<img width="189" alt="Screen Shot 2021-04-16 at 10 22 18 AM" src="https://user-images.githubusercontent.com/6811136/115038896-f6a51480-9e9d-11eb-91bc-ac7a41dbad39.png">


