### PR TITLE
Removal of F12 [function keys] for VC enrollment

### DIFF
--- a/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/CustomerMembershipsUIMessage.java
+++ b/openpos-flow/src/main/java/org/jumpmind/pos/core/ui/message/CustomerMembershipsUIMessage.java
@@ -8,7 +8,6 @@ import org.jumpmind.pos.core.ui.UIMessage;
 import java.util.List;
 
 @Data
-@AssignKeyBindings
 public class CustomerMembershipsUIMessage extends UIMessage {
     private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
### Issues Fixed
When press F12 Fn key from partner keyboard in Membership details screen, system Not responded which is assigned to Enroll another Pet

https://petcoalm.atlassian.net/browse/PDPOS-8591

As a fix, the PMO asked to remove the function key binding for VC enrollment.

![image](https://user-images.githubusercontent.com/89908480/172354744-a1d97f0a-1225-4a6b-9e55-17272a379c94.png)

As per the current logic, function keys were getting assigned to each actions in the Membership details screen and if a customer has enrolled more pets, the function keys keeps on getting assigned. The highest function key being F12, once it reaches this limit, it no more displays the fn key. PFA screenshots:
![image](https://user-images.githubusercontent.com/89908480/172364480-08c68a50-bb78-4988-a5f2-1b1e27b464cb.png)

![image](https://user-images.githubusercontent.com/89908480/172364549-6d498460-42ef-4ae5-a47d-71cd6eb596cc.png)
