### PR TITLE
Feature/issue 3512

### DIFF
--- a/openpos-service/src/main/docs/openpos-service.md
+++ b/openpos-service/src/main/docs/openpos-service.md
@@ -305,3 +305,39 @@ ui:
 The list of parameters determines what values to pull from the subscription request and add to the context object.
 
 See [Client Context](client-context) for adding additional parameters.
+
+## Service Endpoint Statistic Logging
+
+In order to start sampling endpoints and logging statistics, yaml configurations need to be set in the 'application.yml'. Every module and endpoint can optionally have a samplingConfig section for that level. To turn on sampling for an endpoint, a samplingConfig section will need to be created at the module and endpoint levels with enabled set to true. Optionally, in each section, a number for retention days can be set to specify how long logs should be retained for.
+
+For example, a module section may look like the following.
+~~~yaml
+openpos:
+  service:
+    specificConfig:
+      customer:
+        samplingConfig:
+          enabled: true
+          retentionDays: 4
+        profileIds:
+          - local
+        strategy: LOCAL_ONLY
+        endpoints:
+          - path: /customer/customergroups
+            profile:
+            strategy: LOCAL_ONLY
+            samplingConfig:
+                enabled: true
+          - path: /customer/detailed
+            profile:
+            strategy: LOCAL_ONLY
+            samplingConfig:
+              enabled: true
+~~~
+
+### Database Overriding
+
+Sampling configurations can also be overridden by entries in the CTX_CONFIG table. In order to override values using this method three columns are important. 
+- CONFIG_NAME column requires the yaml key leading to the desired configuration. For example, "openpos.services.specificConfig.customer.samplingConfig.enabled". 
+- CONFIG_VALUE specifies the value that should be set in the location specified by CONFIG_NAME. 
+- ENABLED will specify if this rows configuration should be used.  

--- a/openpos-service/src/main/docs/openpos-service.md
+++ b/openpos-service/src/main/docs/openpos-service.md
@@ -84,12 +84,10 @@ The module declaration provides at least the following information about the mod
 @RequestMapping("/customer")
 public interface ICustomerService {
 
-    @Sample
     @RequestMapping(path="/search", method=RequestMethod.POST)
     @ResponseBody
     public SearchCustomerResult searchCustomer(@RequestBody SearchCustomerRequest request);
     
-    @Sample
     @RequestMapping(value="/device/{deviceId}/save", method=RequestMethod.POST)
     public CustomerModel saveCustomer(@PathVariable("deviceId") String deviceId, @RequestBody CustomerModel customer);
 }
@@ -99,7 +97,6 @@ Description of the annotations:
 * @Api (Swagger) is used by swagger to generate documentation and a Rest service test page.
 * @RestController (Spring) makes this a Spring bean.
 * @RequestMapping (Spring) maps all method in this Service Interface under the URL path of "/customer"
