### PR TITLE
Multiple `@Endpoint` Handler Support

### DIFF
--- a/openpos-service/src/main/java/org/jumpmind/pos/service/Endpoints.java
+++ b/openpos-service/src/main/java/org/jumpmind/pos/service/Endpoints.java
@@ -1,0 +1,13 @@
+package org.jumpmind.pos.service;
+
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Component
+public @interface Endpoints {
+    Endpoint[] value();
+}


### PR DESCRIPTION
### Summary
Adds support for defining multiple endpoint handlers on a single bean. This is useful for when you have virtually identical endpoint implementations and want to keep things DRY.

Example:
```
@Endpoints(
    @Endpoint(path="/some/path")
    @Endpoint(path="/some/other/path/you/need/routed/here")
)
public class SomeEndpointImplementation {}
```