### PR TITLE
PLCC Account look up feature changes

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/customer-details-dialog/customer-details-dialog.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/customer-details-dialog/customer-details-dialog.component.html
@@ -148,6 +148,15 @@
 </div>
 <mat-dialog-actions align="end" class="buttons">
     <app-secondary-button responsive-class
+                          class="button"
+                          *ngIf="screen.plccLookupButton"
+                          [disabled]="!screen.plccLookupButton?.enabled"
+                          [actionItem]="screen.plccLookupButton"
+                          (actionClick)="doAction(screen.plccLookupButton)"
+                          (click)="doAction(screen.plccLookupButton)">
+        <span>{{screen.plccLookupButton.title}}</span>
+    </app-secondary-button>
+    <app-secondary-button responsive-class
                           class="unlink"
                           *ngIf="screen.unlinkButton"
                           [disabled]="!screen.unlinkButton?.enabled"

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/customer-details-dialog/customer-details-dialog.component.spec.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/customer-details-dialog/customer-details-dialog.component.spec.ts
@@ -204,7 +204,7 @@ describe('CustomerDetailsDialog', () => {
             component.screen.editButton = conf;
           };
 
-          beforeEach(() => {
+          beforeEach(() =>  {
             configuration = {
               title: 'Some Title'
             } as IActionItem;
@@ -239,46 +239,46 @@ describe('CustomerDetailsDialog', () => {
         });
 
         describe('plccLookup button', () => {
-                  let button;
-                  let configuration;
-                  const selector = 'mat-dialog-actions .plccLookup';
-                  const setButtonConfiguration = (conf) => {
-                    component.screen.plccLookupButton = conf;
-                  };
+          let button;
+          let configuration;
+          const selector = 'mat-dialog-actions .plccLookup';
+          const setButtonConfiguration = (conf) => {
+             component.screen.plccLookupButton = conf;
+           };
 
-                   beforeEach(() => {
-                              configuration = {
-                                title: 'Some Title'
-                              } as IActionItem;
-                              setButtonConfiguration(configuration);
-                              fixture.detectChanges();
-                              button = fixture.debugElement.query(By.css(selector));
-                            });
+          beforeEach(() => {
+              configuration = {
+                title: 'Some Title'
+              } as IActionItem;
+              setButtonConfiguration(configuration);
+              fixture.detectChanges();
+              button = fixture.debugElement.query(By.css(selector));
+          });
 
-                            it('renders when the button configuration is set', () => {
-                              expect(button.nativeElement).toBeDefined();
-                            });
+          it('renders when the button configuration is set', () => {
+              expect(button.nativeElement).toBeDefined();
+          });
 
-                            it('does not render when the configuration is undefined', () => {
-                              setButtonConfiguration(undefined);
-                              fixture.detectChanges();
-                              validateDoesNotExist(fixture, selector);
-                            });
+          it('does not render when the configuration is undefined', () => {
+              setButtonConfiguration(undefined);
+              fixture.detectChanges();
+              validateDoesNotExist(fixture, selector);
+          });
 
-                            it('calls doAction with the configuration when an actionClick event is triggered', () => {
-                              spyOn(component, 'doAction');
-                              button = fixture.debugElement.query(By.css(selector));
-                              button.nativeElement.dispatchEvent(new Event('actionClick'));
-                              expect(component.doAction).toHaveBeenCalledWith(configuration);
-                            });
+          it('calls doAction with the configuration when an actionClick event is triggered', () => {
+              spyOn(component, 'doAction');
+              button = fixture.debugElement.query(By.css(selector));
+              button.nativeElement.dispatchEvent(new Event('actionClick'));
+              expect(component.doAction).toHaveBeenCalledWith(configuration);
+          });
 
-                            it('calls doAction with the configuration when the button is clicked', () => {
-                              spyOn(component, 'doAction');
-                              button = fixture.debugElement.query(By.css(selector));
-                              button.nativeElement.click();
-                              expect(component.doAction).toHaveBeenCalledWith(configuration);
-                            });
-                          });
+          it('calls doAction with the configuration when the button is clicked', () => {
+              spyOn(component, 'doAction');
+              button = fixture.debugElement.query(By.css(selector));
+              button.nativeElement.click();
+              expect(component.doAction).toHaveBeenCalledWith(configuration);
+          });
+        });
 
         describe('unlink button', () => {
           let button;

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/customer-details-dialog/customer-details-dialog.component.spec.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/customer-details-dialog/customer-details-dialog.component.spec.ts
@@ -237,6 +237,49 @@ describe('CustomerDetailsDialog', () => {
             expect(component.doAction).toHaveBeenCalledWith(configuration);
           });
         });
+
+        describe('plccLookup button', () => {
+                  let button;
+                  let configuration;
+                  const selector = 'mat-dialog-actions .plccLookup';
+                  const setButtonConfiguration = (conf) => {
+                    component.screen.plccLookupButton = conf;
+                  };
+
+                   beforeEach(() => {
+                              configuration = {
+                                title: 'Some Title'
+                              } as IActionItem;
+                              setButtonConfiguration(configuration);
+                              fixture.detectChanges();
+                              button = fixture.debugElement.query(By.css(selector));
+                            });
+
+                            it('renders when the button configuration is set', () => {
+                              expect(button.nativeElement).toBeDefined();
+                            });
+
+                            it('does not render when the configuration is undefined', () => {
+                              setButtonConfiguration(undefined);
+                              fixture.detectChanges();
+                              validateDoesNotExist(fixture, selector);
+                            });
+
+                            it('calls doAction with the configuration when an actionClick event is triggered', () => {
+                              spyOn(component, 'doAction');
+                              button = fixture.debugElement.query(By.css(selector));
+                              button.nativeElement.dispatchEvent(new Event('actionClick'));
+                              expect(component.doAction).toHaveBeenCalledWith(configuration);
+                            });
+
+                            it('calls doAction with the configuration when the button is clicked', () => {
+                              spyOn(component, 'doAction');
+                              button = fixture.debugElement.query(By.css(selector));
+                              button.nativeElement.click();
+                              expect(component.doAction).toHaveBeenCalledWith(configuration);
+                            });
+                          });
+
         describe('unlink button', () => {
           let button;
           let configuration;

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/customer-details-dialog/customer-details-dialog.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/sale/customer-details-dialog/customer-details-dialog.interface.ts
@@ -10,6 +10,7 @@ export interface CustomerDetailsDialogInterface extends IAbstractScreen {
     membershipLabel: string;
     loyaltyPromotions: IActionItem;
     editButton: IActionItem;
+    plccLookupButton: IActionItem;
     unlinkButton: IActionItem;
     doneButton: IActionItem;
     contactLabel: string;

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/customer-information/customer-information.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/customer-information/customer-information.component.html
@@ -7,6 +7,24 @@
 <div *ngIf="customer.loyaltyNumber" class="details-row loyalty-number" responsive-class>
     <app-icon [iconName]="screenData.loyaltyNumberIcon" [iconClass]="'material-icons mat-18'"></app-icon>{{customer.loyaltyNumber}}
 </div>
+<div *ngIf="customer.accountNumberLabel" class="details-row accountNumber-Label" responsive-class>
+     {{customer.accountNumberLabel}}
+</div>
+<div *ngIf="customer.accountNumber" class="details-row-account-details" responsive-class>
+    {{customer.accountNumber}}
+</div>
+<div *ngIf="customer.creditLimitLabel" class="details-row creditLimit-Label" responsive-class>
+    {{customer.creditLimitLabel}}
+</div>
+<div *ngIf="customer.creditLimit" class="details-row-account-details" responsive-class>
+    {{customer.creditLimit}}
+</div>
+<div *ngIf="customer.expiryDateLabel" class="details-row expiryDate-Label" responsive-class>
+    {{customer.expiryDateLabel}}
+</div>
+<div *ngIf="customer.expiryDate" class="details-row-account-details" responsive-class>
+    {{customer.expiryDate}}
+</div>
 <div *ngIf="customer.address" class="details-row address" responsive-class>
     <app-icon [iconName]="screenData.locationIcon" [iconClass]="'material-icons mat-18'"></app-icon>
     <div class="address-details" *ngIf="customer.address">

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/customer-information/customer-information.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/customer-information/customer-information.component.scss
@@ -17,3 +17,8 @@
 .address-details {
   display: inline-grid;
 }
+
+.details-row-account-details{
+    font-size: 20px;
+    font-weight: bold;
+  }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/customer-information/customer-information.component.spec.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/customer-information/customer-information.component.spec.ts
@@ -118,6 +118,71 @@ describe('CustomerInformationComponent', () => {
             validateDoesNotExist(fixture, '.loyalty-number');
         });
 
+        it('displays the customer account number label', () => {
+            validateText(fixture, '.accountNumber-Label', component.customer.accountNumberLabel);
+        });
+
+        it('does not display the customer account number label when the user does not have one', () => {
+            component.customer.accountNumberLabel = undefined;
+            fixture.detectChanges();
+
+            validateDoesNotExist(fixture, '.accountNumber-Label');
+        });
+
+        it('displays the customer account number ', () => {
+            validateText(fixture, '.account-Number', component.customer.accountNumber);
+        });
+
+        it('does not display the customer account number when the user does not have one', () => {
+             component.customer.accountNumber = undefined;
+             fixture.detectChanges();
+
+             validateDoesNotExist(fixture, '.account-Number');
+         });
+
+          it('displays the customer credit Limit label', () => {
+              validateText(fixture, '.creditLimit-Label', component.customer.creditLimitLabel);
+          });
+
+          it('does not display the customer creditLimit  label when the user does not have one', () => {
+              component.customer.creditLimitLabel = undefined;
+              fixture.detectChanges();
+
+              validateDoesNotExist(fixture, '.creditLimit-Label');
+                 });
+
+                 it('displays the account credit limit ', () => {
+                     validateText(fixture, '.credit-Limit', component.customer.creditLimit);
+                 });
+
+                 it('does not display the account credit limit when the user does not have one', () => {
+                      component.customer.creditLimit = undefined;
+                      fixture.detectChanges();
+
+                      validateDoesNotExist(fixture, '.credit-Limit');
+                  });
+
+                 it('displays the account expiry date label', () => {
+                                validateText(fixture, '.expiryDate-Label', component.customer.expiryDateLabel);
+                 });
+
+                  it('does not display the  account expiry date label when the user does not have one', () => {
+                      component.customer.expiryDateLabel = undefined;
+                      fixture.detectChanges();
+
+                      validateDoesNotExist(fixture, '.expiryDate-Label');
+                      });
+
+                      it('displays the account expiry date ', () => {
+                          validateText(fixture, '.expiry-Date', component.customer.expiryDate);
+                      });
+
+                      it('does not display the account expiry date when the user does not have one', () => {
+                       component.customer.expiryDate = undefined;
+                       fixture.detectChanges();
+
+                       validateDoesNotExist(fixture, '.expiry-Date');
+                       });
         describe('customer address', () => {
             it('does not display the customer loyalty number when the user does not have one', () => {
                 component.customer.address = undefined;

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/customer-information/customer-information.component.spec.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/customer-information/customer-information.component.spec.ts
@@ -140,49 +140,49 @@ describe('CustomerInformationComponent', () => {
              validateDoesNotExist(fixture, '.account-Number');
          });
 
-          it('displays the customer credit Limit label', () => {
+        it('displays the customer credit Limit label', () => {
               validateText(fixture, '.creditLimit-Label', component.customer.creditLimitLabel);
-          });
+        });
 
-          it('does not display the customer creditLimit  label when the user does not have one', () => {
-              component.customer.creditLimitLabel = undefined;
-              fixture.detectChanges();
+        it('does not display the customer creditLimit  label when the user does not have one', () => {
+            component.customer.creditLimitLabel = undefined;
+            fixture.detectChanges();
 
-              validateDoesNotExist(fixture, '.creditLimit-Label');
-                 });
+            validateDoesNotExist(fixture, '.creditLimit-Label');
+        });
 
-                 it('displays the account credit limit ', () => {
-                     validateText(fixture, '.credit-Limit', component.customer.creditLimit);
-                 });
+        it('displays the account credit limit ', () => {
+            validateText(fixture, '.credit-Limit', component.customer.creditLimit);
+        });
 
-                 it('does not display the account credit limit when the user does not have one', () => {
-                      component.customer.creditLimit = undefined;
-                      fixture.detectChanges();
+        it('does not display the account credit limit when the user does not have one', () => {
+            component.customer.creditLimit = undefined;
+            fixture.detectChanges();
 
-                      validateDoesNotExist(fixture, '.credit-Limit');
-                  });
+            validateDoesNotExist(fixture, '.credit-Limit');
+        });
 
-                 it('displays the account expiry date label', () => {
-                                validateText(fixture, '.expiryDate-Label', component.customer.expiryDateLabel);
-                 });
+        it('displays the account expiry date label', () => {
+            validateText(fixture, '.expiryDate-Label', component.customer.expiryDateLabel);
+        });
 
-                  it('does not display the  account expiry date label when the user does not have one', () => {
-                      component.customer.expiryDateLabel = undefined;
-                      fixture.detectChanges();
+        it('does not display the  account expiry date label when the user does not have one', () => {
+            component.customer.expiryDateLabel = undefined;
+            fixture.detectChanges();
 
-                      validateDoesNotExist(fixture, '.expiryDate-Label');
-                      });
+            validateDoesNotExist(fixture, '.expiryDate-Label');
+        });
 
-                      it('displays the account expiry date ', () => {
-                          validateText(fixture, '.expiry-Date', component.customer.expiryDate);
-                      });
+        it('displays the account expiry date ', () => {
+            validateText(fixture, '.expiry-Date', component.customer.expiryDate);
+        });
 
-                      it('does not display the account expiry date when the user does not have one', () => {
-                       component.customer.expiryDate = undefined;
-                       fixture.detectChanges();
+        it('does not display the account expiry date when the user does not have one', () => {
+            component.customer.expiryDate = undefined;
+            fixture.detectChanges();
 
-                       validateDoesNotExist(fixture, '.expiry-Date');
-                       });
+            validateDoesNotExist(fixture, '.expiry-Date');
+        });
         describe('customer address', () => {
             it('does not display the customer loyalty number when the user does not have one', () => {
                 component.customer.address = undefined;

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/customer-information/customer-information.interface.ts
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/shared/screen-parts/customer-information/customer-information.interface.ts
@@ -6,6 +6,12 @@ import { IActionItem } from '../../../core/actions/action-item.interface';
 export interface CustomerDetails {
     name: string;
     loyaltyNumber: string;
+    accountNumberLabel: string;
+    accountNumber: string;
+    creditLimitLabel: string;
+    creditLimit: string;
+    expiryDateLabel: string;
+    expiryDate: string;
     phoneNumber: string;
     email: string;
     address: {

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/CustomerDetailsUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/CustomerDetailsUIMessage.java
@@ -10,6 +10,7 @@ public class CustomerDetailsUIMessage extends UIMessage {
 
     private String title;
 
+    private ActionItem plccLookupButton;
     private ActionItem unlinkButton;
     private ActionItem editButton;
     private ActionItem doneButton;

--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/UICustomerDetailsItem.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/UICustomerDetailsItem.java
@@ -14,6 +14,12 @@ public class UICustomerDetailsItem extends SelectableItem implements Serializabl
     private String privacyRestrictedMessage;
     private String name;
     private String loyaltyNumber;
+    private String accountNumberLabel;
+    private String accountNumber;
+    private String creditLimitLabel;
+    private String creditLimit;
+    private String expiryDateLabel;
+    private String expiryDate;
     private BigDecimal loyaltyPoints;
     private String email;
     private String phoneNumber;


### PR DESCRIPTION
1. to add plcc account look up button on linked customer details in RR loyalty flow.this button will be displayed only if value /action is set.
<img width="1628" alt="Screen Shot 2021-11-19 at 2 45 40 AM" src="https://user-images.githubusercontent.com/92107513/144938999-a6ade2b6-15d6-46f2-93db-352518ca5993.png">

2. to add plcc account details screen .these fields will be displayed only if values are set  .Re0used customer detail screen to do 
<img width="1656" alt="Screen Shot 2021-12-06 at 3 36 08 PM" src="https://user-images.githubusercontent.com/92107513/144939305-120e70f3-276f-476a-8cf9-3012ae8e4716.png">

