### PR TITLE
Bugfix/filter precedence

### DIFF
--- a/openpos-server-core/src/main/java/org/jumpmind/pos/server/service/RestRequestLoggingFilter.java
+++ b/openpos-server-core/src/main/java/org/jumpmind/pos/server/service/RestRequestLoggingFilter.java
@@ -7,12 +7,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.web.filter.AbstractRequestLoggingFilter;
 
 import java.util.List;
 
 @Data
 @ConfigurationProperties("openpos.general.http-requests.logging")
+@Order(Ordered.HIGHEST_PRECEDENCE)
 public class RestRequestLoggingFilter extends AbstractRequestLoggingFilter {
 
     Logger log = LoggerFactory.getLogger(getClass());

--- a/openpos-util/src/main/java/org/jumpmind/pos/util/clientcontext/ClientContentExtractionFilter.java
+++ b/openpos-util/src/main/java/org/jumpmind/pos/util/clientcontext/ClientContentExtractionFilter.java
@@ -4,6 +4,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -15,6 +17,7 @@ import java.io.IOException;
 import java.util.Enumeration;
 
 @Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
 public class ClientContentExtractionFilter extends OncePerRequestFilter {
     Logger log = LoggerFactory.getLogger(getClass());
 
@@ -23,6 +26,14 @@ public class ClientContentExtractionFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        log.info(String.format("Request before ClientContentExtractionFilter: %s",request.toString()));
+        Enumeration gwwHeaderNames = request.getHeaderNames();
+        log.info("Logging headers...");
+        while (gwwHeaderNames.hasMoreElements()) {
+            String key = (String) gwwHeaderNames.nextElement();
+            log.info("Header {}: {}", key, request.getHeader(key));
+        }
+
         Enumeration<String> headerNames = request.getHeaderNames();
         clientContext.clear();
         while( headerNames.hasMoreElements() ) {


### PR DESCRIPTION
### Summary
Add precedence for http request filters.  The LegacyApiRedirectFilter must be run last.  The LegacyApiRedirectFilter must do a forward for 1.11 vs a redirect because the 1.11 code doesn't handle the redirect.  It appears the forward doesn't allow the other filters to run if the LegacyApiRedirectFilter runs first.  This change runs the LegacyApiRedirectFilter last.