### PR TITLE
Fixed bug with price ranges displaying even when prices are the same

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/currency-text/currency-text.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/currency-text/currency-text.component.ts
@@ -44,6 +44,8 @@ export class CurrencyTextComponent implements OnChanges {
     constructor(private localeService: LocaleService) {}
 
     ngOnChanges(): void {
+        this.upperBound = undefined;
+
         let localAmtText = this.amountText || (typeof(this.amountText) === 'number') ? this.amountText.toString().trim() : null;
         if (localAmtText) {
             const rangeMatch = numberMatchWithRange.exec(localAmtText);


### PR DESCRIPTION
### Issues Fixed
PCOM-2882

### Summary
When updating products with a price range, when the range would become more granular, the range would not update to match the selected item.
