### PR TITLE
Fix for ISR UI for size selection

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/option-components/basic-product-option-part/basic-option.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/option-components/basic-product-option-part/basic-option.interface.ts
@@ -1,5 +1,6 @@
 export interface BasicOptionInterface {
     id: string;
     name: string;
+    secondaryLabel: string;
     disabled: boolean;
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/option-components/basic-product-option-part/basic-product-option-part.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/option-components/basic-product-option-part/basic-product-option-part.component.html
@@ -1,6 +1,15 @@
 <h3>{{screenData.optionName}}</h3>
-<mat-select (selectionChange)="optionSelected($event)" [placeholder]="screenData.optionPlaceholder" [value]="screenData.selectedOption">
+<mat-select (selectionChange)="optionSelected($event)" [style.font-weight]="'bold'" [placeholder]="screenData.optionPlaceholder" [value]="screenData.selectedOption" #select>
     <mat-option *ngFor="let option of screenData.options" 
-                [value]="option.id" 
-                >{{option.name}}</mat-option>
+                [value]="option.id">
+        <ng-container *ngIf="option.id === screenData.selectedOption">
+            <b>{{option.name}}</b>
+        </ng-container>
+        <ng-container *ngIf="option.id !== screenData.selectedOption">
+            {{option.name}}
+        </ng-container>
+        <ng-container *ngIf="select.panelOpen && option.secondaryLabel">
+            <span class="secondary-label-option">{{option.secondaryLabel}}</span>
+        </ng-container>
+    </mat-option>
 </mat-select>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/option-components/basic-product-option-part/basic-product-option-part.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/option-components/basic-product-option-part/basic-product-option-part.scss
@@ -1,9 +1,13 @@
 @import "../../../../styles/mixins/typography";
 
 
-
-h3{
+h3 {
   font-weight: normal;
   @extend %text-sm;
   margin-bottom: 4px;
+}
+
+.secondary-label-option {
+  float: right;
+  opacity: 0.5;
 }


### PR DESCRIPTION
Changes:
1. Selected size - bold.
2. Selected size in list - bold.
3. 'Not available' - on the right side.

Before:
![before](https://user-images.githubusercontent.com/77682108/124076730-521f8100-da4f-11eb-85e2-e44b515adbcc.gif)

After:
![after](https://user-images.githubusercontent.com/77682108/124076753-58156200-da4f-11eb-9198-37834436f64a.gif)

But there is a problem - after the item with 'Not available' label is selected - 'MEDIUMNot available' label appears on the screen for milliseconds. You can see it on second gif. I understand why this is happening, but I do not know how to fix it. Thoughts?