### PR TITLE
Loyalty Button theme changes when customer linked

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel-theme.scss
@@ -5,9 +5,8 @@
     $foreground: map-get($theme, foreground );
 
     .linked-customer-summary {
-        .icon {
-            color: map_get($foreground, icon);
-        }
+        color: mat-color($theme, openpos-linked-customer-color);
+        background-color: mat-color($theme, openpos-linked-customer-background);
         .memberships {
             .customer-missing-info {
                 button {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/themes/_bang-orange-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/themes/_bang-orange-theme.scss
@@ -9,12 +9,17 @@
     $openpos-link-customer-color: #ffffff;
     $openpos-link-customer-background: #ff9800;
 
+    $openpos-linked-customer-color: #ffffff;
+    $openpos-linked-customer-background: #ff9800;
+
     $openpos-membership-in-color: #ffffff;
     $openpos-membership-in-background: #ff9800;
 
     $addons: (
             openpos-link-customer-color: $openpos-link-customer-color,
             openpos-link-customer-background: $openpos-link-customer-background,
+            openpos-linked-customer-color: $openpos-linked-customer-color,
+            openpos-linked-customer-background: $openpos-linked-customer-background,
             openpos-membership-in-color: $openpos-membership-in-color,
             openpos-membership-in-background: $openpos-membership-in-background
     );

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/themes/_openpos-default-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/themes/_openpos-default-theme.scss
@@ -7,12 +7,17 @@
     $openpos-link-customer-color: #ffffff;
     $openpos-link-customer-background: #296db6;
 
+    $openpos-linked-customer-color: #ffffff;
+    $openpos-linked-customer-background: #296db6;
+
     $openpos-membership-in-color: #ffffff;
     $openpos-membership-in-background: #64834D;
 
     $addons: (
             openpos-link-customer-color: $openpos-link-customer-color,
             openpos-link-customer-background: $openpos-link-customer-background,
+            openpos-linked-customer-color: $openpos-linked-customer-color,
+            openpos-linked-customer-background: $openpos-linked-customer-background,
             openpos-membership-in-color: $openpos-membership-in-color,
             openpos-membership-in-background: $openpos-membership-in-background
     );


### PR DESCRIPTION
### Summary
Introduced new sass variables for the loyalty button when a customer is linked so that themes can define a pre and post linked user color set.

### Screenshots
![image](https://user-images.githubusercontent.com/2406987/118165281-1de5f780-b3f2-11eb-8aa1-34f49ce1fc39.png)
