### PR TITLE
Not in group memberships more identifiable

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/membership-display/_membership-display-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/membership-display/_membership-display-theme.scss
@@ -2,17 +2,18 @@
     $foreground: map-get($theme, foreground );
     $openpos-membership-in-color: map-get($theme, openpos-membership-in-color );
     $openpos-membership-in-background: map-get($theme, openpos-membership-in-background );
+    $openpos-membership-not-in-color: map-get($theme, openpos-membership-not-in-color );
+    $openpos-membership-not-in-background: map-get($theme, openpos-membership-not-in-background );
 
     .membership-chips {
         mat-chip {
             &.not-in {
-                background-color: white !important;
-                border: 3px solid $openpos-membership-in-background;
-                color: mat-color($foreground, secondary-text) !important;
+                background-color: $openpos-membership-not-in-background;
+                color: $openpos-membership-not-in-color;
             }
             &.in {
-                color: $openpos-membership-in-color !important;
-                background-color: $openpos-membership-in-background !important;
+                color: $openpos-membership-in-color;
+                background-color: $openpos-membership-in-background;
             }
         }
     }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/membership-display/membership-display.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/membership-display/membership-display.component.html
@@ -1,7 +1,10 @@
 <mat-chip-list class="membership-chips">
     <mat-chip (click)="clickEvent.emit(membership)" [ngClass]="{'in': membership.member, 'not-in': !membership.member}" [selectable]="false" responsive-class>
         <app-icon *ngIf="membership.member"
-                  [iconName]="screenData.checkMarkIcon"
-                  [iconClass]="'material-icons mat-24'"></app-icon> {{membership.name}}
+                  [iconName]="screenData.memberIcon"
+                  [iconClass]="'material-icons mat-24 in'"></app-icon>
+        <app-icon *ngIf="!membership.member"
+                  [iconName]="screenData.nonMemberIcon"
+                  [iconClass]="'material-icons mat-24 not-in'"></app-icon>{{membership.name}}
     </mat-chip>
 </mat-chip-list>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/membership-display/membership-display.component.spec.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/membership-display/membership-display.component.spec.ts
