### PR TITLE
Updated loyalty customer form dialog to display differently by loyalty vs non-loyalty customers

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/loyalty-customer-form-dialog/loyalty-customer-form-dialog.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/loyalty-customer-form-dialog/loyalty-customer-form-dialog.component.html
@@ -98,7 +98,7 @@
                                     <app-icon matPrefix [iconName]="screen.loyaltyNumberIcon" iconClass="material-icons sm"></app-icon>
                                     <app-dynamic-form-field [formGroup]="screen.formGroup" [formField]="loyaltyNumberField" (onFieldChanged)="onFieldChanged($event)"></app-dynamic-form-field>
                                 </div>
-                                <div *ngIf="screen.membershipEnabled" class="memberships">
+                                <div *ngIf="screen.membershipEnabled && screen.isStructuredForm" class="memberships">
                                     <div *ngIf="screen.memberships && screen.memberships.length">
                                         <div class="title">
                                             {{screen.membershipsLabel}}
@@ -115,6 +115,13 @@
                                 </div>
                             </div>
                         </ng-template>
+
+                        <div class="extraFormFields">
+                            <div *ngFor="let formElement of screen.form.formElements">
+                                <app-dynamic-form-field *ngIf="handledFormFields.indexOf(formElement.id) == -1"
+                                        [formGroup]="screen.formGroup" [formField]="formElement" (onFieldChanged)="onFieldChanged($event)"></app-dynamic-form-field>
+                            </div>
+                        </div>
                     </div>
                     <mat-error>
                         <div id="formErrorsWrapper"><app-show-errors #formErrors [control]="screen.formGroup"></app-show-errors></div>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/loyalty-customer-form-dialog/loyalty-customer-form-dialog.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/loyalty-customer-form-dialog/loyalty-customer-form-dialog.component.scss
@@ -70,7 +70,8 @@
     gap: 0px 2.5em;
     grid-template-areas:
     "basic-info loyalty"
-    "contact location";
+    "contact location"
+    "extraFormFields extraFormFields";
 
     .basic-info {
         grid-area: basic-info;
@@ -185,6 +186,7 @@
         }
     }
 
+    .extraFormFields { grid-area: extraFormFields; }
 }
 
 .mobile-grid-container {
@@ -194,7 +196,8 @@
     "basic-info"
     "contact"
     "location"
-    "loyalty";
+    "loyalty"
+    "extraFormFields";
 
     .basic-info {
         grid-area: basic-info;
@@ -309,4 +312,6 @@
             }
         }
     }
+
+    .extraFormFields { grid-area: extraFormFields; }
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/loyalty-customer-form-dialog/loyalty-customer-form-dialog.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/loyalty-customer-form-dialog/loyalty-customer-form-dialog.component.ts
@@ -31,6 +31,8 @@ export class LoyaltyCustomerFormDialogComponent extends PosScreen<LoyaltyCustome
     emailFields : IFormElement[] = [];
     emailLabelFields : IFormElement[] = [];
 
+    handledFormFields : string[] = [];
+
     line1Field : IFormElement;
     line2Field : IFormElement;
     cityField : IFormElement;
@@ -78,6 +80,28 @@ export class LoyaltyCustomerFormDialogComponent extends PosScreen<LoyaltyCustome
     }
 
     buildScreen() : void {
+        if(this.screen.isStructuredForm) {
+            this.buildStructuredForm();
+        }
+
+        this.screen.formGroup = this.formBuilder.group(this.screen.form);
+    }
+
+    private buildStructuredForm(): void {
+        this.handledFormFields = [
+            'firstName',
+            'lastName',
+            'loyaltyNumber',
+            'phone',
+            'email',
+            'line1',
+            'line2',
+            'city',
+            'state',
+            'postalCode',
+            'country',
+        ];
+
         this.firstNameField = this.getFormElementById('firstName');
         this.lastNameField = this.getFormElementById('lastName');
         this.loyaltyNumberField = this.getFormElementById('loyaltyNumber');
@@ -124,8 +148,6 @@ export class LoyaltyCustomerFormDialogComponent extends PosScreen<LoyaltyCustome
                 }
             });
         }
-
-        this.screen.formGroup = this.formBuilder.group(this.screen.form);
     }
 
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/loyalty-customer-form-dialog/loyalty-customer-form.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/loyalty-customer-form-dialog/loyalty-customer-form.interface.ts
@@ -15,6 +15,7 @@ export interface LoyaltyCustomerFormInterface extends IAbstractScreen {
     name: string;
 
     instructions: string;
+    isStructuredForm: boolean;
     memberships: Membership[];
     membershipEnabled: boolean;
     membershipsLabel: string;

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/LoyaltyCustomerFormUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/LoyaltyCustomerFormUIMessage.java
@@ -14,6 +14,7 @@ public class LoyaltyCustomerFormUIMessage extends UIMessage implements IHasForm 
 
     private Form form = new Form();
 
+    private Boolean isStructuredForm;
     private Boolean membershipEnabled;
     private List<UIMembership> memberships;
     private String membershipsLabel;


### PR DESCRIPTION
### Summary
Added dynamic form elements to loyalty customer dialog for extra unexpected fields and added flag to check if loyalty customer for showing structured form. This strongly-structured form was cross-impacting return dialogs for tax exempt customers; these changes should preserve same look and feel as before the move from a strictly dynamic form.

### Screenshots
ELO POS view of all dynamic form fields (as if viewing on Tax Exempt customer, or for a bunch of fields that aren't part of the normal "Add/Edit Loyalty Customer" dialog.
![CustomerForm_ELOPOS_FullyDynamicFields](https://user-images.githubusercontent.com/28220454/115784694-79413e80-a38c-11eb-857f-851f83385432.PNG)

ELO POS view of all dynamic form fields scrolled down to see the extra non-normal Customer Loyalty form field appended to the bottom of the form.
![CustomerForm_ELOPOS_ScrollDynamicField](https://user-images.githubusercontent.com/28220454/115784696-79413e80-a38c-11eb-928b-d1a4b6bfae9f.PNG)

Same as above but on desktop to show that the overflow-y scroll bar is always on.
![CustomerForm_DesktopScrollDynamicField](https://user-images.githubusercontent.com/28220454/115784697-79d9d500-a38c-11eb-85a2-b2bd85b78e0b.PNG)

All form fields shown as dynamic fields (as if extra or viewing on Tax Exempt customer).
![CustomerForm_Edit_AllDynamicFields](https://user-images.githubusercontent.com/28220454/115784698-79d9d500-a38c-11eb-92be-f7d56342174e.PNG)