### PR TITLE
Allow additional actions on Customer Details Screen

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/customer-details-dialog/customer-details-dialog.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/customer-details-dialog/customer-details-dialog.component.html
@@ -82,6 +82,15 @@
 </div>
 <mat-dialog-actions align="end" class="buttons">
     <app-secondary-button responsive-class
+                          *ngFor="let menuItem of screen.additionalActions"
+                          [disabled]="!menuItem?.enabled"
+                          [actionItem]="menuItem"
+                          (actionClick)="doAction(menuItem)"
+                          (click)="doAction(menuItem)">
+        <span responsive-class>{{menuItem.title}}</span>
+        <app-icon *ngIf="menuItem.icon" [iconClass]="'md'" [iconName]="menuItem.icon"></app-icon>
+    </app-secondary-button>
+    <app-secondary-button responsive-class
                           class="unlink"
                           *ngIf="screen.unlinkButton"
                           [disabled]="!screen.unlinkButton?.enabled"

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/customer-details-dialog/customer-details-dialog.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/customer-details-dialog/customer-details-dialog.interface.ts
@@ -12,6 +12,7 @@ export interface CustomerDetailsDialogInterface extends IAbstractScreen {
     editButton: IActionItem;
     unlinkButton: IActionItem;
     doneButton: IActionItem;
+    additionalActions: IActionItem[];
     contactLabel: string;
     rewardsLabel: string;
     rewardTabEnabled: boolean;

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/CustomerDetailsUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/CustomerDetailsUIMessage.java
@@ -4,6 +4,9 @@ import lombok.Data;
 import org.jumpmind.pos.core.ui.ActionItem;
 import org.jumpmind.pos.core.ui.UIMessage;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Data
 public class CustomerDetailsUIMessage extends UIMessage {
     private static final long serialVersionUID = 1L;
@@ -13,6 +16,7 @@ public class CustomerDetailsUIMessage extends UIMessage {
     private ActionItem unlinkButton;
     private ActionItem editButton;
     private ActionItem doneButton;
+    private List<ActionItem> additionalActions;
 
     private UICustomerDetailsItem customer;
 
@@ -46,5 +50,12 @@ public class CustomerDetailsUIMessage extends UIMessage {
 
     public CustomerDetailsUIMessage() {
         setScreenType(UIMessageType.CUSTOMER_DETAILS_DIALOG);
+    }
+
+    public void addAdditionalAction(ActionItem action) {
+        if (additionalActions == null) {
+            additionalActions = new ArrayList<>();
+        }
+        additionalActions.add(action);
     }
 }


### PR DESCRIPTION
### Summary
Small UI update which allows us to add additional actions onto the button tray of the customer details screen in addition to "Edit", "Unlink", and "Done". For example, the Petco Pay enroll button.

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/39058176/116145800-c171a100-a6ab-11eb-8ccc-2c1f34e76d64.png)

After:
![image](https://user-images.githubusercontent.com/39058176/116145768-b7e83900-a6ab-11eb-9eaa-6570392d1100.png)
