### PR TITLE
fix 'Item Detail screen does not scroll on mobile #2058'

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/item-detail/item-detail.component.scss
@@ -8,6 +8,7 @@ app-bacon-strip{
 .item-details {
     display: flex;
     flex-direction: column;
+    overflow: auto;
     position: absolute;
     bottom: 0;
     left: 0;


### PR DESCRIPTION
### Issues Fixed
Closes #2058 

![item-details-scroll-fix](https://user-images.githubusercontent.com/6811136/157107364-56937c90-6fbf-4239-a325-74cda4f3c297.gif)

