### PR TITLE
Support percent based rewards in linked customer details.

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.html
@@ -8,8 +8,8 @@
         <div *ngIf="reward.statusText" class="name" responsive-class>{{reward.statusText}}</div>
     </div>
     <div class="reward" responsive-class>
-        <app-currency-text *ngIf="reward.amount && reward.amountType != 'PCT'" [amountText]="reward.amount"></app-currency-text>
-        <div class="pctReward" *ngIf="reward.amount && reward.amountType == 'PCT'">{{reward.amount * 100}}%</div>
+        <app-currency-text *ngIf="reward.reward && reward.rewardType != 'PCT'" [amountText]="reward.reward"></app-currency-text>
+        <div class="pctReward" *ngIf="reward.reward && reward.rewardType == 'PCT'">{{reward.reward * 100}}% off</div>
     </div>
     <div class="apply">
         <a *ngIf="reward.actionButton"

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.html
@@ -8,7 +8,8 @@
         <div *ngIf="reward.statusText" class="name" responsive-class>{{reward.statusText}}</div>
     </div>
     <div class="reward" responsive-class>
-        <app-currency-text *ngIf="reward.amount" [amountText]="reward.amount"></app-currency-text>
+        <app-currency-text *ngIf="reward.amount && reward.amountType != 'PCT'" [amountText]="reward.amount"></app-currency-text>
+        <div class="pctReward" *ngIf="reward.amount && reward.amountType == 'PCT'">{{reward.amount * 100}}%</div>
     </div>
     <div class="apply">
         <a *ngIf="reward.actionButton"

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.scss
@@ -2,7 +2,7 @@
 
 .reward-line-item-wrapper {
   display: grid;
-  grid-template-columns: 1fr 8fr 2fr 1fr 4fr;
+  grid-template-columns: 1fr 8fr 2fr 2fr 4fr;
   grid-template-rows: 1fr;
   gap: 0px 0px;
   grid-template-areas:

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.scss
@@ -41,6 +41,9 @@
     @extend %text-md;
     grid-area: reward;
     align-self: center;
+    .pctReward {
+      font-weight: bold;
+    }
   }
   .apply {
     grid-area: apply;

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.spec.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.spec.ts
@@ -137,7 +137,7 @@ describe('RewardsLineItemComponent', () => {
             describe('reward', () => {
                 describe('when reward has an amount', () => {
                     beforeEach(() => {
-                        component.reward.amount = 200;
+                        component.reward.reward = 200;
                         fixture.detectChanges();
                     });
                     it('renders the app-currency-text', () => {
@@ -151,7 +151,7 @@ describe('RewardsLineItemComponent', () => {
 
                 describe('when reward does not have an amount', () => {
                     beforeEach(() => {
-                        component.reward.amount = undefined;
+                        component.reward.reward = undefined;
                         fixture.detectChanges();
                     });
                     it('does not render the app-currency-text', () => {
@@ -161,8 +161,8 @@ describe('RewardsLineItemComponent', () => {
 
                 describe('when reward has a percent amount', () => {
                     beforeEach(() => {
-                      component.reward.amountType = 'PCT';
-                      component.reward.amount = .5;
+                      component.reward.rewardType = 'PCT';
+                      component.reward.reward = .5;
                       fixture.detectChanges();
                     });
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.spec.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.component.spec.ts
@@ -143,6 +143,10 @@ describe('RewardsLineItemComponent', () => {
                     it('renders the app-currency-text', () => {
                         validateExist(fixture, '.reward app-currency-text');
                     });
+
+                    it('does not renders the .pctReward', () => {
+                        validateDoesNotExist(fixture, '.reward .pctReward');
+                    });
                 });
 
                 describe('when reward does not have an amount', () => {
@@ -153,6 +157,25 @@ describe('RewardsLineItemComponent', () => {
                     it('does not render the app-currency-text', () => {
                         validateDoesNotExist(fixture, '.reward app-currency-text');
                     });
+                });
+
+                describe('when reward has a percent amount', () => {
+                    beforeEach(() => {
+                      component.reward.amountType = 'PCT';
+                      component.reward.amount = .5;
+                      fixture.detectChanges();
+                    });
+
+                    it('does not render the app-currency-text', function () {
+                        validateDoesNotExist(fixture, '.reward app-currency-text');
+                    });
+
+                    it('does render a XX%', function () {
+                        validateExist(fixture, '.reward .pctReward');
+                        validateText(fixture, '.reward .pctReward', '50%');
+                    });
+
+
                 });
             });
 

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.interface.ts
@@ -4,8 +4,8 @@ export interface Reward {
     promotionId: string;
     name: string;
     expirationDate: string;
-    amountType: string
-    amount: number;
+    rewardType: string
+    reward: number;
     actionButton: IActionItem;
     actionIcon: string;
     statusText: string;

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/rewards-line-item/rewards-line-item.interface.ts
@@ -4,6 +4,7 @@ export interface Reward {
     promotionId: string;
     name: string;
     expirationDate: string;
+    amountType: string
     amount: number;
     actionButton: IActionItem;
     actionIcon: string;

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/UILoyaltyReward.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/UILoyaltyReward.java
@@ -17,6 +17,7 @@ public class UILoyaltyReward implements Serializable {
     private String expirationDate;
     private String expirationLabel;
     private String barcode;
+    private String amountType;
     private BigDecimal amount;
     private ActionItem actionButton;
     private String actionIcon;

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/UILoyaltyReward.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/UILoyaltyReward.java
@@ -17,8 +17,8 @@ public class UILoyaltyReward implements Serializable {
     private String expirationDate;
     private String expirationLabel;
     private String barcode;
-    private String amountType;
-    private BigDecimal amount;
+    private String rewardType;
+    private BigDecimal reward;
     private ActionItem actionButton;
     private String actionIcon;
     private Boolean isAppliedToTransaction;


### PR DESCRIPTION
### Issues Fixed
Jira PDPOS-5892: https://petcoalm.atlassian.net/browse/PDPOS-5892

### Summary
This issue concerned the reward line items in the LinkedCustomerDetialsDialog not displaying the percent values of percent based rewards. To fix this an addition variable, amountType, was added to LoyaltyRewardDetails and UILoyaltyReward to dictate if the value in amount was a dollar amount or a percent amount off. Meaning that we needed to fill this value in the endpoint as well as the state.

### Screenshots
LinkedCutomerDetailsDialog
![Screen Shot 2021-07-14 at 11 03 48 AM](https://user-images.githubusercontent.com/16402926/125674617-3861e3a2-53dc-4939-84e9-d0cc7f7e730f.png)

