### PR TITLE
Fix autopersonalization fault loop

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/startup/auto-personalization-startup-task.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/startup/auto-personalization-startup-task.ts
@@ -117,7 +117,7 @@ export class AutoPersonalizationStartupTask implements IStartupTask {
                 }),
                 catchError(e => {
                     this.logPersonalizationError(e);
-                    return this.personalizeWithHostname();
+                    return this.manualPersonalization();
                 }));
     }
 


### PR DESCRIPTION
### Summary
Fix a scenario where auto personalization loops between `attemptAutoPersonalize` and `personalizeWithHostname` without going to manual personalization.