### PR TITLE
Sale Panel Shifting Display style fixes

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel-theme.scss
@@ -86,6 +86,8 @@
     .sale-total-employee-sale-button {
         button {
             @extend %text-sm;
+            padding-top: 10px;
+            padding-bottom: 10px;
             .mat-button-wrapper {
                 display: grid;
                 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
@@ -23,6 +23,7 @@
         border-width: 2px;
         padding: $text-md/2 $text-md*1.25;
         min-width: 150px;
+        max-height: 93.59px;
         .material-icons {
             margin-top: -12px;
         }
@@ -37,7 +38,7 @@
             vertical-align: inherit;
             width: 100%;
             text-align: left;
-            padding: 10px;
+            padding: 0px 10px;
             .grid-container {
                 display: grid;
                 grid-template-columns: 1fr 7fr 3fr;
@@ -106,8 +107,8 @@
     grid-area: item-count;
     display: flex;
     height: fit-content;
-    padding-top: 12px;
-    padding-bottom: 12px;
+    padding-top: 8px;
+    padding-bottom: 8px;
     justify-content: center;
     align-items: center;
 }
@@ -152,8 +153,8 @@
 
             .sale-total-subtotal-title {
                 @extend %text-sm;
-                padding-bottom: 8px;
-                padding-top: 8px;
+                padding-bottom: 4px;
+                padding-top: 4px;
             }
 
             .sale-total-subtotal-amount {
@@ -172,9 +173,9 @@
 
             .sale-total-total-title {
                 @extend %text-lg;
-                padding-top: 8px;
-                padding-bottom: 8px;
-
+                padding-top: 4px;
+                padding-bottom: 4px;
+                margin-bottom: -7px;
                 &.small-desktop-landscape {
                     @extend %text-md;
                 }
@@ -195,7 +196,7 @@
             .sale-total-itemcount-title {
                 @extend %text-lg;
                 padding-top: 16px;
-                padding-bottom: 8px;
+                padding-bottom: 4px;
             }
 
             .sale-total-itemcount-amount {


### PR DESCRIPTION
### Summary
Fixed an issue where the screen was forced to scroll when an employee discount was applied to the transaction. Resizing of padding/margins to facilitate the presence of the loyalty button contents of the sale-total-panel to prevent the scrolling/resizing.

### Screenshots
elo pos (1366 x 768)
![linked_elo_pos](https://user-images.githubusercontent.com/2406987/121902217-1e292980-ccf5-11eb-91f7-c54ca9ffa938.png)
![linked_with_employee_discount_elo_pos](https://user-images.githubusercontent.com/2406987/121902244-25503780-ccf5-11eb-8952-6287440ec84a.png)
![unlinked_with_employee_discount_elo_pos](https://user-images.githubusercontent.com/2406987/121902258-27b29180-ccf5-11eb-88b4-6dbdfd69f0a4.png)
![unlinked_elo_pos](https://user-images.githubusercontent.com/2406987/121902272-297c5500-ccf5-11eb-937e-4aa0c2fc2af6.png)

hp engage (1920 x 1080)
![linked_hp_engage](https://user-images.githubusercontent.com/2406987/121902277-2b461880-ccf5-11eb-83d5-77f0ae25f401.png)
![linked_with_employee_discount_hp_engage](https://user-images.githubusercontent.com/2406987/121902286-2da87280-ccf5-11eb-8939-12afb718790c.png)
![unlinked_with_employee_discount_hp_engage](https://user-images.githubusercontent.com/2406987/121902301-300acc80-ccf5-11eb-95e1-21a7aebfc23a.png)
![unlinked_hp_engage](https://user-images.githubusercontent.com/2406987/121902310-31d49000-ccf5-11eb-99ae-25db4571ff90.png)

