### PR TITLE
Add the field length properties

### DIFF
--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/ui/PromptConfig.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/flow/ui/PromptConfig.java
@@ -29,6 +29,25 @@ public class PromptConfig {
     private String id;
     private boolean allowScan;
     private boolean editable = true;
+    private Integer maxLength;
+    private Integer minLength;
+
+
+    public Integer getMaxLength() {
+        return maxLength;
+    }
+
+    public void setMaxLength(Integer maxLength) {
+        this.maxLength = maxLength;
+    }
+
+    public Integer getMinLength() {
+        return minLength;
+    }
+
+    public void setMinLength(Integer minLength) {
+        this.minLength = minLength;
+    }
 
     public PromptConfig named(String name) {
         this.name = name;


### PR DESCRIPTION
This is for fix a bug that for prompt form, the money field not follow the price limit configuration. After add validation, the result should be:

![image](https://user-images.githubusercontent.com/57404096/122942769-7048fb00-d344-11eb-8c27-a84490d68833.png)

Also, this code is associated with other projects changes:

https://code.ae.com/projects/POS/repos/aeo-jumpmind-ext/pull-requests/1304/overview