### PR TITLE
Made it so the AutoFocus ability of prompts is configured through the prompt message.

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/prompt-input/prompt-input.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/prompt-input/prompt-input.component.html
@@ -11,10 +11,18 @@
                     
                     <app-icon matPrefix iconClass="material-icons md primary" [iconName]="promptIcon" responsive-class>
                     </app-icon>
-                    <input matInput [errorStateMatcher]="errorMatcher" [formControlName]="'promptInputControl'"
-                        [formatterName]="responseType" cdkFocusInitial [attr.minlength]="minLength" [attr.maxlength]="maxLength"
+                    <input *ngIf="autoFocus; else noAutoFocusA" matInput cdkFocusInitial [errorStateMatcher]="errorMatcher" [formControlName]="'promptInputControl'"
+                        [formatterName]="responseType" [attr.minlength]="minLength" [attr.maxlength]="maxLength"
                         [readonly]="readOnly" [attr.type]="isNumericField() ? 'tel' : 'text'" [keyboardLayout]="keyboardLayout"
                         class="prompt-input" autoSelectOnFocus responsive-class>
+
+                    <ng-template #noAutoFocusA>
+                        <input matInput [errorStateMatcher]="errorMatcher" [formControlName]="'promptInputControl'"
+                            [formatterName]="responseType" [attr.minlength]="minLength" [attr.maxlength]="maxLength"
+                            [readonly]="readOnly" [attr.type]="isNumericField() ? 'tel' : 'text'" [keyboardLayout]="keyboardLayout"
+                            class="prompt-input" autoSelectOnFocus responsive-class>
+                    </ng-template>
+
                     <mat-placeholder>{{placeholderText}}</mat-placeholder>
                     <mat-hint class="prompt-hint" align="start" responsive-class>{{hintText}}</mat-hint>
                     <mat-error class="prompt-error">
@@ -42,10 +50,16 @@
             <ng-template #iconBlock>
                 <app-icon matPrefix iconClass="material-icons md primary" [iconName]="promptIcon"></app-icon>
             </ng-template>
-            <input matInput [errorStateMatcher]="errorMatcher" [formControlName]="'promptInputControl'"
-                [formatterName]="responseType" cdkFocusInitial [attr.minlength]="minLength" [attr.maxlength]="maxLength"
+            <input *ngIf="autoFocus; else noAutoFocusB" matInput cdkFocusInitial [errorStateMatcher]="errorMatcher" [formControlName]="'promptInputControl'"
+                [formatterName]="responseType" [attr.minlength]="minLength" [attr.maxlength]="maxLength"
                 [readonly]="readOnly" [attr.type]="isNumericField() ? 'tel' : 'text'" [keyboardLayout]="keyboardLayout"
                 [value]="responseText" autoSelectOnFocus>
+            <ng-template #noAutoFocusB>
+                <input matInput [errorStateMatcher]="errorMatcher" [formControlName]="'promptInputControl'"
+                    [formatterName]="responseType" [attr.minlength]="minLength" [attr.maxlength]="maxLength"
+                    [readonly]="readOnly" [attr.type]="isNumericField() ? 'tel' : 'text'" [keyboardLayout]="keyboardLayout"
+                    [value]="responseText" autoSelectOnFocus>
+            </ng-template>
             <mat-placeholder>{{placeholderText}}</mat-placeholder>
             <mat-hint class="text-sm" align="start">{{hintText}}</mat-hint>
             <mat-error class="text-sm">
@@ -55,10 +69,16 @@
         </mat-form-field>
 
         <mat-form-field fxFlexFill *ngSwitchCase="responseType==='TextArea'" ngClass="prompt-textarea" responsive-class>
-            <textarea matInput [rows]="5" [cols]="40" [formControlName]="'promptInputControl'" cdkFocusInitial
+            <textarea *ngIf="autoFocus; else noAutoFocusC" matInput cdkFocusInitial [rows]="5" [cols]="40" [formControlName]="'promptInputControl'" 
                 style="font-size:18px" [attr.minlength]="minLength" [attr.maxlength]="maxLength" [readonly]="readOnly"
                 [attr.type]="isNumericField() ? 'tel' : 'text'" autoSelectOnFocus responsive-class>
+            </textarea>
+            <ng-template #noAutoFocusC>
+                <textarea matInput [rows]="5" [cols]="40" [formControlName]="'promptInputControl'"
+                    style="font-size:18px" [attr.minlength]="minLength" [attr.maxlength]="maxLength" [readonly]="readOnly"
+                    [attr.type]="isNumericField() ? 'tel' : 'text'" autoSelectOnFocus responsive-class>
                 </textarea>
+            </ng-template>
             <mat-placeholder *ngIf="placeholderText">{{placeholderText}}</mat-placeholder>
             <mat-placeholder *ngIf="!placeholderText">Comments</mat-placeholder>
             <mat-hint class="prompt-hint" align="start" responsive-class>{{hintText}}</mat-hint>
@@ -76,9 +96,14 @@
         <mat-form-field fxFlexFill *ngSwitchCase="isPassword()" ngClass="prompt-password" responsive-class>
             <app-icon matPrefix iconClass="material-icons md primary" [iconName]="promptIcon" responsive-class>
             </app-icon>
