### PR TITLE
Remove usage of SQL ARRAY objects in IN clauses

### DIFF
--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/QueryTemplate.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/QueryTemplate.java
@@ -264,6 +264,7 @@ public class QueryTemplate implements Cloneable {
         while (matcher.find()) {
             StringBuilder replacement = new StringBuilder();
             replacement.append("(");
+            int parameterIndex = 0;
             for (Map.Entry<Integer, ? extends List> indexEntry : indexToList.entrySet()) {
                 if (indexEntry.getKey() > 0) {
                     if (matcher.group(2) != null) {
@@ -273,8 +274,18 @@ public class QueryTemplate implements Cloneable {
                         replacement.append(" OR ");
                     }
                 }
-                replacement.append(matcher.group(1)).append(matcher.group(3)).append("$").append(indexEntry.getKey()).append(matcher.group(4));
-                newParams.put(entry.getKey() + "$" + indexEntry.getKey(), indexEntry.getValue());
+                replacement.append(matcher.group(1));
+                List<?> entries = indexEntry.getValue();
+                for (int i = 0; i < entries.size(); i++) {
+                    replacement.append(matcher.group(3)).append("$").append(parameterIndex);
+
+                    newParams.put(entry.getKey() + "$" + parameterIndex, entries.get(i));
+                    if(i != entries.size() - 1) {
+                        replacement.append(",");
+                    }
+                    parameterIndex++;
+                }
+                replacement.append(matcher.group(4));
             }
             replacement.append(")");
             buffer.replace(matcher.start(), matcher.end(), replacement.toString());

--- a/openpos-persist/src/test/java/org/jumpmind/pos/persist/impl/QueryTemplateTest.java
+++ b/openpos-persist/src/test/java/org/jumpmind/pos/persist/impl/QueryTemplateTest.java
@@ -81,11 +81,13 @@ public class QueryTemplateTest {
         params.put("para", Arrays.asList("a", "b", "c", "d"));
         query.setMaxInParameters(2);
         SqlStatement sqlStatement = queryTemplate.generateSQL(query, params);
-        assertEquals("select foo from bar WHERE (baz in ( :para$0 ) OR baz in ( :para$1 ))", sqlStatement.getSql());
-        assertEquals(3, sqlStatement.getParameters().getValues().size());
+        assertEquals("select foo from bar WHERE (baz in ( :para$0,:para$1 ) OR baz in ( :para$2,:para$3 ))", sqlStatement.getSql());
+        assertEquals(5, sqlStatement.getParameters().getValues().size());
         assertEquals(Arrays.asList("a", "b", "c", "d"), sqlStatement.getParameters().getValues().get("para"));
-        assertEquals(Arrays.asList("a", "b"), sqlStatement.getParameters().getValues().get("para$0"));
-        assertEquals(Arrays.asList("c", "d"), sqlStatement.getParameters().getValues().get("para$1"));
+        assertEquals("a", sqlStatement.getParameters().getValues().get("para$0"));
+        assertEquals("b", sqlStatement.getParameters().getValues().get("para$1"));
+        assertEquals("c", sqlStatement.getParameters().getValues().get("para$2"));
+        assertEquals("d", sqlStatement.getParameters().getValues().get("para$3"));
     }
 
     @Test
@@ -94,11 +96,13 @@ public class QueryTemplateTest {
         params.put("para", Arrays.asList("a", "b", "c", "d"));
         query.setMaxInParameters(2);
         SqlStatement sqlStatement = queryTemplate.generateSQL(query, params);
-        assertEquals("select foo from bar WHERE ((baz in ( :para$0 ) OR baz in ( :para$1 )))", sqlStatement.getSql());
-        assertEquals(3, sqlStatement.getParameters().getValues().size());
+        assertEquals("select foo from bar WHERE ((baz in ( :para$0,:para$1 ) OR baz in ( :para$2,:para$3 )))", sqlStatement.getSql());
+        assertEquals(5, sqlStatement.getParameters().getValues().size());
         assertEquals(Arrays.asList("a", "b", "c", "d"), sqlStatement.getParameters().getValues().get("para"));
-        assertEquals(Arrays.asList("a", "b"), sqlStatement.getParameters().getValues().get("para$0"));
-        assertEquals(Arrays.asList("c", "d"), sqlStatement.getParameters().getValues().get("para$1"));
+        assertEquals("a", sqlStatement.getParameters().getValues().get("para$0"));
+        assertEquals("b", sqlStatement.getParameters().getValues().get("para$1"));
+        assertEquals("c", sqlStatement.getParameters().getValues().get("para$2"));
+        assertEquals("d", sqlStatement.getParameters().getValues().get("para$3"));
     }
 
     @Test
@@ -107,11 +111,13 @@ public class QueryTemplateTest {
         params.put("para", new String[] { "a", "b", "c", "d" });
         query.setMaxInParameters(2);
         SqlStatement sqlStatement = queryTemplate.generateSQL(query, params);
-        assertEquals("select foo from bar WHERE (baz in ( :para$0 ) OR baz in ( :para$1 ))", sqlStatement.getSql());
-        assertEquals(3, sqlStatement.getParameters().getValues().size());
+        assertEquals("select foo from bar WHERE (baz in ( :para$0,:para$1 ) OR baz in ( :para$2,:para$3 ))", sqlStatement.getSql());
+        assertEquals(5, sqlStatement.getParameters().getValues().size());
         assertArrayEquals(new String[] { "a", "b", "c", "d" }, (String[]) sqlStatement.getParameters().getValues().get("para"));
-        assertEquals(Arrays.asList("a", "b"), sqlStatement.getParameters().getValues().get("para$0"));
-        assertEquals(Arrays.asList("c", "d"), sqlStatement.getParameters().getValues().get("para$1"));
+        assertEquals("a", sqlStatement.getParameters().getValues().get("para$0"));
+        assertEquals("b", sqlStatement.getParameters().getValues().get("para$1"));
+        assertEquals("c", sqlStatement.getParameters().getValues().get("para$2"));
+        assertEquals("d", sqlStatement.getParameters().getValues().get("para$3"));
     }
 
     @Test
@@ -120,11 +126,13 @@ public class QueryTemplateTest {
         params.put("para", Arrays.asList("a", "b", "c", "d"));
         query.setMaxInParameters(2);
         SqlStatement sqlStatement = queryTemplate.generateSQL(query, params);
-        assertEquals("select foo from bar WHERE (baz NOT IN ( :para$0 ) AND baz NOT IN ( :para$1 ))", sqlStatement.getSql());
-        assertEquals(3, sqlStatement.getParameters().getValues().size());
+        assertEquals("select foo from bar WHERE (baz NOT IN ( :para$0,:para$1 ) AND baz NOT IN ( :para$2,:para$3 ))", sqlStatement.getSql());
+        assertEquals(5, sqlStatement.getParameters().getValues().size());
         assertEquals(Arrays.asList("a", "b", "c", "d"), sqlStatement.getParameters().getValues().get("para"));
-        assertEquals(Arrays.asList("a", "b"), sqlStatement.getParameters().getValues().get("para$0"));
-        assertEquals(Arrays.asList("c", "d"), sqlStatement.getParameters().getValues().get("para$1"));
+        assertEquals("a", sqlStatement.getParameters().getValues().get("para$0"));
+        assertEquals("b", sqlStatement.getParameters().getValues().get("para$1"));
+        assertEquals("c", sqlStatement.getParameters().getValues().get("para$2"));
+        assertEquals("d", sqlStatement.getParameters().getValues().get("para$3"));
     }
 
     @Test
@@ -133,11 +141,13 @@ public class QueryTemplateTest {
         params.put("para", new String[] { "a", "b", "c", "d" });
         query.setMaxInParameters(2);
         SqlStatement sqlStatement = queryTemplate.generateSQL(query, params);
-        assertEquals("select foo from bar WHERE (baz NOT IN ( :para$0 ) AND baz NOT IN ( :para$1 ))", sqlStatement.getSql());
-        assertEquals(3, sqlStatement.getParameters().getValues().size());
+        assertEquals("select foo from bar WHERE (baz NOT IN ( :para$0,:para$1 ) AND baz NOT IN ( :para$2,:para$3 ))", sqlStatement.getSql());
+        assertEquals(5, sqlStatement.getParameters().getValues().size());
         assertArrayEquals(new String[] { "a", "b", "c", "d" }, (String[]) sqlStatement.getParameters().getValues().get("para"));
-        assertEquals(Arrays.asList("a", "b"), sqlStatement.getParameters().getValues().get("para$0"));
-        assertEquals(Arrays.asList("c", "d"), sqlStatement.getParameters().getValues().get("para$1"));
+        assertEquals("a", sqlStatement.getParameters().getValues().get("para$0"));
+        assertEquals("b", sqlStatement.getParameters().getValues().get("para$1"));
+        assertEquals("c", sqlStatement.getParameters().getValues().get("para$2"));
+        assertEquals("d", sqlStatement.getParameters().getValues().get("para$3"));
     }
 
     @Test
@@ -146,11 +156,15 @@ public class QueryTemplateTest {
         params.put("para", Arrays.asList("a", "b", "c", "d"));
         query.setMaxInParameters(2);
         SqlStatement sqlStatement = queryTemplate.generateSQL(query, params);
-        assertEquals("select foo from bar WHERE (baz in \n( :para$0 ) OR baz in \n( :para$1 ))", sqlStatement.getSql());
-        assertEquals(3, sqlStatement.getParameters().getValues().size());
+        assertEquals("select foo from bar WHERE (baz in \n" +
+                "( :para$0,:para$1 ) OR baz in \n" +
+                "( :para$2,:para$3 ))", sqlStatement.getSql());
+        assertEquals(5, sqlStatement.getParameters().getValues().size());
         assertEquals(Arrays.asList("a", "b", "c", "d"), sqlStatement.getParameters().getValues().get("para"));
-        assertEquals(Arrays.asList("a", "b"), sqlStatement.getParameters().getValues().get("para$0"));
-        assertEquals(Arrays.asList("c", "d"), sqlStatement.getParameters().getValues().get("para$1"));
+        assertEquals("a", sqlStatement.getParameters().getValues().get("para$0"));
+        assertEquals("b", sqlStatement.getParameters().getValues().get("para$1"));
+        assertEquals("c", sqlStatement.getParameters().getValues().get("para$2"));
+        assertEquals("d", sqlStatement.getParameters().getValues().get("para$3"));
     }
 
     @Test
@@ -160,16 +174,20 @@ public class QueryTemplateTest {
         params.put("arap", Arrays.asList("z", "y", "x", "w", "v"));
         query.setMaxInParameters(2);
         SqlStatement sqlStatement = queryTemplate.generateSQL(query, params);
-        assertEquals("select foo from bar WHERE (baz in ( :para$0 ) OR baz in ( :para$1 )) and " +
-                "(waz not in ( :arap$0 ) AND waz not in ( :arap$1 ) AND waz not in ( :arap$2 ))", sqlStatement.getSql());
-        assertEquals(7, sqlStatement.getParameters().getValues().size());
+        assertEquals("select foo from bar WHERE (baz in ( :para$0,:para$1 ) OR baz in ( :para$2,:para$3 )) and (waz not in ( :arap$0,:arap$1 ) AND waz not in ( :arap$2,:arap$3 ) AND waz not in ( :arap$4 ))", sqlStatement.getSql());
+        assertEquals(11, sqlStatement.getParameters().getValues().size());
         assertEquals(Arrays.asList("a", "b", "c", "d"), sqlStatement.getParameters().getValues().get("para"));
-        assertEquals(Arrays.asList("a", "b"), sqlStatement.getParameters().getValues().get("para$0"));
-        assertEquals(Arrays.asList("c", "d"), sqlStatement.getParameters().getValues().get("para$1"));
+        assertEquals("a", sqlStatement.getParameters().getValues().get("para$0"));
+        assertEquals("b", sqlStatement.getParameters().getValues().get("para$1"));
+        assertEquals("c", sqlStatement.getParameters().getValues().get("para$2"));
+        assertEquals("d", sqlStatement.getParameters().getValues().get("para$3"));
         assertEquals(Arrays.asList("z", "y", "x", "w", "v"), sqlStatement.getParameters().getValues().get("arap"));
-        assertEquals(Arrays.asList("z", "y"), sqlStatement.getParameters().getValues().get("arap$0"));
-        assertEquals(Arrays.asList("x", "w"), sqlStatement.getParameters().getValues().get("arap$1"));
-        assertEquals(Arrays.asList("v"), sqlStatement.getParameters().getValues().get("arap$2"));
+        assertEquals("z", sqlStatement.getParameters().getValues().get("arap$0"));
+        assertEquals("y", sqlStatement.getParameters().getValues().get("arap$1"));
+        assertEquals("x", sqlStatement.getParameters().getValues().get("arap$2"));
+        assertEquals("w", sqlStatement.getParameters().getValues().get("arap$3"));
+        assertEquals("v", sqlStatement.getParameters().getValues().get("arap$4"));
+
     }
 
     @Test


### PR DESCRIPTION
### Summary
SQL Server does not support SQL ARRAY objects, and we are using arrays in our logic that splits IN clauses with too many parameters into multiple IN clauses. Update the logic to NOT use arrays, but create a uniquely named parameter for each entry in the IN clause.
