### PR TITLE
Remove duplicate search component on mobile screens

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/return/return.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/return/return.component.html
@@ -1,4 +1,4 @@
-<app-bacon-strip class="return-bacon-strip">
+<app-bacon-strip class="return-bacon-strip" [searchEnabled]="true">
     <div class="return-outer">
         <div *ngIf="!(isMobile | async)" class="return-body">
             <section class="receipts" *ngIf="receipts && receipts.length > 0">

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/sale.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/sale.component.html
@@ -1,4 +1,4 @@
-<app-bacon-strip class="sale-bacon-strip">
+<app-bacon-strip class="sale-bacon-strip" [searchEnabled]="true">
     <div class="sale-outer">
         <div *ngIf="!(isMobile | async)" class="sale-body">
             <section class="orders" *ngIf="screen.orders && screen.orders.length > 0">

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/bacon-strip/bacon-strip.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/bacon-strip/bacon-strip.component.html
@@ -6,7 +6,7 @@
         </app-icon-button>
         <app-icon-button *ngIf="helpTextService.isAvailable() | async" iconName="help"
                          (click)="helpTextService.toggle()"></app-icon-button>
-        <app-search-expand-input *ngIf="(isMobile | async)" (expanded)="onSearchExpand($event)"
+        <app-search-expand-input *ngIf="searchEnabled && (isMobile | async)" (expanded)="onSearchExpand($event)"
                                  class="bacon-strip-search"></app-search-expand-input>
     </div>
     <div *ngIf="!(isMobile | async) && !searchExpanded">

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/bacon-strip/bacon-strip.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/bacon-strip/bacon-strip.component.ts
@@ -1,7 +1,7 @@
 import {MatSidenav} from '@angular/material/sidenav';
 import {BaconStripInterface} from './bacon-strip.interface';
 import {ScreenPartComponent} from '../screen-part';
-import {Component, Injector, ViewChild} from '@angular/core';
+import {Component, Injector, Input, ViewChild} from '@angular/core';
 import {ScreenPart} from '../../decorators/screen-part.decorator';
 import {HelpTextService} from '../../../core/help-text/help-text.service';
 import {MediaBreakpoints, OpenposMediaService} from '../../../core/media/openpos-media.service';
@@ -27,6 +27,9 @@ export class BaconStripComponent extends ScreenPartComponent<BaconStripInterface
     isMobile: Observable<boolean>;
 
     searchExpanded = false;
+
+    @Input()
+    searchEnabled = false;
 
     constructor(injector: Injector, public helpTextService: HelpTextService, private media: OpenposMediaService,
                 protected keyPresses: KeyPressProvider) {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/search-expand-input/search-expand-input.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/search-expand-input/search-expand-input.component.ts
@@ -67,6 +67,7 @@ export class SearchExpandInputComponent extends ScreenPartComponent<ScanOrSearch
 
     ngOnDestroy(): void {
         this.unregisterScanner();
+        super.ngOnDestroy();
     }
 
     private registerScanner() {


### PR DESCRIPTION
### Summary
This was causing scans to be duplicated because multiple scan subscriptions were being created
