### PR TITLE
Do a case insensitive match for content file types

### DIFF
--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/content/AbstractFileContentProvider.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/content/AbstractFileContentProvider.java
@@ -124,9 +124,10 @@ public abstract class AbstractFileContentProvider implements IContentProvider {
     }
 
     public boolean isFileSupported(String filename) {
-        if (this.supportedFileTypes != null) {
+        if (this.supportedFileTypes != null && filename != null) {
+            String lowerFilename = filename.toLowerCase();
             for (String fileType : this.supportedFileTypes) {
-                if (filename.endsWith(fileType)) {
+                if (lowerFilename.endsWith(fileType.toLowerCase())) {
                     return true;
                 }
             }


### PR DESCRIPTION
### Summary
When matching file types defined by `openpos.ui.content.file.supportedFileTypes`, don't be so sensitive.

