### PR TITLE
Refactor Return and Sales UIMessages.

### DIFF
--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/ReturnUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/ReturnUIMessage.java
@@ -1,10 +1,8 @@
 package org.jumpmind.pos.core.ui.message;
 
 import lombok.Data;
-import org.jumpmind.pos.core.model.Total;
 import org.jumpmind.pos.core.ui.ActionItem;
 import org.jumpmind.pos.core.ui.AssignKeyBindings;
-import org.jumpmind.pos.core.ui.UIMessage;
 import org.jumpmind.pos.core.ui.data.TransactionReceipt;
 
 import java.util.ArrayList;
@@ -12,43 +10,15 @@ import java.util.List;
 
 @AssignKeyBindings
 @Data
-public class ReturnUIMessage extends UIMessage {
+public class ReturnUIMessage extends TransactionUIMessage {
     private static final long serialVersionUID = 1L;
 
-    private String providerKey;
-
-    private List<Total> totals;
-    private Total grandTotal;
-    private Total itemCount;
-
     private List<TransactionReceipt> receipts = new ArrayList<>();
-
-    private ActionItem checkoutButton;
-    private ActionItem loyaltyButton;
-    private ActionItem linkedCustomerButton;
-    private ActionItem linkedEmployeeButton;
     private ActionItem removeReceiptAction;
-
-    private boolean transactionActive = false;
-
-    private UICustomer customer;
-    private UICustomer employee;
-
-    private boolean locationEnabled;
-    private String locationOverridePrompt;
-
-    private boolean enableCollapsibleItems = true;
 
     public ReturnUIMessage() {
         this.setScreenType(UIMessageType.RETURN);
         this.setId("returns");
-    }
-
-    public void addTotal(String name, String amount) {
-        if (totals == null) {
-            totals = new ArrayList<>();
-        }
-        totals.add(new Total(name, amount));
     }
 
     public void addReceipt(TransactionReceipt receipt) {

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/SaleUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/SaleUIMessage.java
@@ -13,63 +13,21 @@ import org.jumpmind.pos.core.ui.data.OrderSummary;
 
 @AssignKeyBindings
 @Data
-public class SaleUIMessage extends UIMessage {
+public class SaleUIMessage extends TransactionUIMessage {
     private static final long serialVersionUID = 1L;
-
-    private String providerKey;
-
-    private List<Total> totals;
-    private Total grandTotal;
-    private Total itemCount;
-    
 
     private List<OrderSummary> orders;
     private ActionItem removeOrderAction;
 
-    private ActionItem checkoutButton;
     private ActionItem helpButton;
     private ActionItem logoutButton;
-    private ActionItem loyaltyButton;
-    private String loyaltyIDLabel;
-    private String profileIcon;
-    private List<UIMembership> memberships;
-    private boolean membershipEnabled;
-    private boolean customerMissingInfoEnabled;
-    private boolean customerMissingInfo;
-    private String customerMissingInfoIcon;
-    private String customerMissingInfoLabel;
-    private String checkMarkIcon;
-    private String noMembershipsFoundLabel;
-    private ActionItem mobileLoyaltyButton;
-    private ActionItem linkedCustomerButton;
-    private ActionItem linkedEmployeeButton;
     private ActionItem promoButton;
 
-    private boolean transactionActive = false;
-
-    private UICustomer customer;
-    private UICustomer employee;
     private AdditionalLabel taxExemptCertificateDetail;
-
-    private boolean locationEnabled;
-    private String locationOverridePrompt;
-
-    private boolean enableCollapsibleItems = true;
 
     public SaleUIMessage() {
         this.setScreenType(UIMessageType.SALE);
         this.setId("sale");
-    }
-
-    public void addTotal(String name, String amount) {
-        if (totals == null) {
-            totals = new ArrayList<>();
-        }
-        totals.add(new Total(name, amount));
-    }
-
-    public void setGrandTotal(String name, String amount) {
-        this.grandTotal = new Total(name, amount);
     }
 
     public void addOrder(OrderSummary orderSummary) {

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/TransactionUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/TransactionUIMessage.java
@@ -1,0 +1,59 @@
+package org.jumpmind.pos.core.ui.message;
+
+import lombok.Data;
+import org.jumpmind.pos.core.model.Total;
+import org.jumpmind.pos.core.ui.ActionItem;
+import org.jumpmind.pos.core.ui.UIMessage;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+public class TransactionUIMessage extends UIMessage {
+    private static final long serialVersionUID = 1L;
+
+    private String providerKey;
+
+    private List<Total> totals;
+    private Total grandTotal;
+    private Total itemCount;
+
+    private ActionItem checkoutButton;
+    private ActionItem loyaltyButton;
+    private ActionItem linkedCustomerButton;
+    private ActionItem linkedEmployeeButton;
+
+    private String loyaltyIDLabel;
+    private String profileIcon;
+    private List<UIMembership> memberships;
+    private boolean membershipEnabled;
+    private boolean customerMissingInfoEnabled;
+    private boolean customerMissingInfo;
+    private String customerMissingInfoIcon;
+    private String customerMissingInfoLabel;
+    private String checkMarkIcon;
+    private String noMembershipsFoundLabel;
+    private ActionItem mobileLoyaltyButton;
+
+    private boolean transactionActive = false;
+
+    private UICustomer customer;
+    private UICustomer employee;
+
+    private boolean locationEnabled;
+    private String locationOverridePrompt;
+
+    private boolean enableCollapsibleItems = true;
+
+    public void addTotal(String name, String amount) {
+        if (totals == null) {
+            totals = new ArrayList<>();
+        }
+        totals.add(new Total(name, amount));
+    }
+
+
+    public void setGrandTotal(String name, String amount) {
+        this.grandTotal = new Total(name, amount);
+    }
+}


### PR DESCRIPTION
### Summary
Previously the returns page was not up to date with the changes to loyalty membership button and display. These changes brings returns up to par with the sales page. These changes also refactor the ReturnsUIMessage and SalesUIMessage to reduce redundant code as well as pulling out code configuring membership info

### Screenshots
Loyalty button.
![image](https://user-images.githubusercontent.com/16402926/116254850-b23c3300-a73f-11eb-8ffd-58890a5da2d7.png)

Missing information.
![image](https://user-images.githubusercontent.com/16402926/116254910-bff1b880-a73f-11eb-8801-5b0e8656bafb.png)

Memberships. 
![image](https://user-images.githubusercontent.com/16402926/116254885-b9634100-a73f-11eb-87ed-689d0875f4f3.png)

