### PR TITLE
Updated reward-line-item component to support status text instead of an icon

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/customer-details-dialog/customer-details-dialog.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/customer-details-dialog/customer-details-dialog.component.scss
@@ -76,6 +76,7 @@ app-content-card {
   .membership-icon {
     .material-icons{
       margin-top: -10px;
+      width: 80px;
     }
   }
   .memberships {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/customer-details-dialog/customer-details-dialog.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/customer-details-dialog/customer-details-dialog.component.ts
@@ -37,8 +37,8 @@ export class CustomerDetailsDialogComponent extends PosScreen<CustomerDetailsDia
     this.spacebarSubscription = this.keyPresses.subscribe(KeyboardClassKey.Space, 1, (event: KeyboardEvent) => {
       if (event.repeat || event.type !== 'keydown' || !Configuration.enableKeybinds) { return; }
       if (event.type === 'keydown' && this.selectedReward) {
-        if(this.selectedReward.applyButton && this.selectedReward.applyButton.enabled) {
-          this.actionService.doAction(this.selectedReward.applyButton);
+        if(this.selectedReward.actionButton && this.selectedReward.actionButton.enabled) {
+          this.actionService.doAction(this.selectedReward.actionButton);
         }
       }
     })
@@ -74,7 +74,7 @@ export class CustomerDetailsDialogComponent extends PosScreen<CustomerDetailsDia
   buildScreen() {
     for (let i = 0; i < this.screen.customer.rewards.length; i++) {
       const reward = this.screen.customer.rewards[i];
-      reward.enabled = (reward.applyButton && reward.applyButton.enabled == true);
+      reward.enabled = (reward.actionButton && reward.actionButton.enabled == true);
       this.allRewards.set(i, reward);
       if(!reward.enabled) {
         this.allDisabledRewards.set(i, reward);

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.html
@@ -4,27 +4,21 @@
         <div class="name" responsive-class>{{reward.name}}</div>
         <div *ngIf="reward.expirationDate" class="expiration" responsive-class><app-icon [iconName]="screenData.expiredIcon" [iconClass]="'material-icons' + (isMobile | async) ? ' mat-16' : ' mat-24'"></app-icon>{{screenData.expiresLabel}} {{reward.expirationDate}}</div>
     </div>
-    <div class="status-icon" responsive-class>
-        <app-icon *ngIf="reward.statusIcon" [iconName]="reward.statusIcon" [iconClass]="'material-icons mat-24'"></app-icon>
+    <div class="status-text">
+        <div class="name" responsive-class>{{reward.statusText}}</div>
     </div>
     <div class="reward" responsive-class>
         <app-currency-text *ngIf="reward.amount" [amountText]="reward.amount"></app-currency-text>
     </div>
     <div class="apply">
-        <a *ngIf="reward.applyButton"
-           [actionItem]="reward.applyButton"
-           (actionClick)="doAction(reward.applyButton)"
-           (click)="doAction(reward.applyButton)"
-           [disabled]="!reward.applyButton.enabled"
+        <a *ngIf="reward.actionButton"
+           [actionItem]="reward.actionButton"
+           (actionClick)="doAction(reward.actionButton)"
+           (click)="doAction(reward.actionButton)"
+           [disabled]="!reward.actionButton.enabled"
            mat-button
            responsive-class>
-            {{reward.applyButton.title}} <app-icon [iconName]="reward.applyIcon" [iconClass]="'material-icons mat-24'"></app-icon>
-        </a>
-        <a *ngIf="!reward.applyButton"
-           [disabled]="true"
-           mat-button
-           responsive-class>
-            {{screenData.appliedLabel}} <app-icon [iconName]="screenData.appliedIcon" [iconClass]="'material-icons mat-24'"></app-icon>
+            {{reward.actionButton.title}} <app-icon [iconName]="reward.actionIcon" [iconClass]="'material-icons mat-24'"></app-icon>
         </a>
     </div>
 </div>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.html
@@ -5,7 +5,7 @@
         <div *ngIf="reward.expirationDate" class="expiration" responsive-class><app-icon [iconName]="screenData.expiredIcon" [iconClass]="'material-icons' + (isMobile | async) ? ' mat-16' : ' mat-24'"></app-icon>{{screenData.expiresLabel}} {{reward.expirationDate}}</div>
     </div>
     <div class="status-text">
-        <div class="name" responsive-class>{{reward.statusText}}</div>
+        <div *ngIf="reward.statusText" class="name" responsive-class>{{reward.statusText}}</div>
     </div>
     <div class="reward" responsive-class>
         <app-currency-text *ngIf="reward.amount" [amountText]="reward.amount"></app-currency-text>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.scss
@@ -2,11 +2,11 @@
 
 .reward-line-item-wrapper {
   display: grid;
-  grid-template-columns: 1fr 9fr 1fr 1fr 4fr;
+  grid-template-columns: 1fr 8fr 2fr 1fr 4fr;
   grid-template-rows: 1fr;
   gap: 0px 0px;
   grid-template-areas:
-    "loyalty-icon details status-icon reward apply";
+    "loyalty-icon details status-text reward apply";
   .loyalty-icon {
     grid-area: loyalty-icon;
     text-align: center;
@@ -30,10 +30,12 @@
       display: inline-block;
     }
   }
-  .status-icon {
-    @extend %text-md;
-    grid-area: status-icon;
+  .status-text {
+    @extend %text-xs;
+    font-style: italic;
+    grid-area: status-text;
     align-self: center;
+    text-align: center;
   }
   .reward {
     @extend %text-md;
@@ -59,7 +61,7 @@
   grid-template-rows: 1fr;
   gap: 0px 0px;
   grid-template-areas:
-    "details status-icon reward apply";
+    "details status-text reward apply";
   .loyalty-icon {
     grid-area: loyalty-icon;
     text-align: center;
@@ -67,10 +69,12 @@
       display: inline-block;
     }
   }
-  .status-icon {
-    @extend %text-md;
-    grid-area: status-icon;
+  .status-text {
+    @extend %text-xs;
+    font-style: italic;
+    grid-area: status-text;
     align-self: center;
+    text-align: center;
   }
   .details {
     grid-area: details;

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.spec.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.spec.ts
@@ -69,11 +69,7 @@ describe('RewardsLineItemComponent', () => {
             component.screenData = {
                 expiresLabel: 'Expires',
                 loyaltyIcon: 'loyalty',
-                expiredIcon: 'access_time',
-                applyIcon: 'chevron_right',
-                appliedLabel: 'Applied',
-                appliedIcon: 'cart_check',
-                statusIcon: 'check_decagram_outline'
+                expiredIcon: 'access_time'
             } as RewardsLineItemComponentInterface;
             fixture.detectChanges();
         });
@@ -160,43 +156,16 @@ describe('RewardsLineItemComponent', () => {
                 });
             });
 
-            describe('reward loaded status', () => {
+            describe('reward extra status text', () => {
                 beforeEach(() => {
                     component.reward.promotionId = '123';
-                    component.reward.statusText = 'check_decagram_outline';
+                    component.reward.statusText = 'Bonus Reward';
                     component.reward.actionButton = {title: 'a title', enabled: true} as IActionItem;
                     fixture.detectChanges();
                 });
 
-                it('shows the configured status icon when enabled', () => {
-                    validateIcon(fixture, '.status-icon app-icon', 'check_decagram_outline');
-                });
-            });
-
-            describe('apply button disabled when reward applied', () => {
-                beforeEach(() => {
-                    component.reward.promotionId = '123';
-                    component.reward.statusText = 'check_decagram_outline';
-                    component.reward.enabled = false;
-                    component.reward.actionButton = undefined;
-                    fixture.detectChanges();
-                });
-
-                it('renders the button', () => {
-                    validateExist(fixture, '.apply a');
-                });
-
-                it('renders the applied label', () => {
-                    validateText(fixture, '.apply a', component.screenData.appliedLabel);
-                });
-
-                it('renders the cart_check icon', () => {
-                    validateIcon(fixture, '.apply a app-icon', 'cart_check');
-                });
-
-                it('is disabled when the button is disabled', () => {
-                    const button = fixture.debugElement.query(By.css('.apply a'));
-                    expect(button.properties.disabled).toBe(true);
+                it('shows the configured status text when enabled', () => {
+                    validateText(fixture, '.status-text', component.reward.statusText);
                 });
             });
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.spec.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.spec.ts
@@ -169,6 +169,16 @@ describe('RewardsLineItemComponent', () => {
                 });
             });
 
+            describe('when status text does not have a value', () => {
+                beforeEach(() => {
+                    component.reward.statusText = undefined;
+                    fixture.detectChanges();
+                });
+                it('does not render the status text', () => {
+                    validateDoesNotExist(fixture, '.status-text .name');
+                });
+            });
+
             describe('apply button', () => {
                 beforeEach(() => {
                     component.reward.promotionId = '123';

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.spec.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.spec.ts
@@ -64,7 +64,7 @@ describe('RewardsLineItemComponent', () => {
             component = fixture.componentInstance;
             component.reward = {
                 expirationDate: '01/01/2000',
-                applyButton: {title: 'a title', enabled: true}
+                actionButton: {title: 'a title', enabled: true}
             } as Reward;
             component.screenData = {
                 expiresLabel: 'Expires',
@@ -163,8 +163,8 @@ describe('RewardsLineItemComponent', () => {
             describe('reward loaded status', () => {
                 beforeEach(() => {
                     component.reward.promotionId = '123';
-                    component.reward.statusIcon = 'check_decagram_outline';
-                    component.reward.applyButton = {title: 'a title', enabled: true} as IActionItem;
+                    component.reward.statusText = 'check_decagram_outline';
+                    component.reward.actionButton = {title: 'a title', enabled: true} as IActionItem;
                     fixture.detectChanges();
                 });
 
@@ -176,9 +176,9 @@ describe('RewardsLineItemComponent', () => {
             describe('apply button disabled when reward applied', () => {
                 beforeEach(() => {
                     component.reward.promotionId = '123';
-                    component.reward.statusIcon = 'check_decagram_outline';
+                    component.reward.statusText = 'check_decagram_outline';
                     component.reward.enabled = false;
-                    component.reward.applyButton = undefined;
+                    component.reward.actionButton = undefined;
                     fixture.detectChanges();
                 });
 
@@ -203,8 +203,8 @@ describe('RewardsLineItemComponent', () => {
             describe('apply button', () => {
                 beforeEach(() => {
                     component.reward.promotionId = '123';
-                    component.reward.applyButton = {title: 'a title', enabled: true} as IActionItem;
-                    component.reward.applyIcon = 'chevron_right'
+                    component.reward.actionButton = {title: 'a title', enabled: true} as IActionItem;
+                    component.reward.actionIcon = 'chevron_right'
                     fixture.detectChanges();
                 });
 
@@ -213,7 +213,7 @@ describe('RewardsLineItemComponent', () => {
                 });
 
                 it('renders the button title', () => {
-                    validateText(fixture, '.apply a', component.reward.applyButton.title);
+                    validateText(fixture, '.apply a', component.reward.actionButton.title);
                 });
 
                 it('renders the chevron icon', () => {
@@ -224,25 +224,25 @@ describe('RewardsLineItemComponent', () => {
                     spyOn(component, 'doAction');
                     const button = fixture.debugElement.query(By.css('.apply a'));
                     button.nativeElement.dispatchEvent(new Event('actionClick'));
-                    expect(component.doAction).toHaveBeenCalledWith(component.reward.applyButton);
+                    expect(component.doAction).toHaveBeenCalledWith(component.reward.actionButton);
                 });
 
                 it('calls doAction with the configuration and promotionId when the button is clicked', () => {
                     spyOn(component, 'doAction');
                     const button = fixture.debugElement.query(By.css('.apply a'));
                     button.nativeElement.click();
-                    expect(component.doAction).toHaveBeenCalledWith(component.reward.applyButton);
+                    expect(component.doAction).toHaveBeenCalledWith(component.reward.actionButton);
                 });
 
                 it('is enabled when the button is enabled', () => {
-                    component.reward.applyButton.enabled = true;
+                    component.reward.actionButton.enabled = true;
                     fixture.detectChanges();
                     const button = fixture.debugElement.query(By.css('.apply a'));
                     expect(button.properties.disabled).toBe(false);
                 });
 
                 it('is disabled when the button is disabled', () => {
-                    component.reward.applyButton.enabled = false;
+                    component.reward.actionButton.enabled = false;
                     fixture.detectChanges();
                     const button = fixture.debugElement.query(By.css('.apply a'));
                     expect(button.properties.disabled).toBe(true);
@@ -274,7 +274,7 @@ describe('RewardsLineItemComponent', () => {
             fixture = TestBed.createComponent(RewardsLineItemComponent);
             component = fixture.componentInstance;
             component.reward = {
-                applyButton: {title: 'a title', enabled: true}
+                actionButton: {title: 'a title', enabled: true}
             } as Reward;
             component.screenData = {
                 expiresLabel: 'Expires',
@@ -318,7 +318,7 @@ describe('RewardsLineItemComponent', () => {
             fixture = TestBed.createComponent(RewardsLineItemComponent);
             component = fixture.componentInstance;
             component.reward = {
-                applyButton: {title: 'a title', enabled: true}
+                actionButton: {title: 'a title', enabled: true}
             } as Reward;
             component.screenData = {
                 expiresLabel: 'Expires',

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.interface.ts
@@ -5,9 +5,9 @@ export interface Reward {
     name: string;
     expirationDate: string;
     amount: number;
-    applyButton: IActionItem;
-    applyIcon: string;
-    statusIcon: string;
+    actionButton: IActionItem;
+    actionIcon: string;
+    statusText: string;
     barcode: string;
 
     selected: boolean;
@@ -15,9 +15,7 @@ export interface Reward {
 };
 
 export interface RewardsLineItemComponentInterface {
-    appliedLabel: string;
     expiresLabel: string;
     loyaltyIcon: string;
     expiredIcon: string;
-    appliedIcon: string;
 }

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/UILoyaltyReward.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/UILoyaltyReward.java
@@ -11,13 +11,14 @@ import java.util.Date;
 public class UILoyaltyReward implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    private String applyIcon;
-    private String statusIcon;
+    private String statusText;
     private String promotionId;
     private String name;
     private String expirationDate;
     private String expirationLabel;
     private String barcode;
     private BigDecimal amount;
-    private ActionItem applyButton;
+    private ActionItem actionButton;
+    private String actionIcon;
+    private Boolean isAppliedToTransaction;
 }


### PR DESCRIPTION
### Summary
Updated the RewardsLineItem components (part of CustomerDetails) to take reward-based action item details instead of screen level, and updated the optional status icon to be text instead.

### Screenshots
A sample reward that can have a customized status text displayed (in the example below, this is a "Fancy Reward").
![image](https://user-images.githubusercontent.com/28220454/122787126-04eb2480-d283-11eb-9cfa-fddebee5dc5c.png)
