### PR TITLE
Fix personalization screen dropdown transparent and tender screen pos…

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/personalization.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/personalization.component.html
@@ -67,8 +67,8 @@
                         pattern="[a-zA-Z0-9\-]+">
                 </mat-form-field>
                 <mat-form-field>
-                    <mat-select *ngIf="appIds" formControlName="appId" placeholder="App ID" required>
-                        <mat-option *ngFor="let appId of appIds" [value]="appId">{{appId}}</mat-option>
+                    <mat-select *ngIf="appIds" formControlName="appId" placeholder="App ID" required  >
+                        <mat-option class="dropdown" *ngFor="let appId of appIds" [value]="appId">{{appId}}</mat-option>
                     </mat-select>
                     <input *ngIf="!appIds" matInput placeholder="App ID" formControlName="appId" required novalidate>
                 </mat-form-field>
@@ -77,7 +77,7 @@
                 <ng-template matStepLabel>Select Device</ng-template>
                 <mat-form-field>
                     <mat-select formControlName="device" required >
-                        <mat-option *ngFor="let value of availableDevices" [value]="value.key">{{value.value}}</mat-option>
+                        <mat-option class="dropdown" *ngFor="let value of availableDevices" [value]="value.key">{{value.value}}</mat-option>
                     </mat-select>
                 </mat-form-field>
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/personalization.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/personalization.component.scss
@@ -1,0 +1,15 @@
+.dropdown{
+    background-color: #faf9f9;
+}
+
+::ng-deep{
+    .mat-option-text:hover:not(.mat-option-disabled) {
+        background: lightgray !important;
+        color: gray;
+    }
+
+    .mat-option:hover {
+        background: lightgray !important;
+        color: gray !important;
+    }
+}

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/personalization.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/personalization/personalization.component.ts
@@ -14,7 +14,8 @@ import { DiscoveryResponse } from '../discovery/discovery-response.interface';
 
 @Component({
     selector: 'app-personalization',
-    templateUrl: './personalization.component.html'
+    templateUrl: './personalization.component.html',
+    styleUrls: ['./personalization.component.scss']
 })
 export class PersonalizationComponent implements IScreen, OnInit {
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/tender/tender.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/tender/tender.component.scss
@@ -21,3 +21,7 @@
         }
     }
 }
+
+app-bacon-strip{
+    height: 1%;
+}


### PR DESCRIPTION
Fix the following UI bugs:

1. Tender screen positions, responsive on the a proper position:

![image](https://user-images.githubusercontent.com/57404096/122624991-d990eb80-d070-11eb-8e2c-036406a1ad2d.png)

2. Fix personalization screen dropdown transparent, added mouse hover item by highlight:

![image](https://user-images.githubusercontent.com/57404096/122625036-16f57900-d071-11eb-978c-0a2aad6d37ef.png)


![image](https://user-images.githubusercontent.com/57404096/122625043-1d83f080-d071-11eb-868e-e29e10505518.png)
