### PR TITLE
add text to the employee linked button

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.html
@@ -117,6 +117,7 @@
                 <div *ngIf="screenData.employee.label && screenData.employee.id" class="muted-color">
                     {{screenData.employee.label}}: {{screenData.employee.id}}
                 </div>
+                <div *ngIf="screenData.linkedEmployeeButton.title" class="muted-color">{{screenData.linkedEmployeeButton.title}}</div>
             </app-secondary-button>
             <app-secondary-button responsive-class *ngIf="screenData.helpButton"
                                   [actionItem]="screenData.helpButton"


### PR DESCRIPTION

### Summary
adding optional text to the employee linked button on the sale screen

### Screen Shots

<img width="356" alt="image" src="https://user-images.githubusercontent.com/22771013/117214480-e3b1a000-adca-11eb-9786-1feb07529fa0.png">

