### PR TITLE
Fixed Sale Screen Not Showing Return Items

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-item-card-list/sale-item-card-list.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-item-card-list/sale-item-card-list.component.html
@@ -8,4 +8,4 @@
 (click)="updateExpandedIndex(i)" >
 </app-item-card>
 </div>
-<app-image-text-panel [instructionsSize]="'text-xl'"></app-image-text-panel>
+<app-image-text-panel *ngIf="(items$ | async).length === 0" [instructionsSize]="'text-xl'"></app-image-text-panel>


### PR DESCRIPTION
### Issues Fixed
[PCOM-3108](https://jira.ae.com/browse/PCOM-3108)
[PCOM-3136](https://jira.ae.com/browse/PCOM-3136)
[PCOM-3146](https://jira.ae.com/browse/PCOM-3146)

### Summary
This fixes a bug, introduced from UI fixes for the **April 2021 Symposium Demo** [#1312](https://github.com/JumpMind/openpos-framework/pull/1312)

### Screenshots
#### Before Fix
![before](https://user-images.githubusercontent.com/3991426/117875558-5067e700-b270-11eb-921c-eee68a542ada.gif)

#### After Fix
![after](https://user-images.githubusercontent.com/3991426/117875574-53fb6e00-b270-11eb-9786-15316eb84290.gif)
