### PR TITLE
Make preserved columns not required

### DIFF
--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/SchemaObjectRemoveInterceptor.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/SchemaObjectRemoveInterceptor.java
@@ -24,9 +24,11 @@ public class SchemaObjectRemoveInterceptor implements IAlterDatabaseInterceptor 
             if ((modelChange instanceof RemoveColumnChange)) {
                 RemoveColumnChange removeColumnChange = (RemoveColumnChange) modelChange;
                 log.info("Preserve unrecognized column as not required: " + removeColumnChange.getColumn());
-                ColumnRequiredChange columnRequiredChange = new ColumnRequiredChange(removeColumnChange.getChangedTable(), removeColumnChange.getColumn());
-                columnRequiredChange.getChangedColumn().setRequired(false);
-                interceptedChanges.add(columnRequiredChange);
+                if (removeColumnChange.getColumn().isRequired()) {
+                    ColumnRequiredChange columnRequiredChange = new ColumnRequiredChange(removeColumnChange.getChangedTable(), removeColumnChange.getColumn());
+                    columnRequiredChange.getChangedColumn().setRequired(false);
+                    interceptedChanges.add(columnRequiredChange);
+                }
             } else if ((modelChange instanceof RemoveIndexChange)) {
                 RemoveIndexChange removeIndexChange = (RemoveIndexChange) modelChange;
                 log.info("Preserve unrecognized index: " + removeIndexChange.getIndex().getName());

--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/SchemaObjectRemoveInterceptor.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/impl/SchemaObjectRemoveInterceptor.java
@@ -3,6 +3,7 @@ package org.jumpmind.pos.persist.impl;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jumpmind.db.alter.ColumnRequiredChange;
 import org.jumpmind.db.alter.IModelChange;
 import org.jumpmind.db.alter.RemoveColumnChange;
 import org.jumpmind.db.alter.RemoveIndexChange;
@@ -22,11 +23,13 @@ public class SchemaObjectRemoveInterceptor implements IAlterDatabaseInterceptor 
         for (IModelChange modelChange : detectedChanges) {
             if ((modelChange instanceof RemoveColumnChange)) {
                 RemoveColumnChange removeColumnChange = (RemoveColumnChange) modelChange;
-                log.info("Preserve unrecognized column: " + removeColumnChange.getColumn());
+                log.info("Preserve unrecognized column as not required: " + removeColumnChange.getColumn());
+                ColumnRequiredChange columnRequiredChange = new ColumnRequiredChange(removeColumnChange.getChangedTable(), removeColumnChange.getColumn());
+                columnRequiredChange.getChangedColumn().setRequired(false);
+                interceptedChanges.add(columnRequiredChange);
             } else if ((modelChange instanceof RemoveIndexChange)) {
                 RemoveIndexChange removeIndexChange = (RemoveIndexChange) modelChange;
                 log.info("Preserve unrecognized index: " + removeIndexChange.getIndex().getName());
-
             } else {
                 interceptedChanges.add(modelChange);
             }


### PR DESCRIPTION
### Summary
Make preserved columns not required.   When we upgrade the database schema we leave abandoned columns behind.   This causes issues with existing code if the column was previously required.