### PR TITLE
Loyalty Button layout changes

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/membership-display/_membership-display-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/membership-display/_membership-display-theme.scss
@@ -4,15 +4,16 @@
     $openpos-membership-in-background: map-get($theme, openpos-membership-in-background );
 
     .membership-chips {
-        mat-chip.not-in {
-            background-color: white !important;
-            border: 1px solid mat-color($foreground, secondary-text);
-            color: mat-color($foreground, secondary-text) !important;
-        }
-
-        mat-chip.in {
-            color: $openpos-membership-in-color !important;
-            background-color: $openpos-membership-in-background !important;
+        mat-chip {
+            &.not-in {
+                background-color: white !important;
+                border: 3px solid $openpos-membership-in-background;
+                color: mat-color($foreground, secondary-text) !important;
+            }
+            &.in {
+                color: $openpos-membership-in-color !important;
+                background-color: $openpos-membership-in-background !important;
+            }
         }
     }
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel-theme.scss
@@ -6,7 +6,13 @@
 
     .linked-customer-summary {
         color: mat-color($theme, openpos-linked-customer-color);
-        background-color: mat-color($theme, openpos-linked-customer-background);
+        &.header {
+            background-color: mat-color($theme, openpos-linked-customer-background);
+            border-radius: 4px 4px 0px 0px;
+        }
+        &.content {
+            border-radius: 0px 0px 4px 4px;
+        }
         .memberships {
             .customer-missing-info {
                 button {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.html
@@ -19,7 +19,7 @@
             <mat-icon class="material-icons" style="vertical-align: top">keyboard_arrow_right</mat-icon>
         </button>
         <button *ngIf="!screenData.readOnly && screenData.linkedCustomerButton && screenData.customer"
-                class="linked-customer-summary"
+                class="linked-customer-summary header"
                 style="width: 100%;"
                 responsive-class
                 mat-flat-button
@@ -31,10 +31,25 @@
                     <div class="name">
                         <div class="customer-name">
                             {{screenData.customer.name}}
-                            <span *ngIf="keybindsEnabled(screenData.linkedCustomerButton)"
-                                  class="muted-color loyalty-keybind">{{screenData.linkedCustomerButton.keybindDisplayName}}</span></div>
                         </div>
+                    </div>
                     <div class="icon"><app-icon [iconName]="screenData.profileIcon" [iconClass]="(isMobile | async) ? null: 'material-icons mat-36'"></app-icon></div>
+                    <div class="loyalty-icon">
+                        <img *ngIf="screenData.loyaltyButton.icon" [src]="screenData.loyaltyButton.icon | imageUrl" class="sale-total-loyalty-button-icon">
+                    </div>
+                </div>
+            </div>
+        </button>
+        <button *ngIf="!screenData.readOnly && screenData.linkedCustomerButton && screenData.customer"
+                class="linked-customer-summary content"
+                style="width: 100%;"
+                responsive-class
+                mat-flat-button
+                [actionItem]="screenData.linkedCustomerButton"
+                (actionClick)="doAction(screenData.linkedCustomerButton)"
+                (click)="doAction(screenData.linkedCustomerButton)">
+            <div class="button-wrapper">
+                <div class="grid-container">
                     <div class="memberships">
                         <div *ngIf="isMissingCustomerInfo()" class="customer-missing-info">
                             <app-warn-button responsive-class>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
@@ -40,12 +40,12 @@
             padding: 10px;
             .grid-container {
                 display: grid;
-                grid-template-columns: 1fr 10fr;
+                grid-template-columns: 1fr 7fr 3fr;
                 grid-template-rows: auto 1fr;
                 gap: 0px 0px;
                 grid-template-areas:
-                    "Icon Name"
-                    "Memberships Memberships";
+                    "Icon Name LoyaltyIcon"
+                    "Memberships Memberships Memberships";
                 .name {
                     grid-area: Name;
                     .customer-name {
@@ -58,6 +58,14 @@
                 .icon {
                     grid-area: Icon;
                     display: inline-block;
+                }
+                .loyalty-icon {
+                    grid-area: LoyaltyIcon;
+                    display: inline-block;
+                    .sale-total-loyalty-button-icon {
+                        max-height: 36px;
+                        vertical-align: middle;
+                    }
                 }
                 .memberships {
                     grid-area: Memberships;

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.spec.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.spec.ts
@@ -225,19 +225,6 @@ describe('SaleTotalPanelComponent', () => {
                             expect(component.doAction).toHaveBeenCalledWith(component.screenData.linkedCustomerButton);
                         });
 
-                        it('shows the keybinding when keybinds are enabled', () => {
-                            spyOn(component, 'keybindsEnabled').and.returnValue(true);
-                            fixture.detectChanges();
-                            const button = fixture.debugElement.query(By.css('.sale-total-header .linked-customer-summary .loyalty-keybind'));
-                            expect(button.nativeElement.textContent).toContain('F7');
-                        });
-
-                        it('hides the keybinding when keybinds are disabled', () => {
-                            spyOn(component, 'keybindsEnabled').and.returnValue(false);
-                            fixture.detectChanges();
-                            validateDoesNotExist(fixture, '.sale-total-header .linked-customer-summary .loyalty-keybind');
-                        });
-
                         describe('when customerMissingInfoEnabled is true', () => {
                             beforeEach(() => {
                                 component.screenData.customerMissingInfoEnabled = true;

--- a/openpos-flow/src/main/resources/content/icons/exclamation.svg
+++ b/openpos-flow/src/main/resources/content/icons/exclamation.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1"  width="24" height="24" viewBox="0 0 24 24">
+    <path d="M10 3H14V14H10V3M10 21V17H14V21H10Z" />
+</svg>


### PR DESCRIPTION

### Summary
Changed the layout/styling to the loyalty button when a customer is linked.

### Screenshots
Default
![image](https://user-images.githubusercontent.com/2406987/119399514-fd962280-bca6-11eb-9a5d-8225a3232568.png)
![image](https://user-images.githubusercontent.com/2406987/119399540-04bd3080-bca7-11eb-8dd6-56227a298afc.png)


dark-blue (the icon being white is an artifact of the image for the inverted logo colors being white, this would be tailored per customer)
![image](https://user-images.githubusercontent.com/2406987/119399679-2cac9400-bca7-11eb-9767-8054e9b48738.png)
![image](https://user-images.githubusercontent.com/2406987/119399699-333b0b80-bca7-11eb-9215-dc85a6c4eaf6.png)


pets
![image](https://user-images.githubusercontent.com/2406987/119399741-4057fa80-bca7-11eb-8622-a9602db4dffe.png)
![image](https://user-images.githubusercontent.com/2406987/119399721-3a621980-bca7-11eb-89b8-720f7f598bb3.png)


training
![image](https://user-images.githubusercontent.com/2406987/119399798-51a10700-bca7-11eb-8065-2572f668a72c.png)
![image](https://user-images.githubusercontent.com/2406987/119399756-46e67200-bca7-11eb-82fa-ccfda2b337c3.png)


patriotic bird
![image](https://user-images.githubusercontent.com/2406987/119399853-667d9a80-bca7-11eb-8bad-49e71f72d43a.png)
![image](https://user-images.githubusercontent.com/2406987/119399861-69788b00-bca7-11eb-8b5a-715b85708f62.png)


patriotic nest
![image](https://user-images.githubusercontent.com/2406987/119399939-857c2c80-bca7-11eb-87cf-9eb03caaf068.png)
![image](https://user-images.githubusercontent.com/2406987/119399929-81500f00-bca7-11eb-9090-15be5e8be73e.png)


burl red
![image](https://user-images.githubusercontent.com/2406987/119399994-9167ee80-bca7-11eb-80e5-446492e600b0.png)
![image](https://user-images.githubusercontent.com/2406987/119399967-8ca33a80-bca7-11eb-92cb-5385aabd5eb0.png)


bang orange
![image](https://user-images.githubusercontent.com/2406987/119400028-9a58c000-bca7-11eb-8cc7-0de2703aeb26.png)
![image](https://user-images.githubusercontent.com/2406987/119400043-a0e73780-bca7-11eb-9690-c703db975c9e.png)
