### PR TITLE
Merge fix: move loyalty signup fields from SaleUIMessage to TransactionUIMessage

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.html
@@ -73,7 +73,7 @@
                             {{screenData.customer.name}}
                         </div>
                     </div>
-                    <div class="icon"><app-icon [iconName]="screenData.profileIcon" [iconClass]="(isMobile | async) ? null: 'material-icons mat-36'"></app-icon></div>
+                    <div class="icon"><app-icon [iconName]="screenData.profileIcon" [iconClass]="(isMobile$ | async) ? null: 'material-icons mat-36'"></app-icon></div>
                     <div class="loyalty-icon">
                         <img *ngIf="screenData.loyaltyButton.icon" [src]="screenData.loyaltyButton.icon | imageUrl" class="sale-total-loyalty-button-icon">
                     </div>

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/SaleUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/SaleUIMessage.java
@@ -31,11 +31,6 @@ public class SaleUIMessage extends TransactionUIMessage {
     private boolean enableCollapsibleItems = true;
     private String iconName;
 
-    private String loyaltySignupInProgressTitle;
-    private String loyaltySignupInProgressIcon;
-    private String loyaltySignupInProgressDetailsIcon;
-    private ActionItem loyaltyCancelButton;
-
     public SaleUIMessage() {
         this.setScreenType(UIMessageType.SALE);
         this.setId("sale");

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/TransactionUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/TransactionUIMessage.java
@@ -23,6 +23,11 @@ public class TransactionUIMessage extends UIMessage {
     private ActionItem linkedCustomerButton;
     private ActionItem linkedEmployeeButton;
 
+    private String loyaltySignupInProgressTitle;
+    private String loyaltySignupInProgressIcon;
+    private String loyaltySignupInProgressDetailsIcon;
+    private ActionItem loyaltyCancelButton;
+
     private String loyaltyIDLabel;
     private String profileIcon;
     private List<UIMembership> memberships;


### PR DESCRIPTION
### Summary
Most fields were refactored out of SaleUIMessage in master, but not releases/2.2. These fields we added in #1465 should be in the new ui message