### PR TITLE
Use correct Device import for device info

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/services/capacitor.service.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/services/capacitor.service.ts
@@ -1,7 +1,9 @@
 import {Injectable} from '@angular/core';
-import {Capacitor, Device} from "@capacitor/core";
+import {Capacitor, DeviceInfo, Plugins} from "@capacitor/core";
 import {from, Observable} from "rxjs";
 import {map} from "rxjs/operators";
+
+const {Device} = Plugins;
 
 @Injectable({
     providedIn: 'root',
@@ -18,7 +20,7 @@ export class CapacitorService {
 
     public getDeviceName(): Observable<string> {
         return from(Device.getInfo()).pipe(
-            map(info => info.name)
+            map((info: DeviceInfo) => info.name)
         );
     }
 }


### PR DESCRIPTION
### Summary
Incorrect import for Device plugin used to get device name. Corrected import.
