### PR TITLE
Stop text from being cut off in customer search results.

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/display-customer-lookup/display-customer-lookup.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/display-customer-lookup/display-customer-lookup.component.scss
@@ -15,7 +15,7 @@
   .customer-email-phone{
     display: grid;
     grid-template-columns: 1fr;
-    grid-template-rows: 1em 1em;
+    grid-template-rows: 1.2em;
     gap: 0px 0px;
     grid-template-areas:
     "email"


### PR DESCRIPTION
### Issues Fixed
https://petcoalm.atlassian.net/browse/PDPOS-5787

### Summary
Previously email addresses were getting the bottom of letter requiring the allowed area to be expanded.

### Screenshots
<img width="1159" alt="Screen Shot 2021-06-15 at 9 43 20 AM" src="https://user-images.githubusercontent.com/16402926/122063352-2ef1a200-cdbe-11eb-9e10-3a8484b9f507.png">