-* @Sample (openpos_ means that you want this web method to be sampled and for the framework to collect statistics about how it is invokved.
 * @RequestMapping (Spring) is the standard Spring annotation to map a method to a more specific part of the REST URL and to an HTTP method.
 * @ResponseBody (Spring) indicates that the method return value should be mapped to the web response body (in this case, as JSON)
 

--- a/openpos-service/src/main/java/org/jumpmind/pos/service/EndpointInvoker.java
+++ b/openpos-service/src/main/java/org/jumpmind/pos/service/EndpointInvoker.java
@@ -291,7 +291,7 @@ public class EndpointInvoker implements InvocationHandler {
 
         IInvocationStrategy strategy;
         List<String> profileIds = new ArrayList<>();
-        if (endConfig != null) {
+        if (endConfig != null && endConfig.getStrategy() != null) {
             strategy = strategies.get(endConfig.getStrategy().name());
             profileIds.add(endConfig.getProfile());
         } else {
@@ -368,8 +368,7 @@ public class EndpointInvoker implements InvocationHandler {
             Object proxy,
             Method method,
             Object[] args) {
-        maintainCache(path, config);
-        if(endpointEnabledCache.get(path)){
+        if(isSamplingEnabled(path, config)){
                 ServiceSampleModel serviceSampleModel = new ServiceSampleModel();
                 serviceSampleModel.setSampleId(installationId + System.currentTimeMillis());
                 serviceSampleModel.setInstallationId(installationId);
@@ -382,7 +381,7 @@ public class EndpointInvoker implements InvocationHandler {
         return null;
     }
 
-    protected void maintainCache(String path, ServiceSpecificConfig config) {
+    protected boolean isSamplingEnabled(String path, ServiceSpecificConfig config) {
         if(endpointEnabledCache.get(path) == null) {
             Optional<EndpointSpecificConfig> endpointSpecificConfig = Optional.empty();
             if (config != null && config.getSamplingConfig() != null && config.getSamplingConfig().isEnabled()
@@ -394,6 +393,7 @@ public class EndpointInvoker implements InvocationHandler {
             }
             endpointEnabledCache.put(path, endpointSpecificConfig.isPresent());
         }
+        return endpointEnabledCache.get(path);
     }
 
     protected void endSampleSuccess(

--- a/openpos-service/src/main/java/org/jumpmind/pos/service/EndpointInvoker.java
+++ b/openpos-service/src/main/java/org/jumpmind/pos/service/EndpointInvoker.java
@@ -368,7 +368,8 @@ public class EndpointInvoker implements InvocationHandler {
             Method method,
             Object[] args) {
         Optional<ServiceSampleModel> serviceSampleModel = Optional.empty();
-        if (config != null && config.getSamplingConfig() != null && config.getSamplingConfig().isEnabled()) {
+        if (config != null && config.getSamplingConfig() != null && config.getSamplingConfig().isEnabled()
+            && config.getEndpoints() != null) {
             serviceSampleModel = config.getEndpoints()
                     .stream()
                     .filter(endpoint -> endpoint.getSamplingConfig().isEnabled() && path.equals(endpoint.getPath()))

--- a/openpos-service/src/main/java/org/jumpmind/pos/service/EndpointInvoker.java
+++ b/openpos-service/src/main/java/org/jumpmind/pos/service/EndpointInvoker.java
@@ -367,9 +367,6 @@ public class EndpointInvoker implements InvocationHandler {
             Object proxy,
             Method method,
             Object[] args) {
-        if (path.equals("/customer/search")){
-            path.trim();
-        }
         Optional<ServiceSampleModel> serviceSampleModel = Optional.empty();
         if (config != null && config.getSamplingConfig() != null && config.getSamplingConfig().isEnabled()) {
             serviceSampleModel = config.getEndpoints()

--- a/openpos-service/src/main/java/org/jumpmind/pos/service/EndpointInvoker.java
+++ b/openpos-service/src/main/java/org/jumpmind/pos/service/EndpointInvoker.java
@@ -300,10 +300,10 @@ public class EndpointInvoker implements InvocationHandler {
         if (profileIds.size() == 0) {
             profileIds.add("local");
         }
-        return invokeStrategy(path, strategy, profileIds, config, proxy, method, args, endpointImplementation);
+        return invokeStrategy(path, strategy, profileIds, config, proxy, method, args, endpointImplementation, endpointsByPathMap);
     }
 
-    protected Object invokeStrategy(String path, IInvocationStrategy strategy, List<String> profileIds, ServiceSpecificConfig config, Object proxy, Method method, Object[] args, String endpointImplementation) throws Throwable {
+    protected Object invokeStrategy(String path, IInvocationStrategy strategy, List<String> profileIds, ServiceSpecificConfig config, Object proxy, Method method, Object[] args, String endpointImplementation, Map<String, Object> endpointsByPathMap) throws Throwable {
         ServiceSampleModel sample = startSample(path, strategy, config, proxy, method, args);
         Object result = null;
         try {

--- a/openpos-service/src/main/java/org/jumpmind/pos/service/EndpointSpecificConfig.java
+++ b/openpos-service/src/main/java/org/jumpmind/pos/service/EndpointSpecificConfig.java
@@ -1,12 +1,27 @@
 package org.jumpmind.pos.service;
 
 import org.jumpmind.pos.service.strategy.InvocationStrategy;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
+@Component
 public class EndpointSpecificConfig implements Cloneable {
+
+    @Autowired(required = false)
+    IConfigApplicator additionalConfigSource;
 
     protected String profile;
     protected InvocationStrategy strategy;
     protected String path;
+    protected SamplingConfig samplingConfig;
+
+    public SamplingConfig getSamplingConfig() {
+        return samplingConfig;
+    }
+
+    public void setSamplingConfig(SamplingConfig samplingConfig) {
+        this.samplingConfig = samplingConfig;
+    }
 
     public String getPath() {
         return path;
@@ -42,5 +57,14 @@ public class EndpointSpecificConfig implements Cloneable {
         }
     }
 
+    public void findAdditionalConfigs(String serviceId, int index) {
+        if(samplingConfig == null){
+            samplingConfig = new SamplingConfig();
+        }
 
+        if(additionalConfigSource != null){
+            String startsWith = String.format("openpos.services.specificConfig.%s.endpoints[%d].samplingConfig", serviceId, index);
+            additionalConfigSource.applyAdditionalConfiguration(startsWith, samplingConfig);
+        }
+    }
 }

--- a/openpos-service/src/main/java/org/jumpmind/pos/service/SamplingConfig.java
+++ b/openpos-service/src/main/java/org/jumpmind/pos/service/SamplingConfig.java
@@ -1,0 +1,32 @@
+package org.jumpmind.pos.service;
+
+public class SamplingConfig implements Cloneable{
+    private boolean enabled = false;
+    private int retentionDays;
+
+    public int getRetentionDays() {
+        return retentionDays;
+    }
+
+    public void setRetentionDays(int retentionDays) {
+        this.retentionDays = retentionDays;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public SamplingConfig copy(){
+        SamplingConfig copy;
+        try {
+            copy = (SamplingConfig)this.clone();
+            return copy;
+        } catch (CloneNotSupportedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/openpos-service/src/main/java/org/jumpmind/pos/service/SamplingConfig.java
+++ b/openpos-service/src/main/java/org/jumpmind/pos/service/SamplingConfig.java
@@ -1,6 +1,6 @@
 package org.jumpmind.pos.service;
 
-public class SamplingConfig implements Cloneable{
+public class SamplingConfig{
     private boolean enabled = false;
     private int retentionDays;
 
@@ -18,15 +18,5 @@ public class SamplingConfig implements Cloneable{
 
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
-    }
-
-    public SamplingConfig copy(){
-        SamplingConfig copy;
-        try {
-            copy = (SamplingConfig)this.clone();
-            return copy;
-        } catch (CloneNotSupportedException e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/openpos-service/src/main/java/org/jumpmind/pos/service/ServiceConfig.java
+++ b/openpos-service/src/main/java/org/jumpmind/pos/service/ServiceConfig.java
@@ -55,6 +55,7 @@ public class ServiceConfig {
         }
         if (additionalConfigSource != null) {
             additionalConfigSource.applyAdditionalConfiguration(String.format("openpos.services.specificConfig.%s", serviceId), config);
+            config.findAdditionalConfigs(serviceId);
         }
         return config;
     }

--- a/openpos-service/src/test/java/org/jumpmind/pos/service/EndpointInvokerTest.java
+++ b/openpos-service/src/test/java/org/jumpmind/pos/service/EndpointInvokerTest.java
@@ -162,7 +162,7 @@ public class EndpointInvokerTest {
     }
 
     @Test
-    public void maintainCacheAddsUnseenPathsToCache(){
+    public void isSamplingEnabledAddsUnseenPathsToCache(){
         String path = "/test/one";
         ServiceSpecificConfig serviceSpecificConfig = serviceSpecificConfigSetup(path);
 
@@ -170,15 +170,16 @@ public class EndpointInvokerTest {
         HashMap<String, Boolean> endpointCache = spy(new HashMap<>());
         endpointInvoker.endpointEnabledCache = endpointCache;
 
-        endpointInvoker.maintainCache(path, serviceSpecificConfig);
+        boolean result = endpointInvoker.isSamplingEnabled(path, serviceSpecificConfig);
 
         verify(endpointCache, atLeastOnce()).get(path);
         verify(endpointCache, atLeastOnce()).put(path, true);
         assertEquals(endpointCache.size(), 1);
+        assertEquals(result, true);
     }
 
     @Test
-    public void maintainCacheDoseNotAddSeenPathsToCache(){
+    public void isSamplingEnabledDoseNotAddSeenPathsToCache(){
         String path = "/test/one";
         ServiceSpecificConfig serviceSpecificConfig = serviceSpecificConfigSetup(path);
 
@@ -186,16 +187,17 @@ public class EndpointInvokerTest {
         HashMap<String, Boolean> endpointCache = spy(new HashMap<>());
         endpointInvoker.endpointEnabledCache = endpointCache;
 
-        endpointInvoker.maintainCache(path, serviceSpecificConfig);
-        endpointInvoker.maintainCache(path, serviceSpecificConfig);
+        endpointInvoker.isSamplingEnabled(path, serviceSpecificConfig);
+        boolean result = endpointInvoker.isSamplingEnabled(path, serviceSpecificConfig);
 
         verify(endpointCache, atLeastOnce()).get(path);
         verify(endpointCache, atLeastOnce()).put(path, true);
         assertEquals(endpointCache.size(), 1);
+        assertEquals(result, true);
     }
 
     @Test
-    public void maintainCacheDoseNotAddDisabledEndpointsAtEndpointLevel(){
+    public void isSamplingEnabledDoseNotAddDisabledEndpointsAtEndpointLevel(){
         String path = "/test/one";
         ServiceSpecificConfig serviceSpecificConfig = serviceSpecificConfigSetup(path);
 
@@ -204,19 +206,20 @@ public class EndpointInvokerTest {
         endpointInvoker.endpointEnabledCache = endpointCache;
 
         serviceSpecificConfig.getEndpoints().get(0).getSamplingConfig().setEnabled(false);
-        endpointInvoker.maintainCache(path, serviceSpecificConfig);
+        boolean result = endpointInvoker.isSamplingEnabled(path, serviceSpecificConfig);
 
         serviceSpecificConfig.getEndpoints().get(0).getSamplingConfig().setEnabled(true);
         serviceSpecificConfig.getSamplingConfig().setEnabled(false);
-        endpointInvoker.maintainCache(path, serviceSpecificConfig);
+        endpointInvoker.isSamplingEnabled(path, serviceSpecificConfig);
 
         verify(endpointCache, atLeastOnce()).get(path);
         verify(endpointCache, atLeastOnce()).put(path, false);
         assertEquals(endpointCache.size(), 1);
+        assertEquals(result, false);
     }
 
     @Test
-    public void maintainCacheDoseNotAddDisabledEndpointsAtModuleLevel(){
+    public void isSamplingEnabledDoseNotAddDisabledEndpointsAtModuleLevel(){
         String path = "/test/one";
         ServiceSpecificConfig serviceSpecificConfig = serviceSpecificConfigSetup(path);
 
@@ -225,11 +228,28 @@ public class EndpointInvokerTest {
         endpointInvoker.endpointEnabledCache = endpointCache;
 
         serviceSpecificConfig.getSamplingConfig().setEnabled(false);
-        endpointInvoker.maintainCache(path, serviceSpecificConfig);
+        boolean result = endpointInvoker.isSamplingEnabled(path, serviceSpecificConfig);
 
         verify(endpointCache, atLeastOnce()).get(path);
         verify(endpointCache, atLeastOnce()).put(path, false);
         assertEquals(endpointCache.size(), 1);
+        assertEquals(result, false);
+    }
+
+    @Test
+    public void isSamplingEnabledReturnsNullWithConfigNull(){
+        String path = "/test/one";
+
+        EndpointInvoker endpointInvoker = new EndpointInvoker();
+        HashMap<String, Boolean> endpointCache = spy(new HashMap<>());
+        endpointInvoker.endpointEnabledCache = endpointCache;
+
+        boolean result = endpointInvoker.isSamplingEnabled(path, null);
+
+        verify(endpointCache, atLeastOnce()).get(path);
+        verify(endpointCache, atLeastOnce()).put(path, false);
+        assertEquals(endpointCache.size(), 1);
+        assertEquals(result, false);
     }
 
     private ServiceSpecificConfig serviceSpecificConfigSetup(String path) {

--- a/openpos-service/src/test/java/org/jumpmind/pos/service/EndpointInvokerTest.java
+++ b/openpos-service/src/test/java/org/jumpmind/pos/service/EndpointInvokerTest.java
@@ -39,7 +39,7 @@ public class EndpointInvokerTest {
         config.setSamplingConfig(sampleConfig);
 
         EndpointSpecificConfig endpointSpecificConfig = new EndpointSpecificConfig();
-        endpointSpecificConfig.setPath("/one");
+        endpointSpecificConfig.setPath("/test/one");
         endpointSpecificConfig.setSamplingConfig(sampleConfig);
 
         List<EndpointSpecificConfig> endpoints = new ArrayList<>();

--- a/openpos-service/src/test/java/org/jumpmind/pos/service/EndpointInvokerTest.java
+++ b/openpos-service/src/test/java/org/jumpmind/pos/service/EndpointInvokerTest.java
@@ -1,0 +1,136 @@
+package org.jumpmind.pos.service;
+
+import org.jumpmind.pos.persist.DBSession;
+import org.jumpmind.pos.service.instrumentation.Sample;
+import org.jumpmind.pos.service.instrumentation.ServiceSampleModel;
+import org.jumpmind.pos.service.strategy.IInvocationStrategy;
+import org.jumpmind.pos.service.strategy.LocalOnlyStrategy;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.lang.reflect.Method;
+import java.util.Date;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EndpointInvokerTest {
+
+    public void TestMethodNotAnnotated() {}
+
+    @Sample
+    public void TestMethodAnnotated() {}
+
+    String installationId = "TestInstallationId";
+
+    private ServiceSampleModel getServiceSampleModel() {
+        ServiceSampleModel sampleModel = mock(ServiceSampleModel.class, RETURNS_DEEP_STUBS);
+        sampleModel.setStartTime(new Date());
+        sampleModel.setEndTime(new Date());
+        return sampleModel;
+    }
+
+    @Test
+    public void startSampleReturnsNullWhenNotConfiguredToSampleMethodTest() throws NoSuchMethodException {
+        IInvocationStrategy invocationStrategy = new LocalOnlyStrategy();
+
+        Method method = EndpointInvokerTest.class.getMethod("TestMethodNotAnnotated");
+
+        EndpointInvoker endpointInvoker = new EndpointInvoker();
+        ServiceSampleModel result = endpointInvoker.startSample(invocationStrategy, null, null, method, null);
+        assertNull(result, "EndpointInvoker.startSample should return null when the method passed is not configured to be sampled");
+    }
+
+    @Test
+    public void startSampleReturnsNotNullWhenIsConfiguredToSampleMethodTest() throws NoSuchMethodException {
+        IInvocationStrategy invocationStrategy = new LocalOnlyStrategy();
+
+        Method method = EndpointInvokerTest.class.getMethod("TestMethodAnnotated");
+
+        EndpointInvoker endpointInvoker = new EndpointInvoker();
+        endpointInvoker.installationId = installationId;
+        ServiceSampleModel result = endpointInvoker.startSample(invocationStrategy, null, null, method, null);
+
+        assertNotNull(result, "EndpointInvoker.startSample should return not null when the method passed is configured to be sampled.");
+    }
+
+    @Test
+    public void startSampleReturnsAcceptableFieldsTest() throws NoSuchMethodException {
+        IInvocationStrategy invocationStrategy = new LocalOnlyStrategy();
+
+        Method method = EndpointInvokerTest.class.getMethod("TestMethodAnnotated");
+        String simpleName = method.getDeclaringClass().getSimpleName();
+        String methodName = method.getName();
+
+        EndpointInvoker endpointInvoker = new EndpointInvoker();
+        endpointInvoker.installationId = installationId;
+
+        ServiceSampleModel result = endpointInvoker.startSample(invocationStrategy, null, null, method, null);
+
+        assertTrue(Pattern.matches(installationId + "\\d*", result.getSampleId()), "sampleId should have installationId followed by the system time in milliseconds.");
+        assertEquals(installationId, result.getInstallationId(), "installationId should be populated with the installationId.");
+        assertNotNull(result.getHostname(), "hostname should populate results with the systems hostname.");
+        assertTrue(Pattern.matches(simpleName + "." + methodName, result.getServiceName()), "serviceName should be populated with the methodDeclaringClassSimpleName.methodName.");
+        assertEquals(invocationStrategy.getStrategyName(), result.getServiceType(), "serviceType should be populated with the strategy name of the strategy passed.");
+        assertNotNull(result.getStartTime(), "startTime should be populated with the data the approximate date the method was called.");
+        assertNull(result.getServicePath(), "servicePath should not be set by startSample.");
+        assertNull(result.getServiceResult(), "serviceResult should not be set by startSample.");
+        assertNull(result.getEndTime(), "serviceResult should not be set by startSample.");
+        assertEquals( 0, result.getDurationMs(), "durationMS should not be set by startSample.");
+        assertFalse(result.isErrorFlag(), "errorFlag should not be set by startSample.");
+        assertNull(result.getErrorSummary(), "errorSummary should not be set by startSample.");
+    }
+
+    @Test
+    public void endSampleSuccessEndsSampleTest() throws NoSuchMethodException, NoSuchFieldException, IllegalAccessException {
+        ServiceSampleModel sampleModel = getServiceSampleModel();
+
+        Object testResult = new Object();
+        DBSession session = mock(DBSession.class);
+
+        EndpointInvoker endpointInvoker = spy(new EndpointInvoker());
+        endpointInvoker.dbSession = session;
+
+        endpointInvoker.endSampleSuccess(sampleModel, null, null, null, null, testResult);
+
+        verify(sampleModel, atLeastOnce()).setServiceResult(anyString());
+        verify(endpointInvoker, atLeastOnce()).endSample(sampleModel, null, null, null, null);
+    }
+
+    @Test
+    public void endSampleErrorProperlySetsFieldsTest() throws NoSuchMethodException {
+        ServiceSampleModel sampleModel = getServiceSampleModel();
+
+        Object testResult = new Object();
+        DBSession session = mock(DBSession.class);
+
+        EndpointInvoker endpointInvoker = spy(new EndpointInvoker());
+        endpointInvoker.dbSession = session;
+
+        endpointInvoker.endSampleError(sampleModel, null, null, null, null, testResult, new Exception("Test"));
+
+        verify(sampleModel, atLeastOnce()).setServiceResult(null);
+        verify(sampleModel, atLeastOnce()).setErrorFlag(true);
+        verify(sampleModel, atLeastOnce()).setErrorSummary(anyString());
+        verify(endpointInvoker, atLeastOnce()).endSample(sampleModel, null, null, null, null);
+    }
+
+    @Test
+    public void endSampleSetsDataAndSavesToDBSession() throws NoSuchMethodException {
+        ServiceSampleModel sampleModel = getServiceSampleModel();
+
+        DBSession session = mock(DBSession.class);
+
+        EndpointInvoker endpointInvoker = new EndpointInvoker();
+        endpointInvoker.dbSession = session;
+
+        endpointInvoker.endSample(sampleModel, null, null, null, null);
+
+        verify(sampleModel, atLeastOnce()).setEndTime(anyObject());
+        verify(sampleModel, atLeastOnce()).setDurationMs(anyLong());
+        verify(session, atLeastOnce()).save(sampleModel);
+    }
+}

--- a/openpos-service/src/test/java/org/jumpmind/pos/service/EndpointInvokerTest.java
+++ b/openpos-service/src/test/java/org/jumpmind/pos/service/EndpointInvokerTest.java
@@ -64,7 +64,7 @@ public class EndpointInvokerTest {
         EndpointInvoker endpointInvoker = spy(new EndpointInvoker());
         endpointInvoker.dbSession = session;
 
-        Object result = endpointInvoker.invokeStrategy(path, invocationStrategy, profileIds, config, null, method, null, null);
+        Object result = endpointInvoker.invokeStrategy(path, invocationStrategy, profileIds, config, null, method, null, null, null);
 
         verify(endpointInvoker, atLeastOnce()).startSample(path, invocationStrategy, config, null, method, null);
         verify(invocationStrategy, atLeastOnce()).invoke(eq(profileIds), eq(null), eq(method), anyObject(), eq(null));
@@ -91,7 +91,7 @@ public class EndpointInvokerTest {
         endpointInvoker.dbSession = session;
 
         try{
-            Object result = endpointInvoker.invokeStrategy(path, invocationStrategy, profileIds, config, null, method, null, null);
+            Object result = endpointInvoker.invokeStrategy(path, invocationStrategy, profileIds, config, null, method, null, null, null);
         } catch (Throwable ex) {
             verify(endpointInvoker, atLeastOnce()).startSample(path, invocationStrategy, config, null, method, null);
             verify(invocationStrategy, atLeastOnce()).invoke(eq(profileIds), eq(null), eq(method), anyObject(), eq(null));

--- a/openpos-service/src/test/java/org/jumpmind/pos/service/EndpointSpecificConfigTest.java
+++ b/openpos-service/src/test/java/org/jumpmind/pos/service/EndpointSpecificConfigTest.java
@@ -1,0 +1,52 @@
+package org.jumpmind.pos.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+class EndpointSpecificConfigTest {
+
+    String serviceTestId;
+    int endpointIndex;
+    String path;
+    SamplingConfig samplingConfig;
+
+    EndpointSpecificConfig endpointSpecificConfig = new EndpointSpecificConfig();
+
+    @Mock
+    IConfigApplicator iConfigApplicator;
+
+    @BeforeEach
+    public void before(){
+        MockitoAnnotations.initMocks(this);
+        serviceTestId = "TestID";
+        endpointIndex = 0;
+        path = String.format("openpos.services.specificConfig.%s.endpoints[%d].samplingConfig", serviceTestId, endpointIndex);
+        endpointSpecificConfig.additionalConfigSource = iConfigApplicator;
+        samplingConfig = new SamplingConfig();
+        endpointSpecificConfig.samplingConfig = samplingConfig;
+
+    }
+
+    @Test
+    public void findAdditionalConfigsWithNullSampleConfig() {
+        endpointSpecificConfig.samplingConfig = null;
+        endpointSpecificConfig.findAdditionalConfigs(serviceTestId, endpointIndex);
+        verify(iConfigApplicator, atLeastOnce()).applyAdditionalConfiguration(eq(path), any(SamplingConfig.class));
+    }
+
+    @Test
+    public void findAdditionalConfigsWithNullAdditionalConfigSource() {
+        endpointSpecificConfig.additionalConfigSource = null;
+        endpointSpecificConfig.findAdditionalConfigs(serviceTestId, endpointIndex);
+        verify(iConfigApplicator, never()).applyAdditionalConfiguration(eq(path), eq(samplingConfig));
+    }
+}

--- a/openpos-service/src/test/java/org/jumpmind/pos/service/EndpointSpecificConfigTest.java
+++ b/openpos-service/src/test/java/org/jumpmind/pos/service/EndpointSpecificConfigTest.java
@@ -1,7 +1,7 @@
 package org.jumpmind.pos.service;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -12,7 +12,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
-class EndpointSpecificConfigTest {
+public class EndpointSpecificConfigTest {
 
     String serviceTestId;
     int endpointIndex;
@@ -24,7 +24,7 @@ class EndpointSpecificConfigTest {
     @Mock
     IConfigApplicator iConfigApplicator;
 
-    @BeforeEach
+    @Before
     public void before(){
         MockitoAnnotations.initMocks(this);
         serviceTestId = "TestID";

--- a/openpos-service/src/test/java/org/jumpmind/pos/service/ServiceSpecificConfigTest.java
+++ b/openpos-service/src/test/java/org/jumpmind/pos/service/ServiceSpecificConfigTest.java
@@ -1,0 +1,63 @@
+package org.jumpmind.pos.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+class ServiceSpecificConfigTest {
+
+    String modulePath;
+    String endpointPath;
+    String serviceTestId;
+    int endpointIndex;
+    SamplingConfig samplingConfig;
+    EndpointSpecificConfig endpointSpecificConfig;
+
+
+    ServiceSpecificConfig serviceSpecificConfig = new ServiceSpecificConfig();
+
+    @Mock
+    IConfigApplicator iConfigApplicator;
+
+    @BeforeEach
+    public void before(){
+        MockitoAnnotations.initMocks(this);
+        serviceTestId = "TestID";
+        endpointIndex = 0;
+        modulePath = String.format("openpos.services.specificConfig.%s.samplingConfig", serviceTestId);
+        endpointPath = String.format("openpos.services.specificConfig.%s.endpoints[%d]", serviceTestId, endpointIndex);
+        serviceSpecificConfig.additionalConfigSource = iConfigApplicator;
+
+        samplingConfig = new SamplingConfig();
+        serviceSpecificConfig.samplingConfig = samplingConfig;
+
+        List<EndpointSpecificConfig> endpointSpecificConfigList = new ArrayList<>();
+        endpointSpecificConfig = new EndpointSpecificConfig();
+        endpointSpecificConfigList.add(endpointSpecificConfig);
+        serviceSpecificConfig.setEndpoints(endpointSpecificConfigList);
+    }
+
+    @Test
+    public void findAdditionalConfigsWithNullSampleConfig() {
+        serviceSpecificConfig.samplingConfig = null;
+        serviceSpecificConfig.findAdditionalConfigs(serviceTestId);
+        verify(iConfigApplicator, atLeastOnce()).applyAdditionalConfiguration(eq(modulePath), any(SamplingConfig.class));
+        verify(iConfigApplicator, atLeastOnce()).applyAdditionalConfiguration(eq(endpointPath), eq(endpointSpecificConfig));
+    }
+
+    @Test
+    public void findAdditionalConfigsWithNullAdditionalConfigSource() {
+        serviceSpecificConfig.additionalConfigSource = null;
+        serviceSpecificConfig.findAdditionalConfigs(serviceTestId);
+        verify(iConfigApplicator, never()).applyAdditionalConfiguration(eq(modulePath), eq(samplingConfig));
+        verify(iConfigApplicator, never()).applyAdditionalConfiguration(eq(endpointPath), eq(EndpointSpecificConfig.class));
+    }
+}

--- a/openpos-service/src/test/java/org/jumpmind/pos/service/ServiceSpecificConfigTest.java
+++ b/openpos-service/src/test/java/org/jumpmind/pos/service/ServiceSpecificConfigTest.java
@@ -1,9 +1,11 @@
 package org.jumpmind.pos.service;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -12,7 +14,8 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
-class ServiceSpecificConfigTest {
+@RunWith(MockitoJUnitRunner.class)
+public class ServiceSpecificConfigTest {
 
     String modulePath;
     String endpointPath;
@@ -27,7 +30,7 @@ class ServiceSpecificConfigTest {
     @Mock
     IConfigApplicator iConfigApplicator;
 
-    @BeforeEach
+    @Before
     public void before(){
         MockitoAnnotations.initMocks(this);
         serviceTestId = "TestID";


### PR DESCRIPTION
### Issues Fixed
Commerce #3512

### Summary
Changes the sampling strategy from of using `@Sample` annotations to using the database entries in `CTX_CONFIG` and yaml configurations. Removes `@Sample` annotation from all endpoints and updates docs. Adds logic to several config classes for checking the data table `CTX_CONFIG` for overrides to that instance as well as adding class variables for sampling configurations where needed.

Currently the feature "Confirm you can add a config via database on a new endpoint" will not work!