### PR TITLE
Fix Productivity Report is missing title bar and is shrunk

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/bacon-strip/bacon-strip.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/bacon-strip/bacon-strip.component.scss
@@ -6,7 +6,6 @@
     display: grid;
     grid-auto-flow: row;
     grid-template-rows: auto 1fr;
-    height: 100%;
 }
 
 .container {


### PR DESCRIPTION

Result:

![image](https://user-images.githubusercontent.com/57404096/124307819-5d011100-db36-11eb-87e0-370d079ab7b9.png)
