### PR TITLE
We were creating the connection pool for each module more than once

### DIFF
--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/DBSession.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/DBSession.java
@@ -569,9 +569,9 @@ public class DBSession {
         try {
             return jdbcTemplate.getJdbcOperations().update(sql, values, types);
         } catch (DuplicateKeyException e) {
-            throw new DuplicateKeyException("Failed to execute " + type + " statement: " + new LogSqlBuilder().buildDynamicSqlForLog(sql, values, types));
+            throw new DuplicateKeyException("Failed to execute " + type + " statement: " + new LogSqlBuilder().buildDynamicSqlForLog(sql, values, types), e);
         } catch (Exception ex) {
-            throw new PersistException("Failed to execute " + type + " statement: " + new LogSqlBuilder().buildDynamicSqlForLog(sql, values, types));
+            throw new PersistException("Failed to execute " + type + " statement: " + new LogSqlBuilder().buildDynamicSqlForLog(sql, values, types), ex);
         }
     }
 

--- a/openpos-service/src/main/java/org/jumpmind/pos/service/AbstractRDBMSModule.java
+++ b/openpos-service/src/main/java/org/jumpmind/pos/service/AbstractRDBMSModule.java
@@ -122,6 +122,8 @@ abstract public class AbstractRDBMSModule extends AbstractServiceFactory impleme
     @Setter
     private ModuleLoaderConfig loaderConfig;
 
+    protected boolean dataSourceInitialized = false;
+
     static Server h2Server;
 
     @Override
@@ -248,7 +250,7 @@ abstract public class AbstractRDBMSModule extends AbstractServiceFactory impleme
     @Override
     public DataSource getDataSource() {
         boolean isOverridden = isNotBlank(env.getProperty(String.format("%s.%s", getName(), DB_POOL_URL)));
-        if (dataSource == null || isOverridden || !useInjectedDatasource) {
+        if (!dataSourceInitialized && (isOverridden || !useInjectedDatasource)) {
             this.dataSource = null;
             setupH2Server();
             if (this.dataSourceBeanName != null) {
@@ -302,6 +304,7 @@ abstract public class AbstractRDBMSModule extends AbstractServiceFactory impleme
                 dataSource = BasicDataSourceFactory.create(properties, securityService());
             }
         }
+        dataSourceInitialized = true;
         return dataSource;
     }
 


### PR DESCRIPTION
### Summary
We were creating the connection pool for each module more than once.  Also fixed logging in a new DbSession method.  The original exception needed to be included in the stack trace.