### PR TITLE
Add scanData method to console scanner for testing

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/platform-plugins/barcode-scanners/console-scanner/console-scanner.plugin.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/platform-plugins/barcode-scanners/console-scanner/console-scanner.plugin.ts
@@ -6,6 +6,7 @@ import { Scanner, ScanData, ScanDataType } from '../scanner';
 declare global {
     interface Console {
         scan?: (type: ScanDataType, data: string) => void;
+        scanData?: (type: ScanData) => void;
     }
 }
 
@@ -22,6 +23,10 @@ export class ConsoleScannerPlugin implements Scanner {
                 data: value
             });
         };
+
+        console.scanData = (scanData: ScanData) => {
+            this.scanSubject.next({rawData: scanData.rawData, data: scanData.data, rawType: scanData.rawType, type: scanData.type });
+        }
     }
 
     beginScanning(): Observable<ScanData> {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/platform-plugins/barcode-scanners/console-scanner/console-scanner.plugin.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/platform-plugins/barcode-scanners/console-scanner/console-scanner.plugin.ts
@@ -25,7 +25,7 @@ export class ConsoleScannerPlugin implements Scanner {
         };
 
         console.scanData = (scanData: ScanData) => {
-            this.scanSubject.next({rawData: scanData.rawData, data: scanData.data, rawType: scanData.rawType, type: scanData.type });
+            this.scanSubject.next({ rawData: scanData.rawData, data: scanData.data, rawType: scanData.rawType, type: scanData.type });
         }
     }
 


### PR DESCRIPTION
Add a `scanData` method to the console scanner plugin to test with more scan data fields than `data` and `type`