### PR TITLE
Fix a bug where the dialog opening flag gets stuck

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/services/dialog.service.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/services/dialog.service.ts
@@ -120,7 +120,6 @@ export class DialogService {
             const dialogType = this.hasDialog(dialog.subType) ? dialog.subType : 'Dialog';
             if (!this.dialogOpening) {
                 console.info('opening dialog \'' + dialogType + '\'');
-                this.dialogOpening = true;
                 setTimeout(() => this.openDialog(dialog), 0);
             } else {
                 console.info(`[DialogService] putting off the opening of the dialog to the future because another dialog is currently opening`);
@@ -135,6 +134,7 @@ export class DialogService {
             return;
         }
         try {
+            this.dialogOpening = true;
             const dialogComponentFactory: ComponentFactory<IScreen> = this.resolveDialog(dialog.screenType);
             console.info(`[DialogService] Opening a dialog with a ` +
                 `${dialogComponentFactory && dialogComponentFactory.componentType ? dialogComponentFactory.componentType.name : '?'} ` +


### PR DESCRIPTION
### Summary
Since we now are checking sequence numbers and skipping dialogs that are old we had a gap where the dialog opening flag would get stuck and the next dialog would never open.