### PR TITLE
Fallback to specified hostname for auto-personalization

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/configuration/configuration.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/configuration/configuration.ts
@@ -19,4 +19,6 @@ export const Configuration = {
     // These properties are static on the client and not overriden by configuration.service.ts
     compatibilityVersion: 'v1',
     incompatibleVersionMessage: 'Application is not compatible with the server.',
+    autoPersonalizationServicePath: null
+
 };

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/personalization.service.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/personalization.service.ts
@@ -64,9 +64,9 @@ export class PersonalizationService {
         });
     }
 
-    public getAutoPersonalizationParameters(deviceName: string, config: ZeroconfService): Observable<AutoPersonalizationParametersResponse> {
-        let url = this.sslEnabled$.getValue() ? 'https://' : 'http://';
-        url += `${config.ipv4Addresses[0]}:${config.port}/${config.txtRecord.path}`;
+    public getAutoPersonalizationParameters(deviceName: string, url): Observable<AutoPersonalizationParametersResponse> {
+        const protocol = this.sslEnabled$.getValue() ? 'https://' : 'http://';
+        url += protocol + url;
         return this.http.get<AutoPersonalizationParametersResponse>(url, { params: { deviceName: deviceName }})
             .pipe(
                 timeout(Configuration.autoPersonalizationRequestTimeoutMillis),


### PR DESCRIPTION
### Summary
Add a fallback to the auto-personalization to check for a statically configured hostname and endpoint for the auto-personalization config. If the call fails or the config is null, will fall back to manual personalization.