### PR TITLE
Item Details Fixes

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.scss
@@ -120,6 +120,7 @@ app-bacon-strip{
         display: grid;
         grid-auto-flow: column;
         margin-bottom: 16px;
+        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
     }
 
     ul{

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/option-components/swatch-product-option-part/swatch-product-option-part.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/option-components/swatch-product-option-part/swatch-product-option-part.scss
@@ -6,8 +6,9 @@
 }
 
 .swatch-container {
-  display: grid;
-  grid-auto-flow: column;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
 
   .swatch {
     border-radius: 50%;

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/carousel/carousel.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/carousel/carousel.component.html
@@ -5,4 +5,4 @@
         [src]="thumbnailUrl | imageUrl">
 </div>
 
-<img [src]="(selectedImageUrl || altImageUrl) | imageUrl" [alt]="altImageText" (error)="onSelectedImageError()">
+<img class="main" [src]="(selectedImageUrl || altImageUrl) | imageUrl" [alt]="altImageText" (error)="onSelectedImageError()">

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/carousel/carousel.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/components/carousel/carousel.component.scss
@@ -7,16 +7,18 @@
 .thumbnails {
     display: flex;
     flex-direction: column;
-    max-width: 75px;
 
     overflow-y: auto;
 
     img {
         cursor: pointer;
+
+        height: auto;
+        width: 64px;
     }
 }
 
-img {
+img.main {
     object-fit: contain;
     object-position: top;
 


### PR DESCRIPTION
### Summary
Fixes two small things on the item details page:
1. Swatch options will now wrap onto new rows. Previously they would all show inline and when there were a lot of options it would overflow significantly. See attached screenshot for an idea of what it looks like now.
2. On WebKit browsers, thumbnail heights were inferred as 100vh and will only fit within their container if you set both width/height.


### Screenshots
![Swatches](https://user-images.githubusercontent.com/2295721/125106986-7efe1480-e09d-11eb-9d3f-8fba4b2eebe9.png)
Example of 100 swatches.
