### PR TITLE
Add scrolling to sale total panel for some resolutions

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/sale.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/sale.component.scss
@@ -78,6 +78,7 @@
             }
 
             app-sale-total-panel {
+                overflow-y: auto;
                 grid-area: 1/3/1/3
             }
             

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/sale-total-panel/sale-total-panel.component.scss
@@ -13,8 +13,13 @@ $loyalty-signup-column-gap: 8px;
     grid-template-areas:
             "header"
             "body";
-    .sale-total-header { grid-area: header; }
-    .sale-total-background { grid-area: body; }
+    .sale-total-header {
+        grid-area: header;
+    }
+    .sale-total-background {
+        overflow-y: unset;
+        grid-area: body;
+    }
 }
 
 .sale-total-header {


### PR DESCRIPTION
### Issues Fixed

[PCOM-5440](https://jira.ae.com/browse/PCOM-5440)

### Summary

When we have some specific resolution (for example 1366x768) checkout button is not shown fully and scrolling is not available for this one. I added an opportunity to scroll. I checked other resolutions and it looks good with these changes.

### Demonstration

![recording (6)](https://user-images.githubusercontent.com/82650510/141126087-c40b87c8-7fd2-427b-9e58-5b0c7382251b.gif)

