### PR TITLE
Add static hostname fallback to auto-personalization

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/configuration/configuration.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/configuration/configuration.ts
@@ -16,6 +16,7 @@ export const Configuration = {
     loadingDialogDelay: 4000,
     confirmConnectionTimeoutMillis: 172800000,
     autoPersonalizationRequestTimeoutMillis: 10000,
+    autoPersonalizationServicePath: 'personalization.jumpmind-commerce.com/admin/personalizeMe',
     // These properties are static on the client and not overriden by configuration.service.ts
     compatibilityVersion: 'v1',
     incompatibleVersionMessage: 'Application is not compatible with the server.',

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/personalization.service.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/personalization.service.ts
@@ -33,9 +33,9 @@ export class PersonalizationService {
         return this.wrapperService.shouldAutoPersonalize();
     }
 
-    public getAutoPersonalizationParameters(deviceName: string, config: ZeroconfService): Observable<AutoPersonalizationParametersResponse> {
-        let url = this.sslEnabled$.getValue() ? 'https://' : 'http://';
-        url += `${config.hostname}:${config.port}/${config.txtRecord.path}`;
+    public getAutoPersonalizationParameters(deviceName: string, url: string): Observable<AutoPersonalizationParametersResponse> {
+        const protocol = this.sslEnabled$.getValue() ? 'https://' : 'http://';
+        url = protocol + url;
         return this.http.get<AutoPersonalizationParametersResponse>(url, { params: { deviceName: deviceName }})
             .pipe(
                 timeout(Configuration.autoPersonalizationRequestTimeoutMillis),

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/startup/auto-personalization-startup-task.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/startup/auto-personalization-startup-task.ts
@@ -57,15 +57,21 @@ export class AutoPersonalizationStartupTask implements IStartupTask {
 
 
     personalizeWithHostname(): Observable<string> {
-        let name: string = null;
-        return concat(
-            of("Attempting to retrieve personalization params via hostname"),
-            this.wrapperService.getDeviceName().pipe(
-                tap(deviceName => name = deviceName),
-                flatMap(() => this.attemptAutoPersonalize(Configuration.autoPersonalizationServicePath, name)),
-                catchError(() => this.manualPersonalization())
-            ),
-        )
+        const servicePath = Configuration.autoPersonalizationServicePath;
+        if (!!servicePath) {
+            let name: string = null;
+            return concat(
+                of("Attempting to retrieve personalization params via hostname"),
+                this.wrapperService.getDeviceName().pipe(
+                    tap(deviceName => name = deviceName),
+                    flatMap(() => this.attemptAutoPersonalize(Configuration.autoPersonalizationServicePath, name)),
+                    catchError(() => this.manualPersonalization())
+                ),
+            )
+        }
+        else {
+            return this.manualPersonalization();
+        }
     }
 
     manualPersonalization(): Observable<string> {


### PR DESCRIPTION
### Summary
Add a fallback to the auto-personalization to check for a statically configured hostname and endpoint for the auto-personalization config. If the call fails or the config is null, will fall back to manual personalization.