### PR TITLE
Changes to fix issue with matching data series IDs #1386

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/messages/message-types.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/messages/message-types.ts
@@ -29,4 +29,5 @@ export class MessageTypes {
     static HIDE_STATUS_BAR = 'HideStatusBar';
     static CLIENT_EXECUTABLE = 'ClientExecutable';
     static CLOSE_STATUS_DETAILS = 'CloseStatusDetails';
+    static DATA_CLEAR = 'DataClear';
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/ui-data-message/ui-data-message.service.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/ui-data-message/ui-data-message.service.ts
@@ -23,6 +23,12 @@ export class UIDataMessageService {
           this.dataMessages.clear();
       });
 
+      this.sessionService.getMessages(MessageTypes.DATA_CLEAR).subscribe( m => {
+          // Clear out out cache if the device is reset
+          this.accumulatedResultsMap.clear();
+          this.dataMessages.clear();
+      });
+
     this.sessionService.getMessages(MessageTypes.DATA).subscribe( (message: UIDataMessage<any>) => {
         if(message.seriesId === -1){
             // -1 signals stale data that no longer exists on the server so clean up.

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/StateManager.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/StateManager.java
@@ -40,7 +40,7 @@ import org.jumpmind.pos.core.clientconfiguration.LocaleMessageFactory;
 import org.jumpmind.pos.core.error.IErrorHandler;
 import org.jumpmind.pos.core.event.DeviceResetEvent;
 import org.jumpmind.pos.core.flow.config.*;
-import org.jumpmind.pos.core.model.MessageType;
+import org.jumpmind.pos.core.model.DataClearMessage;
 import org.jumpmind.pos.core.model.StartupMessage;
 import org.jumpmind.pos.core.service.UIDataMessageProviderService;
 import org.jumpmind.pos.core.ui.CloseToast;
@@ -246,6 +246,7 @@ public class StateManager implements IStateManager {
                         init(this.getAppId(), this.getDeviceId());
                         log.info("StateManager reset");
                         this.eventPublisher.publish(new DeviceResetEvent(getDeviceId(), getAppId()));
+                        sendDataClearMessage();
                         break;
                     } else if (actionContext.getAction().getName().equals(STATE_MANAGER_STOP_ACTION)) {
                         actionContext.getAction().markProcessed();
@@ -278,6 +279,12 @@ public class StateManager implements IStateManager {
             }
         }
         log.info("State action actionLoop is exiting.");
+    }
+
+    public void sendDataClearMessage() {
+        String appId = applicationState.getAppId();
+        String deviceId = applicationState.getDeviceId();
+        messageService.sendMessage(appId, deviceId, new DataClearMessage());
     }
 
     public void sendStartupCompleteMessage() {

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/StateManager.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/StateManager.java
@@ -282,9 +282,8 @@ public class StateManager implements IStateManager {
     }
 
     public void sendDataClearMessage() {
-        String appId = applicationState.getAppId();
         String deviceId = applicationState.getDeviceId();
-        messageService.sendMessage(appId, deviceId, new DataClearMessage());
+        messageService.sendMessage(deviceId, new DataClearMessage());
     }
 
     public void sendStartupCompleteMessage() {

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/model/DataClearMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/model/DataClearMessage.java
@@ -1,0 +1,9 @@
+package org.jumpmind.pos.core.model;
+
+import org.jumpmind.pos.util.model.Message;
+
+public class DataClearMessage extends Message {
+    public DataClearMessage() {
+        setType(MessageType.DataClear);
+    }
+}

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/model/MessageType.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/model/MessageType.java
@@ -28,4 +28,5 @@ public final class MessageType {
     public static final String HideStatusBar = "HideStatusBar";
     public static final String ClientExecutable = "ClientExecutable";
     public static final String DevicePairingChanged = "DevicePairingChanged";
+    public static final String DataClear = "DataClear";
 }

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/service/UIDataMessageProviderService.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/service/UIDataMessageProviderService.java
@@ -43,7 +43,7 @@ public class UIDataMessageProviderService implements PropertyChangeListener {
                             ((IHasObservableUIDataMessageProviderProperty)provider).addPropertyChangeListener(this);
                         }
                         if(provider.isNewSeries()) {
-                            provider.setSeriesId( provider.getSeriesId() + 1);
+                            provider.setSeriesId(getNextSeriesId());
                             provider.setNewSeries(false);
                         }
                         //If it is a new provider or series add it and initialize it
@@ -64,12 +64,19 @@ public class UIDataMessageProviderService implements PropertyChangeListener {
                     ((IHasObservableUIDataMessageProviderProperty)provider).addPropertyChangeListener(this);
                 }
                 if(provider.isNewSeries()) {
-                    provider.setSeriesId( provider.getSeriesId() + 1);
+                    provider.setSeriesId(getNextSeriesId());
                     provider.setNewSeries(false);
                 }
                 sendDataMessage(applicationState.getAppId(), applicationState.getDeviceId(), provider.getNextDataChunk(), key, provider.getSeriesId());
             });
         }
+    }
+
+    // sets series ID to a random int
+    // resolves issue with matching series ID 1 when a device is reset
+    private int getNextSeriesId() {
+        Random random = new Random();
+        return random.nextInt(Integer.MAX_VALUE);
     }
 
     public boolean handleAction(Action action, ApplicationState applicationState){
@@ -128,7 +135,7 @@ public class UIDataMessageProviderService implements PropertyChangeListener {
         if(evt instanceof UIDataMessageProviderPropertyChangeEvent) {
             UIDataMessageProvider uiDataMessageProvider = (UIDataMessageProvider) evt.getSource();
             if(uiDataMessageProvider.isNewSeries()) {
-                uiDataMessageProvider.setSeriesId( uiDataMessageProvider.getSeriesId() + 1);
+                uiDataMessageProvider.setSeriesId(getNextSeriesId());
                 uiDataMessageProvider.setNewSeries(false);
             }
             sendDataMessage(((UIDataMessageProviderPropertyChangeEvent) evt).getAppId(),


### PR DESCRIPTION
### Issues Fixed
https://petcoalm.atlassian.net/browse/PDPOS-3005

### Summary
Fixing issue when different data sets in UIMessage objects have the same series ID.

Currently the series ID is set in sequential order, so the first series ID for a given message will be 1. The issue comes when the latest series ID is 1, then the state manager resets the device, resetting the data provider and the series ID back to 1. The client sees this as the same data set with another chunk and pushes the data onto the existing cached data array instead of replacing the contents. This change:
- uses random integers for series ID to ensure that no 2 sequential IDs are the same
- Sends a message to the client to clear the data caches when a device has been reset
