### PR TITLE
Put device name behind wrapper service (#1322)

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/core.module.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/core.module.ts
@@ -81,6 +81,7 @@ import { Storage } from './storage/storage.service';
 import { STORAGE_CONTAINERS } from './storage/storage-container';
 import { CapacitorPrinterPlugin } from './platform-plugins/printers/capacitor-printer.plugin';
 import {AutoPersonalizationStartupTask} from "./startup/auto-personalization-startup-task";
+import {WrapperService} from "./services/wrapper.service";
 
 registerLocaleData(locale_enCA, 'en-CA');
 registerLocaleData(locale_frCA, 'fr-CA');
@@ -126,7 +127,7 @@ registerLocaleData(locale_frCA, 'fr-CA');
         MediaMatcher,
         StompRService,
         BarcodeScanner,
-        { provide: STARTUP_TASKS, useClass: AutoPersonalizationStartupTask, multi: true, deps: [PersonalizationService, MatDialog]},
+        { provide: STARTUP_TASKS, useClass: AutoPersonalizationStartupTask, multi: true, deps: [PersonalizationService, MatDialog, WrapperService]},
         { provide: STARTUP_TASKS, useClass: PersonalizationStartupTask, multi: true, deps: [PersonalizationService, MatDialog]},
         { provide: STARTUP_TASKS, useClass: SubscribeToSessionTask, multi: true, deps: [SessionService, Router]},
         { provide: STARTUP_TASKS, useClass: DialogServiceStartupTask, multi: true, deps: [DialogService]},

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/services/capacitor.service.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/services/capacitor.service.ts
@@ -1,7 +1,7 @@
-import { Injectable } from '@angular/core';
-import {Capacitor, Plugins as CapacitorPlugins} from "@capacitor/core";
-
-declare var cordova: any;
+import {Injectable} from '@angular/core';
+import {Capacitor, Device} from "@capacitor/core";
+import {from, Observable} from "rxjs";
+import {map} from "rxjs/operators";
 
 @Injectable({
     providedIn: 'root',
@@ -14,6 +14,12 @@ export class CapacitorService {
 
     public isPluginAvailable(plugin: string): boolean {
         return Capacitor.isPluginAvailable(plugin);
+    }
+
+    public getDeviceName(): Observable<string> {
+        return from(Device.getInfo()).pipe(
+            map(info => info.name)
+        );
     }
 }
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/services/wrapper.service.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/services/wrapper.service.ts
@@ -1,5 +1,6 @@
 import {Injectable} from "@angular/core";
 import {CapacitorService} from "./capacitor.service";
+import {from, Observable} from "rxjs";
 
 @Injectable({
     providedIn: 'root'
@@ -10,6 +11,13 @@ export class WrapperService {
 
     public shouldAutoPersonalize() {
         return this.capacitorService.isRunningInCapacitor();
+    }
+
+    public getDeviceName(): Observable<string> {
+        if (this.capacitorService.isRunningInCapacitor()) {
+            return this.capacitorService.getDeviceName();
+        }
+        return from(null);
     }
 
 }


### PR DESCRIPTION
### Summary
`DeviceInfo` is Capacitor specific code, so pulled that into the CapacitorService and made it available via the WrapperService.