### PR TITLE
Display loyalty reward amount values

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-history-line-item/_rewards-history-line-item-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-history-line-item/_rewards-history-line-item-theme.scss
@@ -4,4 +4,12 @@
     .reward-history-line-item-wrapper .status, .mobile-reward-history-line-item-wrapper .status {
         color: $primary;
     }
+
+    .reward {
+        &.expired {
+            .currency-text-after-symbol {
+                text-decoration: line-through;
+            }
+        }
+    }
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-history-line-item/rewards-history-line-item.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-history-line-item/rewards-history-line-item.component.html
@@ -4,6 +4,9 @@
         <div [ngClass]="{'name': true, 'expired': !reward.redeemed}" responsive-class>{{reward.name}}</div>
         <div *ngIf="reward.expirationDate"  class="expiration" responsive-class><app-icon [iconName]="screenData.expiredIcon" [iconClass]="'material-icons' + (isMobile | async) ? ' mat-16' : 'mat-24'"></app-icon>{{screenData.expiredLabel}} {{reward.expirationDate}}</div>
     </div>
+    <div [ngClass]="{'reward': true, 'expired': !reward.redeemed}" responsive-class>
+        <app-currency-text *ngIf="reward.amount" [amountText]="reward.amount"></app-currency-text>
+    </div>
     <div class="status" >
         <span responsive-class>{{(reward.redeemed) ? screenData.redeemedLabel : screenData.expiredLabel}}</span>
     </div>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-history-line-item/rewards-history-line-item.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-history-line-item/rewards-history-line-item.component.scss
@@ -6,7 +6,7 @@
   grid-template-rows: 1fr;
   gap: 0px 0px;
   grid-template-areas:
-    "loyalty-icon details status";
+    "loyalty-icon details reward status";
   .loyalty-icon {
     grid-area: loyalty-icon;
     text-align: center;
@@ -34,6 +34,17 @@
     }
   }
 
+  .reward {
+    @extend %text-md;
+    grid-area: reward;
+    align-self: center;
+    &.expired {
+      .currency-text-after-symbol {
+        text-decoration: line-through;
+      }
+    }
+  }
+
   .status {
     grid-area: status;
     text-align: center;
@@ -54,7 +65,7 @@
   grid-template-rows: 1fr;
   gap: 0px 0px;
   grid-template-areas:
-    "details status";
+    "details reward status";
   .loyalty-icon {
     grid-area: loyalty-icon;
     text-align: center;
@@ -67,6 +78,9 @@
     .name {
       @extend %text-md;
       font-weight: 500;
+      &.expired {
+        text-decoration: line-through;
+      }
       &.tablet-portrait {
         font-size: $text-sm;
       }
@@ -90,6 +104,25 @@
     }
     app-icon {
       display: inline-block;
+    }
+  }
+
+  .reward {
+    @extend %text-md;
+    grid-area: reward;
+    align-self: center;
+    text-align: center;
+    &.expired {
+      .currency-text-after-symbol {
+        text-decoration: line-through;
+      }
+    }
+    &.tablet-portrait {
+      font-size: $text-sm;
+    }
+
+    &.mobile {
+      font-size: $text-xs-mobile*1.25;
     }
   }
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-history-line-item/rewards-history-line-item.component.spec.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-history-line-item/rewards-history-line-item.component.spec.ts
@@ -140,6 +140,29 @@ describe('RewardsHistoryLineItemComponent', () => {
                     });
                 });
             });
