### PR TITLE
Refactored rewards-line-item for CustomerDetails dialog to support Petco requirements

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/customer-details-dialog/customer-details-dialog.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/customer-details-dialog/customer-details-dialog.component.ts
@@ -38,7 +38,7 @@ export class CustomerDetailsDialogComponent extends PosScreen<CustomerDetailsDia
       if (event.repeat || event.type !== 'keydown' || !Configuration.enableKeybinds) { return; }
       if (event.type === 'keydown' && this.selectedReward) {
         if(this.selectedReward.applyButton && this.selectedReward.applyButton.enabled) {
-          this.actionService.doAction(this.selectedReward.applyButton, this.selectedReward.barcode);
+          this.actionService.doAction(this.selectedReward.applyButton);
         }
       }
     })

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.html
@@ -5,7 +5,7 @@
         <div *ngIf="reward.expirationDate" class="expiration" responsive-class><app-icon [iconName]="screenData.expiredIcon" [iconClass]="'material-icons' + (isMobile | async) ? ' mat-16' : ' mat-24'"></app-icon>{{screenData.expiresLabel}} {{reward.expirationDate}}</div>
     </div>
     <div class="status-icon" responsive-class>
-        <app-icon *ngIf="reward.otherStatusIcon" [iconName]="reward.otherStatusIcon" [iconClass]="'material-icons mat-24'"></app-icon>
+        <app-icon *ngIf="reward.statusIcon" [iconName]="reward.statusIcon" [iconClass]="'material-icons mat-24'"></app-icon>
     </div>
     <div class="reward" responsive-class>
         <app-currency-text *ngIf="reward.amount" [amountText]="reward.amount"></app-currency-text>
@@ -18,7 +18,7 @@
            [disabled]="!reward.applyButton.enabled"
            mat-button
            responsive-class>
-            {{reward.applyButton.title}} <app-icon [iconName]="screenData.applyIcon" [iconClass]="'material-icons mat-24'"></app-icon>
+            {{reward.applyButton.title}} <app-icon [iconName]="reward.applyIcon" [iconClass]="'material-icons mat-24'"></app-icon>
         </a>
         <a *ngIf="!reward.applyButton"
            [disabled]="true"

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.html
@@ -13,8 +13,8 @@
     <div class="apply">
         <a *ngIf="reward.applyButton"
            [actionItem]="reward.applyButton"
-           (actionClick)="doAction(reward.applyButton, reward.barcode)"
-           (click)="doAction(reward.applyButton, reward.barcode)"
+           (actionClick)="doAction(reward.applyButton)"
+           (click)="doAction(reward.applyButton)"
            [disabled]="!reward.applyButton.enabled"
            mat-button
            responsive-class>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.scss
