### PR TITLE
PCOM-9062 Print Temp Pass and close button align on right

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/customer-details-dialog/customer-details-dialog.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/customer-details-dialog/customer-details-dialog.component.html
@@ -353,7 +353,7 @@
     </div>
 </div>
 
-<mat-dialog-actions class="buttons" responsive-class>
+<mat-dialog-actions class="buttons account-detail-buttons" responsive-class >
     <app-secondary-button responsive-class *ngFor="let button of screen.secondaryButtons"
                           class="button"
                           [disabled]="!button?.enabled"

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/customer-details-dialog/customer-details-dialog.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/customer-details-dialog/customer-details-dialog.component.html
@@ -353,7 +353,7 @@
     </div>
 </div>
 
-<mat-dialog-actions class="buttons account-detail-buttons" responsive-class >
+<mat-dialog-actions class="buttons customer-detail-buttons" responsive-class >
     <app-secondary-button responsive-class *ngFor="let button of screen.secondaryButtons"
                           class="button"
                           [disabled]="!button?.enabled"

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/customer-details-dialog/customer-details-dialog.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/customer-details-dialog/customer-details-dialog.component.scss
@@ -29,7 +29,7 @@
   }
 }
 
- .account-detail-buttons{
+ .customer-detail-buttons{
     justify-content: end;
     align-content: end;
   }

--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/customer-details-dialog/customer-details-dialog.component.scss
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/customer-details-dialog/customer-details-dialog.component.scss
@@ -29,6 +29,10 @@
   }
 }
 
+ .account-detail-buttons{
+    justify-content: end;
+    align-content: end;
+  }
 .buttons {
   display: flex;
   gap: 8px;


### PR DESCRIPTION
Jira : [https://jira.ae.com/browse/PCOM-9062](url)

Issue : [https://github.com/JumpMind/openpos-framework/issues/2345](url)

Print Temp Pass and close button are displayed on the left side of the dialog instead of right only in mobile device.

Couldn't replicate this in SIT but happening only in mobile devices in lab. So trying to add right alignment style with a class in html.

<img width="729" alt="Screen Shot 2022-07-05 at 1 15 59 PM" src="https://user-images.githubusercontent.com/103125078/177381530-e53d2b56-8ce3-4630-a5fc-2c809c46e505.png">

