### PR TITLE
Update add customer grid to handle missing sections

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/loyalty-customer-form-dialog/loyalty-customer-form-dialog.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/loyalty-customer-form-dialog/loyalty-customer-form-dialog.component.html
@@ -6,71 +6,73 @@
             <app-content-card>
                 <mat-card-content>
                     <div [ngClass]="{'grid-container': !(isMobile | async), 'mobile-grid-container': (isMobile | async)}">
-                        <div class="basic-info" *ngIf="firstNameField || lastNameField">
-                            <div class="portrait">
-                                <app-icon [iconName]="screen.profileIcon" [iconClass]="'material-icons' + ((isMobile | async) ? ' mat-96' : ' mat-128')"></app-icon>
-                            </div>
-                            <div class="names">
-                                <app-dynamic-form-field *ngIf="firstNameField" [formGroup]="screen.formGroup" [formField]="firstNameField"
-                                                        (onFieldChanged)="onFieldChanged($event)"></app-dynamic-form-field>
-                                <app-dynamic-form-field *ngIf="lastNameField" [formGroup]="screen.formGroup" [formField]="lastNameField"
-                                                        (onFieldChanged)="onFieldChanged($event)"></app-dynamic-form-field>
-                            </div>
-                        </div>
-                        <div class="contact" *ngIf="emailField || emailFields || phoneField || phoneFields">
-                            <div *ngIf="emailField && emailFields.length === 0" class="email">
-                                <app-icon matPrefix [iconName]="screen.emailIcon" iconClass="material-icons sm"></app-icon>
-                                <app-dynamic-form-field [formGroup]="screen.formGroup" [formField]="emailField" (onFieldChanged)="onFieldChanged($event)"></app-dynamic-form-field>
-                            </div>
-                            <div *ngIf="emailFields.length > 0">
-                                <div class="email-list" *ngFor="let emailField of emailFields; let i = index; first as isFirst; last as isLast;">
-                                    <app-mutable-list-item-with-label [formGroup]="screen.formGroup"
-                                                                      [groupIcon]="screen.emailIcon"
-                                                                      [inputField]="emailField"
-                                                                      [labelField]="emailLabelFields[i]"
-                                                                      [isFirst]="isFirst"
-                                                                      [isLast]="isLast"
-                                                                      [isOnly]="emailFields.length == 1"
-                                                                      (onFieldChanged)="onFieldChanged($event)"
-                                                                      (add)="doAction(screen.addEmail, i)"
-                                                                      (remove)="doAction(screen.removeEmail, i)">
-                                    </app-mutable-list-item-with-label>
+                        <div class="left">
+                            <div class="basic-info" *ngIf="firstNameField || lastNameField">
+                                <div class="portrait">
+                                    <app-icon [iconName]="screen.profileIcon" [iconClass]="'material-icons' + ((isMobile | async) ? ' mat-96' : ' mat-128')"></app-icon>
+                                </div>
+                                <div class="names">
+                                    <app-dynamic-form-field *ngIf="firstNameField" [formGroup]="screen.formGroup" [formField]="firstNameField"
+                                                            (onFieldChanged)="onFieldChanged($event)"></app-dynamic-form-field>
+                                    <app-dynamic-form-field *ngIf="lastNameField" [formGroup]="screen.formGroup" [formField]="lastNameField"
+                                                            (onFieldChanged)="onFieldChanged($event)"></app-dynamic-form-field>
                                 </div>
                             </div>
+                            <div class="contact" *ngIf="emailField || emailFields || phoneField || phoneFields">
+                                <div *ngIf="emailField && emailFields.length === 0" class="email">
+                                    <app-icon matPrefix [iconName]="screen.emailIcon" iconClass="material-icons sm"></app-icon>
+                                    <app-dynamic-form-field [formGroup]="screen.formGroup" [formField]="emailField" (onFieldChanged)="onFieldChanged($event)"></app-dynamic-form-field>
+                                </div>
+                                <div *ngIf="emailFields.length > 0">
+                                    <div class="email-list" *ngFor="let emailField of emailFields; let i = index; first as isFirst; last as isLast;">
+                                        <app-mutable-list-item-with-label [formGroup]="screen.formGroup"
+                                                                        [groupIcon]="screen.emailIcon"
+                                                                        [inputField]="emailField"
+                                                                        [labelField]="emailLabelFields[i]"
+                                                                        [isFirst]="isFirst"
+                                                                        [isLast]="isLast"
+                                                                        [isOnly]="emailFields.length == 1"
+                                                                        (onFieldChanged)="onFieldChanged($event)"
+                                                                        (add)="doAction(screen.addEmail, i)"
+                                                                        (remove)="doAction(screen.removeEmail, i)">
+                                        </app-mutable-list-item-with-label>
+                                    </div>
+                                </div>
 
