### PR TITLE
Make remove button not be cut off on return linked receipt

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/receipt-card/receipt-card.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/receipt-card/receipt-card.component.html
@@ -46,7 +46,7 @@
     <div class="remove-button" *ngIf="receipt && removeReceiptAction">
         <button mat-icon-button (click)="onRemoveAction(); $event.stopPropagation()" color="primary">
             {{removeReceiptAction.title}}
-            <app-icon [iconClass]="'material-icons'" [iconName]="removeReceiptAction.icon"></app-icon>
+            <app-icon [iconClass]="'material-icons xs'" [iconName]="removeReceiptAction.icon"></app-icon>
         </button>
     </div>
 </div>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/receipt-card/receipt-card.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/receipt-card/receipt-card.component.scss
@@ -97,5 +97,9 @@
         justify-items:end;
         padding-top:10px;
         padding-right:15px;
+
+        .mat-icon-button {
+            width:70px;
+        }
     }
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/receipt-card/receipt-card.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/receipt-card/receipt-card.component.scss
@@ -99,7 +99,12 @@
         padding-right:15px;
 
         .mat-icon-button {
-            width:70px;
+            min-width: fit-content;
+
+            .app-icon {
+                top: -3px;
+                position: relative;
+            }
         }
     }
 }


### PR DESCRIPTION
### Issues Fixed
At some devices remove button cut off on the return linked receipt:
![image-2021-05-04-08-42-20-862](https://user-images.githubusercontent.com/74003404/119819651-a770eb80-bf01-11eb-8238-be12fd9aa9a0.png)

### Summary
I noticed that the mat-icon-button is hardcoded to be 40px/40px which is not enough for some devices in our case. Also, I found out that we have a bin icon close to the remove button which was cut off on all devices, so my fix also make it visible.

### Screenshots
Comparasion with and without changed width:
<img width="1388" alt="Screenshot 2021-05-19 at 21 47 16" src="https://user-images.githubusercontent.com/74003404/119821676-e1db8800-bf03-11eb-87d4-229f41789aba.png">
<img width="1387" alt="Screenshot 2021-05-19 at 21 47 37" src="https://user-images.githubusercontent.com/74003404/119821680-e2741e80-bf03-11eb-938e-472990fe6307.png">

