### PR TITLE
Fix for issue: "Select" button on Resume Transaction screen is not visible.

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/selection-list/selection-list-screen-dialog.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/selection-list/selection-list-screen-dialog.component.scss
@@ -46,7 +46,7 @@
 
         .dialog-content {
             overflow: auto;
-            max-height: 500px;
+            max-height: 45vh;
 
             .item-card-image {
                 height: 275px;


### PR DESCRIPTION
Before:
<img width="1437" alt="before" src="https://user-images.githubusercontent.com/85353723/122053286-49903f00-cdef-11eb-8bcc-67f792ecb4f2.png">
After:
- 15 inch display:
<img width="1440" alt="15inch" src="https://user-images.githubusercontent.com/85353723/122053314-4f862000-cdef-11eb-9c58-84b216caa24d.png">

- 27 inch display:
![27inch](https://user-images.githubusercontent.com/85353723/122053336-544ad400-cdef-11eb-97c5-b9a5a7e2dc4d.png)
