### PR TITLE
System displayed SHRUG GUY when "ENTER" Hotkey is selected on "Return Transaction Details" screen

### DIFF
--- a/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/return/return-trans-details/return-trans-details-dialog.component.html
+++ b/openpos-client-libs/projects/openpos-client-core-lib/src/lib/screens-with-parts/return/return-trans-details/return-trans-details-dialog.component.html
@@ -28,7 +28,7 @@
                 <span>{{additionalButton.title}}</span>
             </app-secondary-button>
             <app-primary-button cdkFocusInitial [disabled]="index<0"
-                [actionItem]="selectionButton" (actionClick)="doMenuItemAction(selectionButton)" (click)="doMenuItemAction(selectionButton)">
+                [actionItem]="selectionButton" [actionItemPayload] = "index" (actionClick)="doMenuItemAction(selectionButton)" (click)="doMenuItemAction(selectionButton)">
                 <span>{{selectionButton.title}}</span>&nbsp;
                 <span *ngIf="keybindsEnabled(selectionButton)" class="muted-color">{{selectionButton.keybindDisplayName}}</span>
             </app-primary-button>


### PR DESCRIPTION
### Issues Fixed
System displayed SHRUG GUY when "ENTER" Hotkey is selected on "Return Transaction Details" screen
https://petcoalm.atlassian.net/browse/PDPOS-8742

The issue was due to the action payload not getting set on selecting an item to be returned on the "Return Transaction Details" screen