-                            <div *ngIf="phoneField && phoneFields.length === 0" class="phone">
-                                <app-icon matPrefix [iconName]="screen.phoneIcon" iconClass="material-icons sm"></app-icon>
-                                <app-dynamic-form-field [formGroup]="screen.formGroup" [formField]="phoneField" (onFieldChanged)="onFieldChanged($event)"></app-dynamic-form-field>
-                            </div>
-                            <div *ngIf="phoneFields.length > 0">
+                                <div *ngIf="phoneField && phoneFields.length === 0" class="phone">
+                                    <app-icon matPrefix [iconName]="screen.phoneIcon" iconClass="material-icons sm"></app-icon>
+                                    <app-dynamic-form-field [formGroup]="screen.formGroup" [formField]="phoneField" (onFieldChanged)="onFieldChanged($event)"></app-dynamic-form-field>
+                                </div>
+                                <div *ngIf="phoneFields.length > 0">
 
-                                <div class="phone-list" *ngFor="let phoneField of phoneFields; let i = index; first as isFirst; last as isLast;">
-                                    <app-mutable-list-item-with-label [formGroup]="screen.formGroup"
-                                                                      [groupIcon]="screen.phoneIcon"
-                                                                      [inputField]="phoneField"
-                                                                      [labelField]="phoneLabelFields[i]"
-                                                                      [isFirst]="isFirst"
-                                                                      [isLast]="isLast"
-                                                                      [isOnly]="phoneFields.length == 1"
-                                                                      (onFieldChanged)="onFieldChanged($event)"
-                                                                      (add)="doAction(screen.addPhone, screen.form)"
-                                                                      (remove)="doAction(screen.removePhone, i)">
-                                    </app-mutable-list-item-with-label>
+                                    <div class="phone-list" *ngFor="let phoneField of phoneFields; let i = index; first as isFirst; last as isLast;">
+                                        <app-mutable-list-item-with-label [formGroup]="screen.formGroup"
+                                                                        [groupIcon]="screen.phoneIcon"
+                                                                        [inputField]="phoneField"
+                                                                        [labelField]="phoneLabelFields[i]"
+                                                                        [isFirst]="isFirst"
+                                                                        [isLast]="isLast"
+                                                                        [isOnly]="phoneFields.length == 1"
+                                                                        (onFieldChanged)="onFieldChanged($event)"
+                                                                        (add)="doAction(screen.addPhone, screen.form)"
+                                                                        (remove)="doAction(screen.removePhone, i)">
+                                        </app-mutable-list-item-with-label>
+                                    </div>
                                 </div>
                             </div>
                         </div>
-
-                        <!--This different ordering of Location and Loyalty sections here is so the tab order is consistent with form field display order.-->
-                        <div *ngIf="(isMobile | async);then mobileFormFieldOrder else desktopFormFieldOrder"></div>
-                        <ng-template #mobileFormFieldOrder>
-                            <ng-container *ngTemplateOutlet="locationSection"></ng-container>
-                            <ng-container *ngTemplateOutlet="loyaltySection"></ng-container>
-                        </ng-template>
-                        <ng-template #desktopFormFieldOrder>
-                            <ng-container *ngTemplateOutlet="loyaltySection"></ng-container>
-                            <ng-container *ngTemplateOutlet="locationSection"></ng-container>
-                        </ng-template>
-
+                        <div class="right">
+                            <!--This different ordering of Location and Loyalty sections here is so the tab order is consistent with form field display order.-->
+                            <div *ngIf="(isMobile | async);then mobileFormFieldOrder else desktopFormFieldOrder"></div>
+                            <ng-template #mobileFormFieldOrder>
+                                <ng-container *ngTemplateOutlet="locationSection"></ng-container>
+                                <ng-container *ngTemplateOutlet="loyaltySection"></ng-container>
+                            </ng-template>
+                            <ng-template #desktopFormFieldOrder>
+                                <ng-container *ngTemplateOutlet="loyaltySection"></ng-container>
+                                <ng-container *ngTemplateOutlet="locationSection"></ng-container>
+                            </ng-template>
+                        </div>
                         <ng-template #locationSection>
                             <div class="location">
                                 <div [ngClass]="addressIconLocationClass" *ngIf="anyAddressFieldsPresent()">

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/loyalty-customer-form-dialog/loyalty-customer-form-dialog.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/loyalty-customer-form-dialog/loyalty-customer-form-dialog.component.scss
@@ -69,65 +69,80 @@
     grid-template-columns: 1fr 1fr;
     gap: 0px 2.5em;
     grid-template-areas:
