### PR TITLE
I had to take off @JsonIgnore annotation from the AbstractModel in th…

### DIFF
--- a/openpos-persist/src/main/java/org/jumpmind/pos/persist/AbstractModel.java
+++ b/openpos-persist/src/main/java/org/jumpmind/pos/persist/AbstractModel.java
@@ -33,7 +33,6 @@ public abstract class AbstractModel implements IAuditableModel, Serializable {
     @JsonIgnore
     private Map<String, Object> systemData = new HashMap<>();
 
-    @JsonIgnore
     private Map<String, Object> additionalFields = new LinkedCaseInsensitiveMap<>();
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "__extensionClass")


### PR DESCRIPTION
I had to take off @JsonIgnore annotation from the AbstractModel in the variable additionalFiles because It was mapped the original values were lost and after that it couldn’t get additionalFields from the map..


### Issues Fixed
https://github.com/JumpMind/openpos-framework/issues/2341 
Close #2341 

List the issues that this PR addresses. 
https://jira.ae.com/browse/PCOM-8280
https://github.com/JumpMind/openpos-framework/issues/2341


This PR is related with https://code.ae.com/projects/POS/repos/aeo-jumpmind-ext/pull-requests/3172/overview