+
+            describe('reward', () => {
+                describe('when reward has an amount', () => {
+                    beforeEach(() => {
+                        component.reward.amount = 200;
+                        fixture.detectChanges();
+                    });
+                    it('renders the app-currency-text', () => {
+                        validateExist(fixture, '.reward app-currency-text');
+                    });
+                });
+
+                describe('when reward does not have an amount', () => {
+                    beforeEach(() => {
+                        component.reward.amount = undefined;
+                        fixture.detectChanges();
+                    });
+                    it('does not render the app-currency-text', () => {
+                        validateDoesNotExist(fixture, '.reward app-currency-text');
+                    });
+                });
+            });
+
             describe('status', () => {
                it('shows the redeemedLabel when the reward is redeemed', () => {
                    component.screenData.redeemedLabel = 'redeemed label';

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-history-line-item/rewards-history-line-item.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-history-line-item/rewards-history-line-item.interface.ts
@@ -2,6 +2,7 @@ export interface RewardHistory {
     promotionId: string;
     name: string;
     expirationDate: string;
+    amount: number;
     redeemed: boolean;
 };
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.html
@@ -4,6 +4,9 @@
         <div class="name" responsive-class>{{reward.name}}</div>
         <div *ngIf="reward.expirationDate" class="expiration" responsive-class><app-icon [iconName]="screenData.expiredIcon" [iconClass]="'material-icons' + (isMobile | async) ? ' mat-16' : ' mat-24'"></app-icon>{{screenData.expiresLabel}} {{reward.expirationDate}}</div>
     </div>
+    <div class="reward" responsive-class>
+        <app-currency-text *ngIf="reward.amount" [amountText]="reward.amount"></app-currency-text>
+    </div>
     <div class="apply" >
         <a *ngIf="reward.applyButton"
            [actionItem]="reward.applyButton"

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.scss
@@ -2,11 +2,11 @@
 
 .reward-line-item-wrapper {
   display: grid;
-  grid-template-columns: 1fr 10fr 2fr;
+  grid-template-columns: 1fr 10fr 1fr 3fr;
   grid-template-rows: 1fr;
   gap: 0px 0px;
   grid-template-areas:
-    "loyalty-icon details apply";
+    "loyalty-icon details reward apply";
   .loyalty-icon {
     grid-area: loyalty-icon;
     text-align: center;
@@ -30,7 +30,11 @@
       display: inline-block;
     }
   }
-
+  .reward {
+    @extend %text-md;
+    grid-area: reward;
+    align-self: center;
+  }
   .apply {
     grid-area: apply;
     justify-self: end;
@@ -46,11 +50,11 @@
 
 .mobile-reward-line-item-wrapper {
   display: grid;
-  grid-template-columns: 2fr 1fr;
+  grid-template-columns: 3fr 1fr 1fr;
   grid-template-rows: 1fr;
   gap: 0px 0px;
   grid-template-areas:
-    "details apply";
+    "details reward apply";
   .loyalty-icon {
     grid-area: loyalty-icon;
     text-align: center;
@@ -71,6 +75,11 @@
         font-size: $text-xs-mobile*1.25;
       }
     }
+    .reward {
+      @extend %text-md;
+      grid-area: reward;
+      align-self: center;
+    }
     .expiration {
       @extend %text-md;
       &.tablet-portrait {
@@ -86,6 +95,20 @@
     }
     app-icon {
       display: inline-block;
+    }
+  }
+
+  .reward {
+    @extend %text-md;
+    grid-area: reward;
+    align-self: center;
+    text-align: center;
+    &.tablet-portrait {
+      font-size: $text-sm;
+    }
+
+    &.mobile {
+      font-size: $text-xs-mobile*1.25;
     }
   }
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.spec.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.spec.ts
@@ -134,6 +134,28 @@ describe('RewardsLineItemComponent', () => {
                 });
             });
 
+            describe('reward', () => {
+                describe('when reward has an amount', () => {
+                    beforeEach(() => {
+                        component.reward.amount = 200;
+                        fixture.detectChanges();
+                    });
+                    it('renders the app-currency-text', () => {
+                        validateExist(fixture, '.reward app-currency-text');
+                    });
+                });
+
+                describe('when reward does not have an amount', () => {
+                    beforeEach(() => {
+                        component.reward.amount = undefined;
+                        fixture.detectChanges();
+                    });
+                    it('does not render the app-currency-text', () => {
+                        validateDoesNotExist(fixture, '.reward app-currency-text');
+                    });
+                });
+            });
+
             describe('apply button', () => {
                 describe('when applicable', () => {
                     beforeEach(() => {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.interface.ts
@@ -4,6 +4,7 @@ export interface Reward {
     promotionId: string;
     name: string;
     expirationDate: string;
+    amount: number;
     applyButton: IActionItem;
 };
 

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/UILoyaltyReward.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/UILoyaltyReward.java
@@ -4,6 +4,7 @@ import lombok.Data;
 import org.jumpmind.pos.core.ui.ActionItem;
 
 import java.io.Serializable;
+import java.math.BigDecimal;
 import java.util.Date;
 
 @Data
@@ -14,5 +15,6 @@ public class UILoyaltyReward implements Serializable {
     private String name;
     private String expirationDate;
     private String expirationLabel;
+    private BigDecimal amount;
     private ActionItem applyButton;
 }

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/UIRewardHistory.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/UIRewardHistory.java
@@ -3,6 +3,7 @@ package org.jumpmind.pos.core.ui.message;
 import lombok.Data;
 
 import java.io.Serializable;
+import java.math.BigDecimal;
 
 @Data
 public class UIRewardHistory implements Serializable {
@@ -11,5 +12,6 @@ public class UIRewardHistory implements Serializable {
     private String promotionId;
     private String name;
     private String expirationDate;
+    private BigDecimal amount;
     private Boolean redeemed;
 }


### PR DESCRIPTION
### Summary
On the customer details loyalty rewards and loyalty rewards history tabs, added the ability to show the aggregate value of transaction amount based loyalty rewards.

### Screenshots
![image](https://user-images.githubusercontent.com/2406987/114756116-68f3e880-9d28-11eb-8da5-807da6cc8131.png)
![image](https://user-images.githubusercontent.com/2406987/114756130-6db89c80-9d28-11eb-94a7-c24da6378af7.png)
![image](https://user-images.githubusercontent.com/2406987/114756159-727d5080-9d28-11eb-92dd-36bc5a7bad1f.png)
![image](https://user-images.githubusercontent.com/2406987/114756642-f46d7980-9d28-11eb-8440-315726c475de.png)
