### PR TITLE
Item lookup - made selecting a color change the main image

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.ts
@@ -71,6 +71,7 @@ export class ItemDetailComponent extends PosScreen<ItemDetailInterface> {
             .pipe(map( stores => stores != null && stores != undefined));
         this.inventoryMessage$ = this.dataMessageService.getData$(this.screen.inventoryMessageProviderKey)
             .pipe(map(value => value != null ? value[0] : null));
+        this.screen.imageUrls = [].concat(this.screen.imageUrls);
     }
     
     getComponentFromOptionType(productOption: ProductOptionInterface) {


### PR DESCRIPTION
### Summary
This change is needed to make setter in the carousel.component.ts detect changes. It checks only a memory link for an array that is not changing by default. There's a way to override that check itself but it affects performance badly. Let me know if you think it's still better to override the check or if you have a better solution.

Before change:
![before](https://user-images.githubusercontent.com/74003404/123467413-89ca9b00-d601-11eb-9ed3-81a76f7ab3ce.gif)

After change:
![after](https://user-images.githubusercontent.com/74003404/123467731-e3cb6080-d601-11eb-9328-2c3f97fbfe3a.gif)