@@ -48,7 +48,8 @@ describe('MembershipDisplayComponent', () => {
         fixture = TestBed.createComponent(MembershipDisplayComponent);
         component = fixture.componentInstance;
         component.screenData = {
-            checkMarkIcon: 'check'
+            memberIcon: 'check',
+            nonMemberIcon: 'close'
         };
         membership = {
             id: '1',
@@ -91,8 +92,12 @@ describe('MembershipDisplayComponent', () => {
                 expect(chip.nativeElement.classList).toContain('in');
             });
 
-            it('displays the check icon', () => {
+            it('displays the membership icon', () => {
                 validateIcon(fixture, 'mat-chip app-icon', 'check');
+            });
+
+            it('does not have the non membership icon', () => {
+                validateDoesNotExist(fixture, 'mat-chip app-icon .not-in');
             });
         });
 
@@ -107,8 +112,12 @@ describe('MembershipDisplayComponent', () => {
                 expect(chip.nativeElement.classList).toContain('not-in');
             });
 
-            it('does not have the check icon', () => {
-               validateDoesNotExist(fixture, 'mat-chip mat-icon');
+            it('does not have the membership icon', () => {
+                validateDoesNotExist(fixture, 'mat-chip app-icon .in');
+            });
+
+            it('has the non membership icon', () => {
+                validateIcon(fixture, 'mat-chip app-icon', 'close');
             });
         });
     });

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/membership-display/memebership-display.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/membership-display/memebership-display.interface.ts
@@ -5,5 +5,6 @@ export interface Membership {
 };
 
 export interface MembershipDisplayComponentInterface {
-    checkMarkIcon: string;
+    nonMemberIcon: string;
+    memberIcon: string;
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/themes/_bang-orange-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/themes/_bang-orange-theme.scss
@@ -15,13 +15,18 @@
     $openpos-membership-in-color: #ffffff;
     $openpos-membership-in-background: #ff9800;
 
+    $openpos-membership-not-in-color: #969696;
+    $openpos-membership-not-in-background: #DFDFDF;
+
     $addons: (
             openpos-link-customer-color: $openpos-link-customer-color,
             openpos-link-customer-background: $openpos-link-customer-background,
             openpos-linked-customer-color: $openpos-linked-customer-color,
             openpos-linked-customer-background: $openpos-linked-customer-background,
             openpos-membership-in-color: $openpos-membership-in-color,
-            openpos-membership-in-background: $openpos-membership-in-background
+            openpos-membership-in-background: $openpos-membership-in-background,
+            openpos-membership-not-in-color: $openpos-membership-not-in-color,
+            openpos-membership-not-in-background: $openpos-membership-not-in-background
     );
 
     $openpos-theme: openpos-theme-light($openpos-app-primary, $openpos-app-accent, $openpos-app-warn, $openpos-app-selected, $addons);

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/themes/_openpos-default-theme.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/styles/themes/_openpos-default-theme.scss
@@ -13,13 +13,18 @@
     $openpos-membership-in-color: #ffffff;
     $openpos-membership-in-background: #64834D;
 
+    $openpos-membership-not-in-color: #969696;
+    $openpos-membership-not-in-background: #DFDFDF;
+
     $addons: (
             openpos-link-customer-color: $openpos-link-customer-color,
             openpos-link-customer-background: $openpos-link-customer-background,
             openpos-linked-customer-color: $openpos-linked-customer-color,
             openpos-linked-customer-background: $openpos-linked-customer-background,
             openpos-membership-in-color: $openpos-membership-in-color,
-            openpos-membership-in-background: $openpos-membership-in-background
+            openpos-membership-in-background: $openpos-membership-in-background,
+            openpos-membership-not-in-color: $openpos-membership-not-in-color,
+            openpos-membership-not-in-background: $openpos-membership-not-in-background
     );
 
     $openpos-default-theme: openpos-theme-light($openpos-default-app-primary, $openpos-default-app-accent, $openpos-default-app-warn, $openpos-default-app-selected, $addons);

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/CustomerDetailsUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/CustomerDetailsUIMessage.java
@@ -44,7 +44,8 @@ public class CustomerDetailsUIMessage extends UIMessage {
     private String loyaltyIcon;
     private String loyaltyNumberIcon;
     private String locationIcon;
-    private String checkMarkIcon;
+    private String memberIcon;
+    private String nonMemberIcon;
     private String expiredIcon;
     private String applyIcon;
 

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/CustomerSearchResultsUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/CustomerSearchResultsUIMessage.java
@@ -4,7 +4,8 @@ import lombok.Data;
 
 @Data
 public class CustomerSearchResultsUIMessage<T extends SelectableItem> extends SelectionListUIMessage<T>{
-    private String checkMarkIcon;
+    private String memberIcon;
+    private String nonMemberIcon;
 
     public CustomerSearchResultsUIMessage(String uiMessageType) {
         super(uiMessageType);

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/LoyaltyCustomerFormUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/LoyaltyCustomerFormUIMessage.java
@@ -36,7 +36,8 @@ public class LoyaltyCustomerFormUIMessage extends UIMessage implements IHasForm 
     private String membershipsIcon;
     private String addIcon;
     private String removeIcon;
-    private String checkMarkIcon;
+    private String memberIcon;
+    private String nonMemberIcon;
 
     private String instructions;
 

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/TransactionUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/TransactionUIMessage.java
@@ -31,7 +31,8 @@ public class TransactionUIMessage extends UIMessage {
     private boolean customerMissingInfo;
     private String customerMissingInfoIcon;
     private String customerMissingInfoLabel;
-    private String checkMarkIcon;
+    private String memberIcon;
+    private String nonMemberIcon;
     private String noMembershipsFoundLabel;
     private ActionItem mobileLoyaltyButton;
 


### PR DESCRIPTION
### Summary
updates to the membership-display to include an icon and more pronounced styles for when a customer is not in a customer group

### Screenshots
<img width="1365" alt="more_visible_non_memberships" src="https://user-images.githubusercontent.com/2406987/122102590-953ceb80-cde3-11eb-8aaf-e0d4bf9d1c85.png">
