### PR TITLE
Put device name behind wrapper service

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/core.module.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/core.module.ts
@@ -75,6 +75,7 @@ import {ClientExecutableService} from "./services/client-executable.service";
 import {InfineaScannerCapacitorPlugin} from "./platform-plugins/scanners/infinea-scanner/infinea-scanner-capacitor/infinea-scanner-capacitor.plugin";
 import {Dpp255CapacitorPlugin} from "./platform-plugins/printers/dpp-255-capacitor.plugin";
 import {AutoPersonalizationStartupTask} from "./startup/auto-personalization-startup-task";
+import {WrapperService} from "./services/wrapper.service";
 
 registerLocaleData(locale_enCA, 'en-CA');
 registerLocaleData(locale_frCA, 'fr-CA');
@@ -122,7 +123,7 @@ registerLocaleData(locale_frCA, 'fr-CA');
         MediaMatcher,
         StompRService,
         ScannerService,
-        { provide: STARTUP_TASKS, useClass: AutoPersonalizationStartupTask, multi: true, deps: [PersonalizationService, MatDialog]},
+        { provide: STARTUP_TASKS, useClass: AutoPersonalizationStartupTask, multi: true, deps: [PersonalizationService, MatDialog, WrapperService]},
         { provide: STARTUP_TASKS, useClass: PersonalizationStartupTask, multi: true, deps: [PersonalizationService, MatDialog]},
         { provide: STARTUP_TASKS, useClass: SubscribeToSessionTask, multi: true, deps: [SessionService, Router]},
         { provide: STARTUP_TASKS, useClass: DialogServiceStartupTask, multi: true, deps: [DialogService]},

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/services/capacitor.service.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/services/capacitor.service.ts
@@ -1,7 +1,7 @@
-import { Injectable } from '@angular/core';
-import {Capacitor, Plugins as CapacitorPlugins} from "@capacitor/core";
-
-declare var cordova: any;
+import {Injectable} from '@angular/core';
+import {Capacitor, Device} from "@capacitor/core";
+import {from, Observable} from "rxjs";
+import {map} from "rxjs/operators";
 
 @Injectable({
     providedIn: 'root',
@@ -14,6 +14,12 @@ export class CapacitorService {
 
     public isPluginAvailable(plugin: string): boolean {
         return Capacitor.isPluginAvailable(plugin);
+    }
+
+    public getDeviceName(): Observable<string> {
+        return from(Device.getInfo()).pipe(
+            map(info => info.name)
+        );
     }
 }
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/services/wrapper.service.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/services/wrapper.service.ts
@@ -1,5 +1,6 @@
 import {Injectable} from "@angular/core";
 import {CapacitorService} from "./capacitor.service";
+import {from, Observable} from "rxjs";
 
 @Injectable({
     providedIn: 'root'
@@ -10,6 +11,13 @@ export class WrapperService {
 
     public shouldAutoPersonalize() {
         return this.capacitorService.isRunningInCapacitor();
+    }
+
+    public getDeviceName(): Observable<string> {
+        if (this.capacitorService.isRunningInCapacitor()) {
+            return this.capacitorService.getDeviceName();
+        }
+        return from(null);
     }
 
 }


### PR DESCRIPTION
### Summary
`DeviceInfo` is Capacitor specific code, so pulled that into the CapacitorService and made it available via the WrapperService.