### PR TITLE
Style fix for transaction search details tender icons

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/item-card/item-card.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/item-card/item-card.component.html
@@ -1,7 +1,7 @@
 <mat-card class="item-card" [class]="item.lineItemType | lowercase" [ngClass]="{'mat-elevation-z5':hover, 'mat-elevation-z1':!hover}">
     <mat-card-content class="item-content">
         <img responsive-class class="item-card-image" *ngIf="item.imageUrl && !item.svgImage" [src]="item.imageUrl | imageUrl" alt="{{item.description}}" [ngClass]="{'collapsed': !expanded}">
-        <app-icon *ngIf="item.imageUrl && item.svgImage" [iconName]="item.imageUrl"
+        <app-icon *ngIf="item.imageUrl && item.svgImage" [iconName]="item.imageUrl" class="item-card-icon"
             [iconClass]="expanded ? 'material-icons mat-128' : 'material-icons mat-48'" [ngClass]="{'collapsed': !expanded}">
         </app-icon>
         <div class="left-side" [ngClass]="{'collapsed': !expanded}">

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/item-card/item-card.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/item-card/item-card.component.scss
@@ -40,6 +40,7 @@
 
         .item-card-icon {
             align-self: center;
+            margin-right: 16px;
         }
 
         .left-side {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/item-card/item-card.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/item-card/item-card.component.scss
@@ -38,6 +38,10 @@
             height: 50px;
         }
 
+        .item-card-icon {
+            align-self: center;
+        }
+
         .left-side {
             grid-area: 1/2/1/2;
             display: grid;


### PR DESCRIPTION
### Summary
This fixes a minor style issue with the tender icons ,on the transaction search details screen, where the vertical alignment needed centered and also needed some right margin to match the alignment and margin for item images.

### Screenshots
<img width="1792" alt="Screen Shot 2021-04-30 at 11 52 00 AM" src="https://user-images.githubusercontent.com/3991426/116720962-c6379d00-a9aa-11eb-875f-836dd178800a.png">

