### PR TITLE
Fixed bug regarding Image Scanner's not resizing when their container changes size.

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/core.module.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/core.module.ts
@@ -80,6 +80,7 @@ import { CapacitorStorageService } from './storage/capacitor/capacitor-storage.s
 import { Storage } from './storage/storage.service';
 import { STORAGE_CONTAINERS } from './storage/storage-container';
 import { CapacitorPrinterPlugin } from './platform-plugins/printers/capacitor-printer.plugin';
+import { DebugImageScanner } from './platform-plugins/barcode-scanners/debug-image-scanner/debug-image-scanner.service';
 
 registerLocaleData(locale_enCA, 'en-CA');
 registerLocaleData(locale_frCA, 'fr-CA');
@@ -142,6 +143,11 @@ registerLocaleData(locale_frCA, 'fr-CA');
         { provide: SCANNERS, useExisting: ServerScannerPlugin, multi: true, deps: [SessionService]},
         { provide: IMAGE_SCANNERS, useExisting: ScanditScannerCordovaPlugin, multi: true},
         { provide: IMAGE_SCANNERS, useExisting: ScanditCapacitorImageScanner, multi: true },
+
+        // NOTE:    The following image scanner is just a placeholder making it easier to debug the feature
+        //          without having to load the app up on device with the supporting feature. To enable it
+        //          you must change your client configuration for a image scanner type to 'Debug'.
+        { provide: IMAGE_SCANNERS, useClass: DebugImageScanner, multi: true },
         { provide: PLUGINS, useExisting: AilaScannerCordovaPlugin, multi: true},
         { provide: PLUGINS, useExisting: InfineaScannerCordovaPlugin, multi: true},
         { provide: PLUGINS, useExisting: NCRPaymentPlugin, multi: true, deps: [SessionService]},

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/platform-plugins/barcode-scanners/debug-image-scanner/debug-image-scanner.service.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/core/platform-plugins/barcode-scanners/debug-image-scanner/debug-image-scanner.service.ts
@@ -1,0 +1,23 @@
+import { Observable } from "rxjs";
+import { ImageScanner, ScanData, ScannerViewRef } from "../scanner";
+
+export class DebugImageScanner implements ImageScanner {
+    name(): string {
+        return "Debug";
+    }
+
+    beginScanning(view: ScannerViewRef): Observable<ScanData> {
+        return new Observable(() => {
+            let subscription = view.viewChanges().subscribe({
+                next: value => {
+                    console.log('scanner view container changed', value)
+                }
+            });
+
+            return () => {
+                subscription.unsubscribe();
+                console.log('scan data stopped');
+            };
+        });
+    }
+}


### PR DESCRIPTION
### Summary
When the containers size changes, like when a return receipt is scanned, the image scanner will now post a size changed event. Because of limitations of the DOM, this size is evaluated on an interval while the scanner is opened.

This PR also includes a dummy Debug image scanner that just makes it easier to debug.