### PR TITLE
patchJar task

### DIFF
--- a/openpos-gradle/src/main/resources/java.gradle
+++ b/openpos-gradle/src/main/resources/java.gradle
@@ -168,7 +168,6 @@ task patchJar(type: Jar, dependsOn:classes) {
         for (sourceFileName in ext.patchSourceFiles) {
               include sourceFileName;
         }        
-        include '**/SqlPurgeJob.java'
     }
     from(sourceSets.main.output.classesDirs ) {
         for (className in ext.patchClassFiles) {

--- a/openpos-gradle/src/main/resources/java.gradle
+++ b/openpos-gradle/src/main/resources/java.gradle
@@ -143,6 +143,48 @@ task sourcesJar(type: Jar, dependsOn:classes) {
     from sourceSets.main.allSource
 }
 
+// example usage:
+// commerce-assemble$ ./gradlew commerce-context:patchJar -PpatchClasses=SqlPurgeJob,CustomerGroupModel
+task patchJar(type: Jar, dependsOn:classes) {
+    includeEmptyDirs = false
+    outputs.upToDateWhen { false }
+
+    if (!project.hasProperty("patchClasses")) {
+            throw new InvalidUserDataException("patchClasses property not found. Please specify one or more patch classes with a -P properties, such as -PpatchClasses=SqlPurgeJob,SomeOtherClass");
+    }
+
+    def classNames = project.patchClasses.split(",");
+    ext.patchClassFiles = classNames.collect{className -> ["**/${className}.class", "**/${className}\$*.class"]}.flatten()
+    ext.patchSourceFiles = classNames.collect{className -> "**/${className}.java"}
+
+    doFirst {
+        if (!project.hasProperty("patchName")) {
+            ext.patchName = 'patch.jar'
+        }   
+        patchJar.archiveName = ext.patchName;
+    }
+
+    from(sourceSets.main.allSource) {
+        for (sourceFileName in ext.patchSourceFiles) {
+              include sourceFileName;
+        }        
+        include '**/SqlPurgeJob.java'
+    }
+    from(sourceSets.main.output.classesDirs ) {
+        for (className in ext.patchClassFiles) {
+              include className;
+        }
+    }        
+
+    eachFile { file ->
+        println "** Including file in patch: " + file;
+    }
+
+    doLast {
+        println "Patch jar written to ${patchJar.archiveName}";
+    }
+}
+
 task extraClean {
     doFirst {
         println 'Removing bin and .settings directories'


### PR DESCRIPTION
### Summary
A a patchJar task which can generate a patch of selected files from a given java project.  Usage example (from commerce-assemble):
./gradlew commerce-context:patchJar -PpatchClasses=SqlPurgeJob,CustomerGroupModel