@@ -2,7 +2,7 @@
 
 .reward-line-item-wrapper {
   display: grid;
-  grid-template-columns: 1fr 9fr 1fr 1fr 3fr;
+  grid-template-columns: 1fr 9fr 1fr 1fr 4fr;
   grid-template-rows: 1fr;
   gap: 0px 0px;
   grid-template-areas:

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.spec.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.spec.ts
@@ -163,7 +163,7 @@ describe('RewardsLineItemComponent', () => {
             describe('reward loaded status', () => {
                 beforeEach(() => {
                     component.reward.promotionId = '123';
-                    component.reward.otherStatusIcon = 'check_decagram_outline';
+                    component.reward.statusIcon = 'check_decagram_outline';
                     component.reward.applyButton = {title: 'a title', enabled: true} as IActionItem;
                     fixture.detectChanges();
                 });
@@ -176,7 +176,7 @@ describe('RewardsLineItemComponent', () => {
             describe('apply button disabled when reward applied', () => {
                 beforeEach(() => {
                     component.reward.promotionId = '123';
-                    component.reward.otherStatusIcon = 'check_decagram_outline';
+                    component.reward.statusIcon = 'check_decagram_outline';
                     component.reward.enabled = false;
                     component.reward.applyButton = undefined;
                     fixture.detectChanges();
@@ -204,6 +204,7 @@ describe('RewardsLineItemComponent', () => {
                 beforeEach(() => {
                     component.reward.promotionId = '123';
                     component.reward.applyButton = {title: 'a title', enabled: true} as IActionItem;
+                    component.reward.applyIcon = 'chevron_right'
                     fixture.detectChanges();
                 });
 
@@ -279,7 +280,6 @@ describe('RewardsLineItemComponent', () => {
                 expiresLabel: 'Expires',
                 loyaltyIcon: 'loyalty',
                 expiredIcon: 'access_time',
-                applyIcon: 'chevron_right'
             } as RewardsLineItemComponentInterface;
             fixture.detectChanges();
         });
@@ -324,7 +324,6 @@ describe('RewardsLineItemComponent', () => {
                 expiresLabel: 'Expires',
                 loyaltyIcon: 'loyalty',
                 expiredIcon: 'access_time',
-                applyIcon: 'chevron_right'
             } as RewardsLineItemComponentInterface;
             fixture.detectChanges();
         });

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.spec.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.spec.ts
@@ -224,14 +224,14 @@ describe('RewardsLineItemComponent', () => {
                     spyOn(component, 'doAction');
                     const button = fixture.debugElement.query(By.css('.apply a'));
                     button.nativeElement.dispatchEvent(new Event('actionClick'));
-                    expect(component.doAction).toHaveBeenCalledWith(component.reward.applyButton, component.reward.barcode);
+                    expect(component.doAction).toHaveBeenCalledWith(component.reward.applyButton);
                 });
 
                 it('calls doAction with the configuration and promotionId when the button is clicked', () => {
                     spyOn(component, 'doAction');
                     const button = fixture.debugElement.query(By.css('.apply a'));
                     button.nativeElement.click();
-                    expect(component.doAction).toHaveBeenCalledWith(component.reward.applyButton, component.reward.barcode);
+                    expect(component.doAction).toHaveBeenCalledWith(component.reward.applyButton);
                 });
 
                 it('is enabled when the button is enabled', () => {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.interface.ts
@@ -6,7 +6,8 @@ export interface Reward {
     expirationDate: string;
     amount: number;
     applyButton: IActionItem;
-    otherStatusIcon: string;
+    applyIcon: string;
+    statusIcon: string;
     barcode: string;
 
     selected: boolean;
@@ -18,6 +19,5 @@ export interface RewardsLineItemComponentInterface {
     expiresLabel: string;
     loyaltyIcon: string;
     expiredIcon: string;
-    applyIcon: string;
     appliedIcon: string;
 }

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/CustomerDetailsUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/CustomerDetailsUIMessage.java
@@ -51,9 +51,7 @@ public class CustomerDetailsUIMessage extends UIMessage {
     private String memberIcon;
     private String nonMemberIcon;
     private String expiredIcon;
-//    private String applyIcon;
     private String appliedIcon;
-//    private String statusIcon;
 
     public CustomerDetailsUIMessage() {
         setScreenType(UIMessageType.CUSTOMER_DETAILS_DIALOG);

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/CustomerDetailsUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/CustomerDetailsUIMessage.java
@@ -50,9 +50,9 @@ public class CustomerDetailsUIMessage extends UIMessage {
     private String locationIcon;
     private String checkMarkIcon;
     private String expiredIcon;
-    private String applyIcon;
+//    private String applyIcon;
     private String appliedIcon;
-    private String statusIcon;
+//    private String statusIcon;
 
     public CustomerDetailsUIMessage() {
         setScreenType(UIMessageType.CUSTOMER_DETAILS_DIALOG);

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/UILoyaltyReward.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/UILoyaltyReward.java
@@ -11,7 +11,8 @@ import java.util.Date;
 public class UILoyaltyReward implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    private String otherStatusIcon;
+    private String applyIcon;
+    private String statusIcon;
     private String promotionId;
     private String name;
     private String expirationDate;


### PR DESCRIPTION
### Issues Fixed
Related to Petco Jira issue: https://petcoalm.atlassian.net/browse/PDPOS-5772

### Summary
Refactored the way the rewards-line-item component is rendered used in the LinkedCustomerDetailsState so the icons are passed in per reward instead of on the screen. This gives control to the State to determine which rewards should show which icons and individual statuses.