### PR TITLE
Cherry-pick peripheral selection `isEnabled` addition from `releases/2.2`

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/messages/peripheral-device-selection.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/messages/peripheral-device-selection.ts
@@ -3,10 +3,10 @@ import { OpenposMessage } from './message';
 
 export class PeripheralDeviceSelectionMessage implements OpenposMessage {
     type = MessageTypes.PERIPHERAL_DEVICE_SELECTION;
-    
     selectedDevice: PeripheralDeviceDescription;
     category: PeripheralCategoryDescription;
     available: PeripheralDeviceDescription[];
+    enabled: boolean;
 }
 
 export interface PeripheralDeviceDescription {

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/peripherals/peripheral-selection.service.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/peripherals/peripheral-selection.service.ts
@@ -30,7 +30,8 @@ export class PeripheralSelectionService {
                     icon: m.category.icon,
                     localizationNoCategorySelectedKey: m.category.localizationNoCategorySelectedKey,
                     knownDevices: devices,
-                    selectedDevice: m.selectedDevice
+                    selectedDevice: m.selectedDevice,
+                    enabled: m.enabled
                 };
             }),
             tap(n => this._categoryNameToData.set(n.id, n)),

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/status/status-bar/status-bar.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/status/status-bar/status-bar.component.scss
@@ -36,7 +36,9 @@
     grid-auto-flow: column;
     justify-content: right;
     align-content: center;
-    &.mobile{
+    &.mobile,
+    &.tablet,
+    &.desktop-portrait {
       display: none;
     }
   }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/status/status-details/item/status-details-item.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/status/status-details/item/status-details-item.component.html
@@ -4,27 +4,28 @@ Uncomment when statuses are supported.
     <app-icon [iconName]="icon"></app-icon>
 </div> 
 -->
-<button responsive-class *ngIf="title" mat-flat-button (click)="actionExecuted.emit()"
-        color=primary-inverse class="status-item">
+<button responsive-class *ngIf="title" mat-flat-button (click)="actionExecuted.emit()" color=primary-inverse
+    class="status-item" disabled="{{!enabled}}">
     <app-icon class="status-icon" [iconName]="icon"></app-icon>
     <div class="status-content">
-        <span responsive-class class="status-line {{titleTransparency ? '': 'status-title-transparency'}}">{{title}}</span>&nbsp;(<u>Change</u>)
+        <span responsive-class
+            class="status-line {{titleTransparency ? '': 'status-title-transparency'}}">{{title}}</span>&nbsp;(<u>Change</u>)
         <!--
-            Uncomment when statuses are supported.
-            <div class="caption" [ngSwitch]="status">
-                <ng-container *ngSwitchCase="'online'">
-                    Online
-                </ng-container>
-                <ng-container *ngSwitchCase="'offline'">
-                    Offline
-                </ng-container>
-                <ng-container *ngSwitchCase="'error'">
-                    Error
-                </ng-container>
-                <ng-container *ngSwitchDefault>
-                    Unknown
-                </ng-container>
-            </div>
+        Uncomment when statuses are supported.
+        <div class="caption" [ngSwitch]="status">
+            <ng-container *ngSwitchCase="'online'">
+                Online
+            </ng-container>
+            <ng-container *ngSwitchCase="'offline'">
+                Offline
+            </ng-container>
+            <ng-container *ngSwitchCase="'error'">
+                Error
+            </ng-container>
+            <ng-container *ngSwitchDefault>
+                Unknown
+            </ng-container>
+        </div>
         -->
         <ng-content></ng-content>
     </div>

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/status/status-details/item/status-details-item.component.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/status/status-details/item/status-details-item.component.ts
@@ -14,14 +14,17 @@ export class StatusDetailsItemComponent {
     icon?: string;
 
     @Input()
-    title: string
+    title: string;
 
     @Input()
     actionText?: string;
 
     @Input()
-    titleTransparency: string
+    titleTransparency: string;
 
     @Output()
     actionExecuted = new EventEmitter<void>();
+
+    @Input()
+    enabled: boolean;
 }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/status/status-details/status-details.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/status/status-details/status-details.component.html
@@ -20,7 +20,8 @@
                 status="online"
                 [icon]="s.icon"
                 [titleTransparency]="s.selectedDevice?.displayName"
-                (actionExecuted)="onChangeSelectedPeripheral(s)">
+                (actionExecuted)="onChangeSelectedPeripheral(s)"
+                [enabled]="s.enabled">
         </app-status-details-item>
     </div>
 </div>

--- a/openpos-util/src/main/java/org/jumpmind/pos/util/peripheral/IPeripheralDeviceSelector.java
+++ b/openpos-util/src/main/java/org/jumpmind/pos/util/peripheral/IPeripheralDeviceSelector.java
@@ -10,6 +10,11 @@ public interface IPeripheralDeviceSelector {
     void initialize(IInvalidationHandle invalidationHandle);
 
     /**
+     * Called to determine if the status bar detail item should be enabled
+     */
+    boolean isEnabled();
+
+    /**
      * Gets the the category.
      */
     CategoryDescriptor getCategory();

--- a/openpos-util/src/main/java/org/jumpmind/pos/util/peripheral/PeripheralDeviceSelectionMessage.java
+++ b/openpos-util/src/main/java/org/jumpmind/pos/util/peripheral/PeripheralDeviceSelectionMessage.java
@@ -13,6 +13,7 @@ public class PeripheralDeviceSelectionMessage extends Message {
     CategoryDescriptor category;
     List<PeripheralDeviceDescription> available;
     PeripheralDeviceDescription selectedDevice;
+    boolean enabled;
 
     @Override
     public String getType() {


### PR DESCRIPTION
### Summary
Cherry-picking the ability to disable peripheral selection changes in order to resolve a mobile print bug when the printer is forced to retry.