### PR TITLE
Add scanData method to console scanner for testing

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/platform-plugins/scanners/console-scanner/console-scanner.plugin.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/platform-plugins/scanners/console-scanner/console-scanner.plugin.ts
@@ -14,6 +14,10 @@ export class ConsoleScannerPlugin implements IScanner {
         console['scan'] = (value, type) => {
             this.scanSubject.next({data: value, type: type});
         }
+
+        console['scanData'] = (scanData: IScanData) => {
+            this.scanSubject.next({rawData: scanData.rawData, data: scanData.data, rawType: scanData.rawType, type: scanData.type });
+        }
     }
 
     startScanning(): Observable<IScanData> {


### PR DESCRIPTION
### Summary
Add a `scanData` method to the console scanner plugin to test with more scan data fields than `data` and `type`