### PR TITLE
Fixed wedge scanner not working after first try

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/platform-plugins/barcode-scanners/wedge-scanner/wedge-scanner.plugin.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/platform-plugins/barcode-scanners/wedge-scanner/wedge-scanner.plugin.ts
@@ -21,7 +21,7 @@ interface ControlSequence { modifiers: string[]; key: string; }
     private startSequenceObj = this.getControlStrings(this.startSequence);
     private endSequenceObj = this.getControlStrings(this.endSequence);
 
-    private scanObservable = new Observable(observer => {
+    private readonly scanObservable = new Observable(observer => {
         this.scannerActive = true;
 
         const subscription = this.createScanBuffer().subscribe({
@@ -106,7 +106,7 @@ interface ControlSequence { modifiers: string[]; key: string; }
         });
 
         // buffer up all keydown events and prevent them from propagating while scanning
-        return this.scanObservable = this.domEventManager.createEventObserver(window, 'keydown', {capture: true}).pipe(
+        return this.domEventManager.createEventObserver(window, 'keydown', {capture: true}).pipe(
             bufferToggle(
                 startScanBuffer,
                 () => stopScanBuffer


### PR DESCRIPTION
### Summary
The wedge scanner was only working on the first attempt. This was caused by an unintentional re-assignment of a member containing important scan information.