-    "basic-info loyalty"
-    "contact location"
-    "extraFormFields extraFormFields";
-
-    .basic-info {
-        grid-area: basic-info;
+    "left right";
+    
+    .left {
+        grid-area: left;
         display: grid;
-        grid-template-columns: 1fr 4fr;
-        grid-template-rows: 1fr;
-        gap: 0px 1em;
         grid-template-areas:
-        "portrait names";
-
-        .portrait {
-            grid-area: portrait;
-            margin-top: 1em;
-            margin-left: auto;
-            margin-right: auto;
+        "basic-info"
+        "contact"
+        "extraFormFields";
+        .basic-info {
+            grid-area: basic-info;
+            display: grid;
+            grid-template-columns: 1fr 4fr;
+            grid-template-rows: 1fr;
+            gap: 0px 1em;
+            grid-template-areas:
+            "portrait names";
+    
+            .portrait {
+                grid-area: portrait;
+                margin-top: 1em;
+                margin-left: auto;
+                margin-right: auto;
+            }
+    
+            .names { grid-area: names; }
         }
-
-        .names { grid-area: names; }
     }
 
-    .location {
+    .right {
+        grid-area: right;
         display: grid;
-        grid-template-columns: 30px 1fr 1fr 1fr;
-        grid-template-rows: 0fr 0fr 0fr 0fr;
-        gap: 0px 1em;
-        grid-template-areas:
+        grid-template-areas: 
+        "loyalty"
+        "location"
+        "extraFormFields";
+        
+        .location {
+            display: grid;
+            grid-template-columns: 30px 1fr 1fr 1fr;
+            grid-template-rows: 0fr 0fr 0fr 0fr;
+            gap: 0px 1em;
+            grid-template-areas:
             "icon1 line1 line1 line1"
             "icon2 line2 line2 line2"
             "icon3 cityStateZip cityStateZip cityStateZip"
             "icon4 country country country";
-
-        .icon1 {
-            grid-area: icon1;
-            align-self: center;
+            
+            .icon1 {
+                grid-area: icon1;
+                align-self: center;
+            }
+            .icon2 {
+                grid-area: icon2;
+                align-self: center;
+            }
+            .icon3 {
+                grid-area: icon3;
+                align-self: center;
+            }
+            .icon4 {
+                grid-area: icon4;
+                align-self: center;
+            }
+            .cityStateZip {
+                grid-area: cityStateZip;
+                display: flex;
+                gap: 1em;
+                app-dynamic-form-field { flex-grow: 1; width: 10em; }
+            }
+            .line1 { grid-area: line1; }
+            .line2 { grid-area: line2; }
+            .country { grid-area: country; }
         }
-        .icon2 {
-            grid-area: icon2;
-            align-self: center;
-        }
-        .icon3 {
-            grid-area: icon3;
-            align-self: center;
-        }
-        .icon4 {
-            grid-area: icon4;
-            align-self: center;
-        }
-        .cityStateZip {
-            grid-area: cityStateZip;
-            display: flex;
-            gap: 1em;
-            app-dynamic-form-field { flex-grow: 1; width: 10em; }
-        }
-        .line1 { grid-area: line1; }
-        .line2 { grid-area: line2; }
-        .country { grid-area: country; }
     }
 
     .loyalty-and-membership {


### PR DESCRIPTION
### Issues Fixed
[PCOM-3611](https://jira.ae.com/browse/PCOM-3611)

### Summary
AEO doesn't have a loyalty section on the add customer form so it left a blank void in the top right because of the 3x2 grid. My fix here is to make the grid 2 independent columns that size better when a whole section is missing.

### Screenshots

This is what the form currently looks like when the loyalty/membership section is blank
![Screen Shot 2021-07-02 at 10 27 46 AM](https://user-images.githubusercontent.com/76953904/124313094-642c1d00-db3e-11eb-8549-085099063587.png)

This is what the form would look like if I remove that grid cell and moved address to the top. It just moves the blank void to another spot on the page
![Screen Shot 2021-07-02 at 10 35 52 AM](https://user-images.githubusercontent.com/76953904/124313096-64c4b380-db3e-11eb-8438-ed59ea2a3074.png)

This is what it looks like after these changes for 2 columns
![Screen Shot 2021-07-02 at 1 18 27 PM](https://user-images.githubusercontent.com/76953904/124313089-63938680-db3e-11eb-83f2-d310d8b12426.png)

After these changes with the loyalty/membership section in commerce-demo
![Screen Shot 2021-07-02 at 1 35 10 PM](https://user-images.githubusercontent.com/76953904/124313092-642c1d00-db3e-11eb-9bc4-bc054146efa6.png)