-            <input matInput [formControlName]="'promptInputControl'" cdkFocusInitial autoSelectOnFocus
+            <input *ngIf="autoFocus; else noAutoFocusD" matInput cdkFocusInitial [formControlName]="'promptInputControl'" autoSelectOnFocus
                 class="prompt-input" type="password" [formatterName]="responseType" [attr.minlength]="minLength"
                 [attr.maxlength]="maxLength" responsive-class>
+            <ng-template #noAutoFocusD>
+                <input matInput [formControlName]="'promptInputControl'" autoSelectOnFocus
+                    class="prompt-input" type="password" [formatterName]="responseType" [attr.minlength]="minLength"
+                    [attr.maxlength]="maxLength" responsive-class>
+            </ng-template>
             <mat-placeholder>{{placeholderText}}</mat-placeholder>
             <mat-hint class="prompt-hint" align="start" responsive-class>{{hintText}}</mat-hint>
             <mat-error class="prompt-error">

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/prompt-input/prompt-input.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/prompt-input/prompt-input.component.ts
@@ -11,9 +11,7 @@ import { ActionService } from '../../../core/actions/action.service';
     styleUrls: ['./prompt-input.component.scss'],
     templateUrl: './prompt-input.component.html'
 })
-
 export class PromptInputComponent implements OnInit, OnDestroy {
-
     @Input() placeholderText: string;
     @Input() responseType: string;
     @Input() responseText: string;
@@ -26,6 +24,7 @@ export class PromptInputComponent implements OnInit, OnDestroy {
     @Input() keyboardPreference: string;
     @Input() scanEnabled = false;
     @Input() validationMessages: Map<string, string>;
+    @Input() autoFocus = true;
 
     @Input() scanActionName?: string;
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.component.html
@@ -15,7 +15,8 @@
                                       [keyboardPreference]="screenData.keyboardPreference" [scanEnabled]="screenData.scanEnabled"
                                       [validationMessages]="screenData.validationMessages"
                                       [readOnly]="!screenData.editable"
-                                      [scanActionName]="screenData.scan?.scanActionName">
+                                      [scanActionName]="screenData.scan?.scanActionName"
+                                      [autoFocus]="autoFocusPrompt">
                     </app-prompt-input>
                     <app-instructions *ngIf="instructions" [instructions]="instructions" [instructionsSize]="'text-sm'"></app-instructions>
                     <div #optionsRef>
@@ -59,7 +60,8 @@
                                       [minLength]="screenData.minLength" [maxLength]="screenData.maxLength" [promptFormGroup]="promptFormGroup"
                                       [validationMessages]="screenData.validationMessages"
                                       [keyboardPreference]="screenData.keyboardPreference" [scanEnabled]="screenData.scanEnabled" [readOnly]="!screenData.editable"
-                                      [scanActionName]="screenData.scan?.scanActionName">
+                                      [scanActionName]="screenData.scan?.scanActionName"
+                                      [autoFocus]="autoFocusPrompt">
                     </app-prompt-input>
                     <app-instructions *ngIf="instructions" [instructions]="instructions" [instructionsSize]="'text-sm'"></app-instructions>
                     <div #optionsRef>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.component.ts
@@ -23,6 +23,15 @@ export class PromptFormPartComponent extends ScreenPartComponent<PromptFormPartI
     inputControlName = 'promptInputControl';
     hiddenInputControlName = 'promptInputHiddenDateControl';
 
+    get autoFocusPrompt(): boolean {
+        // default to true if not properly defined... it is the way
+        if (this.screenData.autoFocus === null || this.screenData.autoFocus === undefined) {
+            return true;
+        }
+
+        return this.screenData.autoFocus;
+    }
+
     constructor(private validatorsService: ValidatorsService, injector: Injector) {
         super(injector);
     }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/prompt-form-part/prompt-form-part.interface.ts
@@ -28,4 +28,5 @@ export interface PromptFormPartInterface {
     promptPosition: PromptPosition;
     info: DisplayProperty[];
     scan?: ScanInterface;
+    autoFocus: boolean;
 }

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/PromptUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/PromptUIMessage.java
@@ -42,6 +42,7 @@ public class PromptUIMessage extends UIMessage {
     private BigDecimal min;
     private BigDecimal max;
     private String imageUrl;
+    private boolean autoFocus = true;
 
     public PromptUIMessage() {
         this.setScreenType(UIMessageType.PROMPT);
@@ -133,6 +134,14 @@ public class PromptUIMessage extends UIMessage {
 
     public void setOtherActions(List<ActionItem> otherActions) {
         this.otherActions = otherActions;
+    }
+
+    public boolean getAutoFocus() {
+        return autoFocus;
+    }
+
+    public void setAutoFocus(boolean autoFocus) {
+        this.autoFocus = autoFocus;
     }
 
     public void addOtherAction(ActionItem action) {


### PR DESCRIPTION
### Summary
To minimize the iOS keyboard automatically overlaying the app in certain scenarios the ability to configure if the input was automatically focused has been added. This is available on the prompt message.